### PR TITLE
Enhancement/nag compatibility

### DIFF
--- a/bld-test/Makefile
+++ b/bld-test/Makefile
@@ -5,16 +5,29 @@ INC_DIR=../include
 
 COMP_ARGS=OBJ_DIR=$(OBJ_DIR) LIB_DIR=$(LIB_DIR) INC_DIR=$(INC_DIR) CPPDEFS="-DECOSYS_NT=27 -DZOOPLANKTON_CNT=1 -DAUTOTROPH_CNT=3 -DGRAZER_PREY_CNT=3"
 
-all: intel
+.PHONY: intel pgi gnu nag line_check clean
+
+all:gnu
 
 intel:
-	cd $(SRC_DIR) ; make FC=ifort FCFLAGS="-O2 -free -module $(OBJ_DIR) -cpp -nogen-interface -fp-model source" $(COMP_ARGS) LIB_NAME=$(LIB_DIR)/libmarbl-intel.a
+	$(MAKE) $(LIB_DIR)/libmarbl-intel.a FC=ifort FCFLAGS="-O2 -free -module $(OBJ_DIR) -cpp -nogen-interface -fp-model source"
 
 pgi:
-	cd $(SRC_DIR) ; make FC=pgf90 FCFLAGS="-O2 -Mfree -module $(OBJ_DIR)" $(COMP_ARGS) LIB_NAME=$(LIB_DIR)/libmarbl-pgi.a
+	$(MAKE) $(LIB_DIR)/libmarbl-pgi.a FC=pgf90 FCFLAGS="-O2 -Mfree -module $(OBJ_DIR)"
 
 gnu:
-	cd $(SRC_DIR) ; make FC=gfortran FCFLAGS="-O2 -ffree-form -J $(OBJ_DIR) -cpp" $(COMP_ARGS) LIB_NAME=$(LIB_DIR)/libmarbl-gnu.a
+	$(MAKE) $(LIB_DIR)/libmarbl-gnu.a FC=gfortran FCFLAGS="-O2 -ffree-form -J $(OBJ_DIR) -cpp"
+
+nag:
+	$(MAKE) $(LIB_DIR)/libmarbl-nag.a FC=nagfor FCFLAGS="-O2 -free -I $(OBJ_DIR) -mdir $(OBJ_DIR) -kind=byte"
+
+line_check:
+	../tools/check_line_length.sh --dir $(SRC_DIR) --silent
 
 clean:
 	rm -f $(OBJ_DIR)/* $(LIB_DIR)/* $(INC_DIR)/*
+
+# Actual library build
+
+$(LIB_DIR)/%.a: line_check $(SRC_DIR)/*.F90
+	cd $(SRC_DIR) ; make FC=$(FC) FCFLAGS="$(FCFLAGS)" $(COMP_ARGS) LIB_NAME=$@

--- a/tools/check_line_length.sh
+++ b/tools/check_line_length.sh
@@ -91,7 +91,7 @@ FILELIST=""
 if [ -d ${SRC_DIR} ]; then
   FILELIST=`find ${SRC_DIR} -name "*.F90"`
 fi
-if [ -z $FILELIST ] && [ "$SILENT" != "TRUE" ]; then
+if [ -z "$FILELIST" ] && [ "$SILENT" != "TRUE" ]; then
   echo "WARNING: no .F90 files found in ${SRC_DIR}"
 fi
 for file in $FILELIST

--- a/tools/check_line_length.sh
+++ b/tools/check_line_length.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Quick script to check source code for lines exceeded specified length
+# Two uses:
+# 1) NAG compiler requires lines no longer than 132 characters
+# 2) At some point, we may want to enforce a max line length in coding guidelines
+
+# -----------------------------------------------------------------------------
+
+usage() {
+  echo "./check_line_length.sh [-n N] [-s]"
+  echo ""
+  echo "-n N    |    check for lines exceeding N characters (default=132)"
+  echo "-s      |    silent mode - suppress output to stdout"
+  echo "        |                  (rely on return code to detect problem)"
+}
+
+# -----------------------------------------------------------------------------
+
+check_length() {
+  LINEMAX=$((LINELIMIT+1))
+  sed "s/!.*//" $file | grep -Hn ".\{$LINEMAX\}"
+}
+
+# -----------------------------------------------------------------------------
+
+parse_args() {
+
+# DEFAULT SETTINGS
+SILENT=FALSE
+LINELIMIT=132
+
+  while [ $# -gt 0 ]; do
+    case $1 in
+      -n )
+        if [ $# -eq 1 ]; then
+          echo "ERROR: you must provide number of lines with the -n option"
+          exit -1
+        fi
+        LINELIMIT=$2
+        shift
+      ;;
+      -s )
+        SILENT=TRUE
+      ;;
+      -h )
+        usage
+        exit 0
+      ;;
+      * )
+        echo "ERROR: $1 is not a valid option"
+        usage
+        exit -1
+      ;;
+    esac
+    shift
+  done
+}
+
+# -----------------------------------------------------------------------------
+
+process_results() {
+  if [ "$FOUND" == "TRUE" ]; then
+    if [ "$SILENT" != "TRUE" ]; then
+      echo "Test FAILED: found at least one file exceeding $LINELIMIT character limit"
+    fi
+    exit 1
+  else
+    if [ "$SILENT" != "TRUE" ]; then
+      echo "Test PASSED: no lines exceeded $LINELIMIT characters"
+    fi
+    exit 0
+  fi
+}
+
+# -----------------------------------------------------------------------------
+
+parse_args $@ 
+
+FOUND=FALSE
+for file in ../src/*.F90
+do
+  if [[ ! -z `check_length` ]]; then
+    FOUND=TRUE
+    if [ "$SILENT" != "TRUE" ]; then
+      BASEFILE=`basename $file`
+      check_length | sed "s/(standard input)/$BASEFILE/"
+      echo ""
+    fi
+  fi
+done
+
+process_results

--- a/tools/check_line_length.sh
+++ b/tools/check_line_length.sh
@@ -7,11 +7,12 @@
 # -----------------------------------------------------------------------------
 
 usage() {
-  echo "./check_line_length.sh [-n N] [-s]"
+  echo "./check_line_length.sh [-n N] [-s] [-d DIR]"
   echo ""
   echo "-n N    |    check for lines exceeding N characters (default=132)"
   echo "-s      |    silent mode - suppress output to stdout"
   echo "        |                  (rely on return code to detect problem)"
+  echo "-d DIR  |    compare code in directory DIR"
 }
 
 # -----------------------------------------------------------------------------
@@ -28,6 +29,7 @@ parse_args() {
 # DEFAULT SETTINGS
 SILENT=FALSE
 LINELIMIT=132
+SRC_DIR=../src
 
   while [ $# -gt 0 ]; do
     case $1 in
@@ -39,10 +41,18 @@ LINELIMIT=132
         LINELIMIT=$2
         shift
       ;;
-      -s )
+      -s|--silent )
         SILENT=TRUE
       ;;
-      -h )
+      -d|--dir|--src_dir )
+        if [ $# -eq 1 ]; then
+          echo "ERROR: you must provide directory with the -d option"
+          exit -1
+        fi
+        SRC_DIR=$2
+        shift
+      ;;
+      -h|--help )
         usage
         exit 0
       ;;
@@ -77,7 +87,14 @@ process_results() {
 parse_args $@ 
 
 FOUND=FALSE
-for file in ../src/*.F90
+FILELIST=""
+if [ -d ${SRC_DIR} ]; then
+  FILELIST=`find ${SRC_DIR} -name "*.F90"`
+fi
+if [ -z $FILELIST ] && [ "$SILENT" != "TRUE" ]; then
+  echo "WARNING: no .F90 files found in ${SRC_DIR}"
+fi
+for file in $FILELIST
 do
   if [[ ! -z `check_length` ]]; then
     FOUND=TRUE


### PR DESCRIPTION
Introduced a new script to make sure no lines exceed NAG's 132 character limit, and updated the Makefile in bld-test/ to run this script as part of the build - so a developer without access to the NAG compiler still has an easy way to make sure his / her changes to the code will be parsed correctly by NAG.

I also updated the logic in the Makefile to make it a little easier to add new compilers -- there is a single `$(LIB_DIR)/%.a` target and a bunch of `PHONY` targets that set the compiler / flags before building the library.
