### PR TITLE
Enhancement/surface forcing output

### DIFF
--- a/src/marbl_diagnostics_mod.F90
+++ b/src/marbl_diagnostics_mod.F90
@@ -50,6 +50,7 @@ module marbl_diagnostics_mod
   use marbl_interface_types , only : marbl_saved_state_type
   use marbl_interface_types , only : marbl_interior_forcing_input_type
   use marbl_interface_types , only : marbl_surface_forcing_output_type
+  use marbl_interface_types , only : sfo_ind
   use marbl_interface_types , only : marbl_surface_forcing_indexing_type
   use marbl_interface_types , only : marbl_diagnostics_type
 
@@ -3136,7 +3137,6 @@ contains
          o2sat             => surface_forcing_internal%o2sat,                                   &
          iron_flux_in      => surface_forcing_internal%iron_flux,                               &
 
-         flux_co2          => surface_forcing_output%flux_co2,                                  &
 
          ph_prev           => saved_state%ph_prev_surf,                                         &
          ph_prev_alt_co2   => saved_state%ph_prev_alt_co2_surf,                                 &
@@ -3178,7 +3178,10 @@ contains
        
        diags(ind_diag%PV_CO2)%field_2d(:)               = pv_co2(:)
        diags(ind_diag%SCHMIDT_CO2)%field_2d(:)          = schmidt_co2(:)
-       diags(ind_diag%DIC_GAS_FLUX)%field_2d(:)         = flux_co2(:)
+       if (sfo_ind%flux_co2_id.ne.0) then
+         diags(ind_diag%DIC_GAS_FLUX)%field_2d(:)       =                     &
+                surface_forcing_output%sfo(sfo_ind%flux_co2_id)%forcing_field
+       end if
        diags(ind_diag%PH)%field_2d(:)                   = ph_prev(:)
        diags(ind_diag%ATM_CO2)%field_2d(:)              = xco2(:)
       

--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -222,8 +222,6 @@ contains
          
     call this%interior_forcing_input%construct(num_levels, num_PAR_subcols)
 
-    call this%surface_forcing_output%construct(num_surface_elements)
-    
     call this%saved_state%construct(num_surface_elements, num_levels)
 
     allocate(this%surface_vals(num_surface_elements, ecosys_used_tracer_cnt))

--- a/src/marbl_interface_types.F90
+++ b/src/marbl_interface_types.F90
@@ -146,6 +146,7 @@ module marbl_interface_types
   type, public :: marbl_surface_forcing_output_type
      real (r8), allocatable, dimension(:)   :: flux_o2     
      real (r8), allocatable, dimension(:)   :: flux_co2     
+     real (r8), allocatable, dimension(:)   :: totalChl
    contains
      procedure, public :: construct => marbl_surface_forcing_output_constructor
   end type marbl_surface_forcing_output_type
@@ -349,8 +350,9 @@ contains
     class(marbl_surface_forcing_output_type), intent(inout) :: this
     integer (int_kind), intent(in) :: num_elements
 
-    allocate (this%flux_co2          (num_elements))            
-    allocate (this%flux_o2           (num_elements))            
+    allocate (this%totalChl(num_elements))
+    allocate (this%flux_co2(num_elements))
+    allocate (this%flux_o2(num_elements))
 
   end subroutine marbl_surface_forcing_output_constructor
 

--- a/src/marbl_interface_types.F90
+++ b/src/marbl_interface_types.F90
@@ -44,6 +44,9 @@ module marbl_interface_types
 
   !****************************************************************************
 
+  ! NOTE: when adding a new surface forcing output field (a field that the GCM
+  !       may need to pass to flux coupler), remember to add a new index for it
+  !       as well.
   type, public :: marbl_surface_forcing_output_indexing_type
     integer(int_kind) :: flux_o2_id = 0
     integer(int_kind) :: flux_co2_id = 0
@@ -175,7 +178,7 @@ module marbl_interface_types
   type, public :: marbl_surface_forcing_output_type
      integer :: sfo_cnt
      integer :: num_elements
-     type(marbl_single_sfo_type), dimension(:), pointer :: sfo
+     type(marbl_single_sfo_type), dimension(:), pointer :: sfo => NULL()
    contains
      procedure, public :: add_sfo => marbl_sfo_add
   end type marbl_surface_forcing_output_type
@@ -389,7 +392,7 @@ contains
       case("flux_o2")
         this%long_name  = "Oxygen Flux"
         this%short_name = "flux_o2"
-        this%units      = "unknown"
+        this%units      = "nmol/cm^2/s"
         sfo_ind%flux_o2_id = id
       case("flux_co2")
         this%long_name  = "Carbon Dioxide Flux"
@@ -399,11 +402,11 @@ contains
       case("totalChl")
         this%long_name  = "Total Chlorophyll Concentration"
         this%short_name = "totalChl"
-        this%units      = "unknown"
+        this%units      = "mg/m^3"
         sfo_ind%totalChl_id = id
       case DEFAULT
-        write(error_msg, "(3A)") trim(field_name), " is not a valid surface", &
-                                 " forcing field name"
+        write(error_msg, "(2A)") trim(field_name),                            &
+                                 " is not a valid surface forcing field name"
         call marbl_status_log%log_error(error_msg, subname)
         return
     end select
@@ -414,10 +417,25 @@ contains
     this%forcing_field = c0
 
   end subroutine marbl_single_sfo_constructor
+
   !*****************************************************************************
 
   subroutine marbl_sfo_add(this, num_elements, field_name, sfo_id,            &
                            marbl_status_log)
+
+  ! MARBL uses pointers to create an extensible allocatable array. The surface
+  ! forcing output fields (part of the intent(out) of this routine) are stored
+  ! in this%sfo(:). To allow the size of this%sfo to grow, the process for
+  ! adding a new field is:
+  !
+  ! 1) allocate new_sfo to be size N (one element larger than this%sfo)
+  ! 2) copy this%sfo into first N-1 elements of new_sfo
+  ! 3) newest surface forcing output (field_name) is Nth element of new_sfo
+  ! 4) deallocate / nullify this%sfo
+  ! 5) point this%sfo => new_sfo
+  !
+  ! If the number of possible surface forcing output fields grows, this workflow
+  ! may need to be replaced with something that is not O(N^2).
 
     class(marbl_surface_forcing_output_type), intent(inout) :: this
     character(len=*),     intent(in)    :: field_name
@@ -434,22 +452,22 @@ contains
     else
       old_size = 0
     end if
-
     sfo_id = old_size+1
+
+    ! 1) allocate new_sfo to be size N (one element larger than this%sfo)
     allocate(new_sfo(sfo_id))
+
+    ! 2) copy this%sfo into first N-1 elements of new_sfo
     do n=1,old_size
       new_sfo(n)%long_name  = this%sfo(n)%long_name
       new_sfo(n)%short_name = this%sfo(n)%short_name
       new_sfo(n)%units      = this%sfo(n)%units
-
       allocate(new_sfo(n)%forcing_field(num_elements))
       new_sfo(n)%forcing_field = this%sfo(n)%forcing_field
       deallocate(this%sfo(n)%forcing_field)
     end do
-    if (old_size.gt.0) then
-      deallocate(this%sfo)
-      nullify(this%sfo)
-    end if
+
+    ! 3) newest surface forcing output (field_name) is Nth element of new_sfo
     call new_sfo(sfo_id)%construct(num_elements, field_name, sfo_id,          &
                                    marbl_status_log)
     if (marbl_status_log%labort_marbl) then
@@ -457,6 +475,14 @@ contains
       call marbl_status_log%log_error(error_msg, subname)
       return
     end if
+
+    ! 4) deallocate / nullify this%sfo
+    if (old_size.gt.0) then
+      deallocate(this%sfo)
+      nullify(this%sfo)
+    end if
+
+    ! 5) point this%sfo => new_sfo
     this%sfo=>new_sfo
 
   end subroutine marbl_sfo_add

--- a/src/marbl_interface_types.F90
+++ b/src/marbl_interface_types.F90
@@ -6,6 +6,7 @@ module marbl_interface_types
   use marbl_interface_constants , only : marbl_str_length
   use marbl_logging             , only : marbl_log_type
   use marbl_logging             , only : error_msg
+  use marbl_logging             , only : status_msg
 
   implicit none
 
@@ -406,6 +407,8 @@ contains
         call marbl_status_log%log_error(error_msg, subname)
         return
     end select
+    write(status_msg, "(3A)") "Adding ", trim(field_name), " to surface forcing outputs"
+    call marbl_status_log%log_noerror(status_msg, subname)
 
     allocate(this%forcing_field(num_elements))
     this%forcing_field = c0

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -2411,6 +2411,7 @@ contains
 
     !  Compute surface forcing fluxes 
 
+    use marbl_interface_types , only : sfo_ind
     use marbl_schmidt_number_mod , only : schmidt_co2_surf  
     use marbl_oxygen             , only : schmidt_o2_surf
     use marbl_co2calc_mod        , only : marbl_co2calc_surf
@@ -2466,6 +2467,7 @@ contains
     real (r8)               :: ph_new(num_elements)     ! computed ph from solver
     real (r8)               :: xkw_ice(num_elements)    ! common portion of piston vel., (1-fice)*xkw (cm/s)
     real (r8)               :: o2sat_1atm(num_elements) ! o2 saturation @ 1 atm (mmol/m^3)
+    real (r8)               :: totalChl_loc(num_elements)  ! local value of totalChl
     real (r8)               :: flux_co2_loc(num_elements)  ! local value of co2 flux
     real (r8)               :: flux_o2_loc(num_elements)   ! local value of o2 flux
     logical (log_kind)      :: mask(num_elements)
@@ -2538,11 +2540,14 @@ contains
     !  Compute total chlorophyll
     !-----------------------------------------------------------------------
 
-    surface_forcing_output%totalChl(:) = c0
-    do auto_ind = 1,size(autotrophs)
-      surface_forcing_output%totalChl(:) = surface_forcing_output%totalChl(:) + &
-                          max(c0, surface_vals(:,autotrophs(auto_ind)%Chl_ind))
-    end do
+    if (sfo_ind%totalChl_id.ne.0) then
+      totalChl_loc = c0
+      do auto_ind = 1,size(autotrophs)
+        totalChl_loc = totalChl_loc +                                         &
+                       max(c0, surface_vals(:,autotrophs(auto_ind)%Chl_ind))
+      end do
+      surface_forcing_output%sfo(sfo_ind%totalChl_id)%forcing_field = totalChl_loc
+    end if
 
     !-----------------------------------------------------------------------
     !  calculate gas flux quantities if necessary
@@ -2573,12 +2578,15 @@ contains
              pv_o2(:) = xkw_ice(:) * sqrt(660.0_r8 / schmidt_o2(:))
              o2sat(:) = ap_used(:) * o2sat_1atm(:)
              flux_o2_loc(:) = pv_o2(:) * (o2sat(:) - surface_vals(:, o2_ind))
-             ! surface_forcing_output%flux_o2 = flux_o2_loc
              stf(:, o2_ind) = stf(:, o2_ind) + flux_o2_loc(:)
           elsewhere
              pv_o2(:) = c0
              o2sat(:) = c0
+             flux_o2_loc = c0
           end where
+          if (sfo_ind%flux_o2_id.ne.0) then
+            surface_forcing_output%sfo(sfo_ind%flux_o2_id)%forcing_field = flux_o2_loc
+          end if
        else
           schmidt_o2(:) = c0
           pv_o2(:)      = c0
@@ -2648,7 +2656,9 @@ contains
           end if
 
           flux_co2_loc(:) = pv_co2(:) * dco2star(:)
-          surface_forcing_output%flux_co2 = flux_co2_loc
+          if (sfo_ind%flux_co2_id.ne.0) then
+            surface_forcing_output%sfo(sfo_ind%flux_co2_id)%forcing_field = flux_co2_loc
+          end if
  
           !-------------------------------------------------------------------
           !  The following variables need to be shared with other modules,

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -2516,6 +2516,7 @@ contains
 
          flux_o2              => surface_forcing_output%flux_o2(:),                                 &
          flux_co2             => surface_forcing_output%flux_co2(:),                                &
+         totalChl             => surface_forcing_output%totalChl(:),                                &
 
          ph_prev_surf         => saved_state%ph_prev_surf,                                          &
          ph_prev_alt_co2_surf => saved_state%ph_prev_alt_co2_surf,                                  &
@@ -2534,6 +2535,15 @@ contains
     !-----------------------------------------------------------------------
 
     stf(:, :) = c0
+
+    !-----------------------------------------------------------------------
+    !  Compute total chlorophyll
+    !-----------------------------------------------------------------------
+
+    totalChl(:) = c0
+    do auto_ind = 1,size(autotrophs)
+      totalChl(:) = totalChl(:) + max(c0, surface_vals(:,autotrophs(auto_ind)%Chl_ind))
+    end do
 
     !-----------------------------------------------------------------------
     !  calculate gas flux quantities if necessary


### PR DESCRIPTION
I have generalized the surface forcing output data type, which required an updated POP branch as well (because the driver interface changed). See

https://svn-ccsm-models.cgd.ucar.edu/pop2/branch_tags/marbl_dev_levy_tags/marbl_dev_levy_n02_marbl_dev_n01_cesm_pop_2_1_20160317b

For the driver-side changes. I can think of one small tweak to make to this branch before accepting the pull request: we may want to print a log message when MARBL adds a new surface forcing outputs (right now the constructor logs errors, but that is it).
