### PR TITLE
Enhancement/generalize saved state

### DIFF
--- a/src/marbl_diagnostics_mod.F90
+++ b/src/marbl_diagnostics_mod.F90
@@ -4185,12 +4185,14 @@ contains
        surface_tracer_fluxes,                       &
        marbl_tracer_indices,                        &
        saved_state,                                 &
+       saved_state_ind,                             &
        surface_forcing_output,                      &
        surface_forcing_diags)
 
     ! !DESCRIPTION:
     !  Compute surface fluxes for ecosys tracer module.
 
+    use marbl_interface_types , only : marbl_surface_saved_state_indexing_type
     use marbl_share_mod       , only : lflux_gas_o2
     use marbl_share_mod       , only : lflux_gas_co2
     use marbl_share_mod       , only : iron_flux_file     
@@ -4201,7 +4203,7 @@ contains
     use marbl_share_mod       , only : dsi_riv_flux_file          
     use marbl_share_mod       , only : dfe_riv_flux_file          
     use marbl_share_mod       , only : dic_riv_flux_file          
-    use marbl_share_mod       , only : alk_riv_flux_file          
+    use marbl_share_mod       , only : alk_riv_flux_file         
     use marbl_parms           , only : mpercm
 
     implicit none
@@ -4211,6 +4213,7 @@ contains
     real(r8)                                  , intent(in)    :: surface_tracer_fluxes(:,:)
     type(marbl_tracer_index_type)             , intent(in)    :: marbl_tracer_indices
     type(marbl_saved_state_type)              , intent(in)    :: saved_state 
+    type(marbl_surface_saved_state_indexing_type), intent(in) :: saved_state_ind
     type(marbl_surface_forcing_internal_type) , intent(in)    :: surface_forcing_internal
     type(marbl_surface_forcing_output_type)   , intent(in)    :: surface_forcing_output
     type(marbl_diagnostics_type)              , intent(inout) :: surface_forcing_diags
@@ -4254,8 +4257,8 @@ contains
          iron_flux_in      => surface_forcing_internal%iron_flux,                               &
 
 
-         ph_prev           => saved_state%ph_prev_surf,                                         &
-         ph_prev_alt_co2   => saved_state%ph_prev_alt_co2_surf,                                 &
+         ph_prev           => saved_state%state(saved_state_ind%ph_surf)%field_2d,              &
+         ph_prev_alt_co2   => saved_state%state(saved_state_ind%ph_alt_co2_surf)%field_2d,      &
 
          stf               => surface_tracer_fluxes(:,:),                                       &
 

--- a/src/marbl_diagnostics_mod.F90
+++ b/src/marbl_diagnostics_mod.F90
@@ -4192,19 +4192,19 @@ contains
     ! !DESCRIPTION:
     !  Compute surface fluxes for ecosys tracer module.
 
-    use marbl_interface_types , only : marbl_surface_saved_state_indexing_type
-    use marbl_share_mod       , only : lflux_gas_o2
-    use marbl_share_mod       , only : lflux_gas_co2
-    use marbl_share_mod       , only : iron_flux_file     
-    use marbl_share_mod       , only : din_riv_flux_file     
-    use marbl_share_mod       , only : dip_riv_flux_file          
-    use marbl_share_mod       , only : don_riv_flux_file          
-    use marbl_share_mod       , only : dop_riv_flux_file          
-    use marbl_share_mod       , only : dsi_riv_flux_file          
-    use marbl_share_mod       , only : dfe_riv_flux_file          
-    use marbl_share_mod       , only : dic_riv_flux_file          
-    use marbl_share_mod       , only : alk_riv_flux_file         
-    use marbl_parms           , only : mpercm
+    use marbl_internal_types , only : marbl_surface_saved_state_indexing_type
+    use marbl_share_mod      , only : lflux_gas_o2
+    use marbl_share_mod      , only : lflux_gas_co2
+    use marbl_share_mod      , only : iron_flux_file     
+    use marbl_share_mod      , only : din_riv_flux_file     
+    use marbl_share_mod      , only : dip_riv_flux_file          
+    use marbl_share_mod      , only : don_riv_flux_file          
+    use marbl_share_mod      , only : dop_riv_flux_file          
+    use marbl_share_mod      , only : dsi_riv_flux_file          
+    use marbl_share_mod      , only : dfe_riv_flux_file          
+    use marbl_share_mod      , only : dic_riv_flux_file          
+    use marbl_share_mod      , only : alk_riv_flux_file         
+    use marbl_parms          , only : mpercm
 
     implicit none
 

--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -152,6 +152,7 @@ contains
     use marbl_parms           , only : zooplankton
     use marbl_share_mod       , only : tracer_init_ext
     use marbl_share_mod       , only : ciso_tracer_init_ext
+    use marbl_saved_state_mod , only : marbl_saved_state_init
     
     implicit none
 
@@ -169,9 +170,6 @@ contains
 
     character(*), parameter :: subname = 'marbl_interface:marbl_init'
     integer :: i
-    ! For saved_state initialization
-    character(len=char_len) :: lname, sname, units, vgrid
-    integer :: rank
     !--------------------------------------------------------------------
 
     associate(&
@@ -259,56 +257,17 @@ contains
     ! set up saved state variables
     !--------------------------------------------------------------------
 
-    ! MNL MNL MNL -- don't hard-code number of saved state variables!
-    ! Move this to marbl_saved_state_mod.F90?
-    call this%surface_saved_state%construct(2, num_surface_elements, num_levels)
+    call marbl_saved_state_init(this%surface_saved_state,                     &
+                                this%interior_saved_state,                    &
+                                this%surf_state_ind,                          &
+                                this%interior_state_ind,                      &
+                                num_levels,                                   &
+                                num_surface_elements,                         &
+                                num_interior_forcing,                         &
+                                this%StatusLog)
 
-    lname = 'surface pH'
-    sname = 'PH_SURF'
-    units = 'pH'
-    vgrid = 'none'
-    rank  = 2
-    call this%surface_saved_state%add_state(lname, sname, units, vgrid, rank, &
-              this%surf_state_ind%ph_surf, this%StatusLog)
     if (this%StatusLog%labort_marbl) then
-      call this%StatusLog%log_error_trace("add_state(PH_SURF)", subname)
-      return
-    end if
-
-    lname = 'surface pH (alternate CO2)'
-    sname = 'PH_SURF_ALT_CO2'
-    units = 'pH'
-    vgrid = 'none'
-    rank  = 2
-    call this%surface_saved_state%add_state(lname, sname, units, vgrid, rank, &
-              this%surf_state_ind%ph_alt_co2_surf, this%StatusLog)
-    if (this%StatusLog%labort_marbl) then
-      call this%StatusLog%log_error_trace("add_state(PH_SURF_ALT_CO2)", subname)
-      return
-    end if
-
-    call this%interior_saved_state%construct(2, num_interior_forcing, num_levels)
-    lname = '3D pH'
-    sname = 'PH_3D'
-    units = 'pH'
-    vgrid = 'layer_avg'
-    rank  = 3
-    call this%interior_saved_state%add_state(lname, sname, units, vgrid, rank,&
-              this%interior_state_ind%ph_col, this%StatusLog)
-    if (this%StatusLog%labort_marbl) then
-      call this%StatusLog%log_error_trace("add_state(PH_3D)", subname)
-      return
-    end if
-
-    lname = '3D pH (alternate CO2)'
-    sname = 'PH_3D_ALT_CO2'
-    units = 'pH'
-    vgrid = 'layer_avg'
-    rank  = 3
-    call this%interior_saved_state%add_state(lname, sname, units, vgrid, rank,&
-              this%interior_state_ind%ph_alt_co2_col, this%StatusLog)
-    if (this%StatusLog%labort_marbl) then
-      call this%StatusLog%log_error_trace("add_state(PH_3D_ALT_CO2)", subname)
+      call this%StatusLog%log_error_trace("marbl_saved_state_init()", subname)
       return
     end if
 

--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -171,6 +171,7 @@ contains
     integer :: i
     ! For saved_state initialization
     character(len=char_len) :: lname, sname, units, vgrid
+    integer :: rank
     !--------------------------------------------------------------------
 
     associate(&
@@ -266,7 +267,8 @@ contains
     sname = 'PH_SURF'
     units = 'pH'
     vgrid = 'none'
-    call this%surface_saved_state%add_state(lname, sname, units, vgrid,       &
+    rank  = 2
+    call this%surface_saved_state%add_state(lname, sname, units, vgrid, rank, &
               this%surf_state_ind%ph_surf, this%StatusLog)
     if (this%StatusLog%labort_marbl) then
       call this%StatusLog%log_error_trace("add_state(PH_SURF)", subname)
@@ -277,7 +279,8 @@ contains
     sname = 'PH_SURF_ALT_CO2'
     units = 'pH'
     vgrid = 'none'
-    call this%surface_saved_state%add_state(lname, sname, units, vgrid,       &
+    rank  = 2
+    call this%surface_saved_state%add_state(lname, sname, units, vgrid, rank, &
               this%surf_state_ind%ph_alt_co2_surf, this%StatusLog)
     if (this%StatusLog%labort_marbl) then
       call this%StatusLog%log_error_trace("add_state(PH_SURF_ALT_CO2)", subname)
@@ -289,7 +292,8 @@ contains
     sname = 'PH_3D'
     units = 'pH'
     vgrid = 'layer_avg'
-    call this%interior_saved_state%add_state(lname, sname, units, vgrid,      &
+    rank  = 3
+    call this%interior_saved_state%add_state(lname, sname, units, vgrid, rank,&
               this%interior_state_ind%ph_col, this%StatusLog)
     if (this%StatusLog%labort_marbl) then
       call this%StatusLog%log_error_trace("add_state(PH_3D)", subname)
@@ -300,7 +304,8 @@ contains
     sname = 'PH_3D_ALT_CO2'
     units = 'pH'
     vgrid = 'layer_avg'
-    call this%interior_saved_state%add_state(lname, sname, units, vgrid,      &
+    rank  = 3
+    call this%interior_saved_state%add_state(lname, sname, units, vgrid, rank,&
               this%interior_state_ind%ph_alt_co2_col, this%StatusLog)
     if (this%StatusLog%labort_marbl) then
       call this%StatusLog%log_error_trace("add_state(PH_3D_ALT_CO2)", subname)

--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -36,6 +36,8 @@ module marbl_interface
   use marbl_interface_types , only : marbl_surface_forcing_indexing_type
   use marbl_interface_types , only : marbl_forcing_fields_type
   use marbl_interface_types , only : marbl_saved_state_type
+  use marbl_interface_types , only : marbl_surface_saved_state_indexing_type
+  use marbl_interface_types , only : marbl_interior_saved_state_indexing_type
 
   use marbl_internal_types  , only : marbl_PAR_type
   use marbl_internal_types  , only : marbl_interior_share_type
@@ -69,7 +71,10 @@ module marbl_interface
      type(marbl_tracer_read_type)              , public, allocatable  :: tracer_read(:)
      type(marbl_tracer_index_type)             , public               :: tracer_indices
      type(marbl_log_type)                      , public               :: StatusLog
-     type(marbl_saved_state_type)              , public               :: saved_state             ! input/output
+     type(marbl_saved_state_type)              , public               :: surface_saved_state             ! input/output
+     type(marbl_saved_state_type)              , public               :: interior_saved_state             ! input/output
+     type(marbl_surface_saved_state_indexing_type), public            :: surf_state_ind
+     type(marbl_interior_saved_state_indexing_type), public           :: interior_state_ind
 
      ! public data - interior forcing
      real (r8)                                 , public, allocatable  :: column_tracers(:,:)     ! input  *
@@ -164,6 +169,8 @@ contains
 
     character(*), parameter :: subname = 'marbl_interface:marbl_init'
     integer :: i
+    ! For saved_state initialization
+    character(len=char_len) :: lname, sname, units, vgrid
     !--------------------------------------------------------------------
 
     associate(&
@@ -237,8 +244,6 @@ contains
          
     call this%interior_forcing_input%construct(num_levels, num_PAR_subcols)
 
-    call this%saved_state%construct(num_surface_elements, num_levels)
-
     allocate(this%surface_vals(num_surface_elements, marbl_total_tracer_cnt))
 
     allocate(this%surface_tracer_fluxes(num_surface_elements, marbl_total_tracer_cnt))
@@ -248,6 +253,40 @@ contains
     allocate(this%column_dtracers(marbl_total_tracer_cnt, num_levels))
 
     allocate(this%column_restore(marbl_total_tracer_cnt, gcm_num_levels))
+
+    !--------------------------------------------------------------------
+    ! set up saved state variables
+    !--------------------------------------------------------------------
+
+    ! MNL MNL MNL -- don't hard-code number of saved state variables!
+    ! Move this to marbl_saved_state_mod.F90?
+    call this%surface_saved_state%construct(2, num_surface_elements, num_levels)
+    lname = 'surface pH'
+    sname = 'PH_SURF'
+    units = 'pH'
+    vgrid = 'none'
+    call this%surface_saved_state%add_state(lname, sname, units, vgrid,       &
+              this%surf_state_ind%ph_surf, this%StatusLog)
+    lname = 'surface pH (alternate CO2)'
+    sname = 'PH_SURF_ALT_CO2'
+    units = 'pH'
+    vgrid = 'none'
+    call this%surface_saved_state%add_state(lname, sname, units, vgrid,       &
+              this%surf_state_ind%ph_alt_co2_surf, this%StatusLog)
+
+    call this%interior_saved_state%construct(2, num_interior_forcing, num_levels)
+    lname = '3D pH'
+    sname = 'PH_3D'
+    units = 'pH'
+    vgrid = 'layer_avg'
+    call this%surface_saved_state%add_state(lname, sname, units, vgrid,       &
+              this%interior_state_ind%ph_col, this%StatusLog)
+    lname = '3D pH (alternate CO2)'
+    sname = 'PH_3D_ALT_CO2'
+    units = 'pH'
+    vgrid = 'layer_avg'
+    call this%surface_saved_state%add_state(lname, sname, units, vgrid,       &
+              this%interior_state_ind%ph_alt_co2_col, this%StatusLog)
 
     !--------------------------------------------------------------------
     ! Initialize public data / general tracer metadata
@@ -359,7 +398,8 @@ contains
          ciso_on                 = this%ciso_on,                 &
          domain                  = this%domain,                  &
          interior_forcing_input  = this%interior_forcing_input,  &
-         saved_state             = this%saved_state,             &
+         saved_state             = this%interior_saved_state,    &
+         saved_state_ind         = this%interior_state_ind,      &
          interior_restore        = this%column_restore,          &
          tracers                 = this%column_tracers,          &
          dtracers                = this%column_dtracers,         &
@@ -398,7 +438,8 @@ contains
          surface_vals             = this%surface_vals,                        &
          surface_tracer_fluxes    = this%surface_tracer_fluxes,               &
          marbl_tracer_indices     = this%tracer_indices,                      &
-         saved_state              = this%saved_state,                         &
+         saved_state              = this%surface_saved_state,                 &
+         saved_state_ind          = this%surf_state_ind,                      &
          surface_forcing_output   = this%surface_forcing_output,              &
          surface_forcing_internal = this%surface_forcing_internal,            &
          surface_forcing_share    = this%surface_forcing_share,               &

--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -36,9 +36,9 @@ module marbl_interface
   use marbl_interface_types , only : marbl_surface_forcing_indexing_type
   use marbl_interface_types , only : marbl_forcing_fields_type
   use marbl_interface_types , only : marbl_saved_state_type
-  use marbl_interface_types , only : marbl_surface_saved_state_indexing_type
-  use marbl_interface_types , only : marbl_interior_saved_state_indexing_type
 
+  use marbl_internal_types , only : marbl_surface_saved_state_indexing_type
+  use marbl_internal_types , only : marbl_interior_saved_state_indexing_type
   use marbl_internal_types  , only : marbl_PAR_type
   use marbl_internal_types  , only : marbl_interior_share_type
   use marbl_internal_types  , only : marbl_autotroph_share_type

--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -261,32 +261,51 @@ contains
     ! MNL MNL MNL -- don't hard-code number of saved state variables!
     ! Move this to marbl_saved_state_mod.F90?
     call this%surface_saved_state%construct(2, num_surface_elements, num_levels)
+
     lname = 'surface pH'
     sname = 'PH_SURF'
     units = 'pH'
     vgrid = 'none'
     call this%surface_saved_state%add_state(lname, sname, units, vgrid,       &
               this%surf_state_ind%ph_surf, this%StatusLog)
+    if (this%StatusLog%labort_marbl) then
+      call this%StatusLog%log_error_trace("add_state(PH_SURF)", subname)
+      return
+    end if
+
     lname = 'surface pH (alternate CO2)'
     sname = 'PH_SURF_ALT_CO2'
     units = 'pH'
     vgrid = 'none'
     call this%surface_saved_state%add_state(lname, sname, units, vgrid,       &
               this%surf_state_ind%ph_alt_co2_surf, this%StatusLog)
+    if (this%StatusLog%labort_marbl) then
+      call this%StatusLog%log_error_trace("add_state(PH_SURF_ALT_CO2)", subname)
+      return
+    end if
 
     call this%interior_saved_state%construct(2, num_interior_forcing, num_levels)
     lname = '3D pH'
     sname = 'PH_3D'
     units = 'pH'
     vgrid = 'layer_avg'
-    call this%surface_saved_state%add_state(lname, sname, units, vgrid,       &
+    call this%interior_saved_state%add_state(lname, sname, units, vgrid,      &
               this%interior_state_ind%ph_col, this%StatusLog)
+    if (this%StatusLog%labort_marbl) then
+      call this%StatusLog%log_error_trace("add_state(PH_3D)", subname)
+      return
+    end if
+
     lname = '3D pH (alternate CO2)'
     sname = 'PH_3D_ALT_CO2'
     units = 'pH'
     vgrid = 'layer_avg'
-    call this%surface_saved_state%add_state(lname, sname, units, vgrid,       &
+    call this%interior_saved_state%add_state(lname, sname, units, vgrid,      &
               this%interior_state_ind%ph_alt_co2_col, this%StatusLog)
+    if (this%StatusLog%labort_marbl) then
+      call this%StatusLog%log_error_trace("add_state(PH_3D_ALT_CO2)", subname)
+      return
+    end if
 
     !--------------------------------------------------------------------
     ! Initialize public data / general tracer metadata

--- a/src/marbl_interface_types.F90
+++ b/src/marbl_interface_types.F90
@@ -56,28 +56,14 @@ module marbl_interface_types
 
   !*****************************************************************************
 
-  type, public :: marbl_surface_saved_state_indexing_type
-    integer :: ph_surf = 0
-    integer :: ph_alt_co2_surf = 0
-  end type marbl_surface_saved_state_indexing_type
-
-  !*****************************************************************************
-
-  type, public :: marbl_interior_saved_state_indexing_type
-    integer :: ph_col = 0
-    integer :: ph_alt_co2_col = 0
-  end type marbl_interior_saved_state_indexing_type
-
-  !*****************************************************************************
-
   type, public :: marbl_single_saved_state_type
     integer                 :: rank
     character(len=char_len) :: long_name
     character(len=char_len) :: short_name
     character(len=char_len) :: units
     character(len=char_len) :: vertical_grid ! 'none', 'layer_avg', 'layer_iface'
-    real(r8), allocatable, dimension(:)   :: field_2d
-    real(r8), allocatable, dimension(:,:) :: field_3d
+    real(r8), allocatable, dimension(:)   :: field_2d  ! num_elements
+    real(r8), allocatable, dimension(:,:) :: field_3d  ! num_levels, num_elements
   contains
     procedure :: construct => marbl_single_saved_state_construct
   end type marbl_single_saved_state_type

--- a/src/marbl_interface_types.F90
+++ b/src/marbl_interface_types.F90
@@ -403,6 +403,7 @@ contains
     this%short_name    = trim(sname)
     this%units         = trim(units)
     this%vertical_grid = trim(vgrid)
+    this%rank          = rank
 
   end subroutine marbl_single_saved_state_init
 

--- a/src/marbl_internal_types.F90
+++ b/src/marbl_internal_types.F90
@@ -366,6 +366,20 @@ module marbl_internal_types
     procedure, public :: construct => tracer_index_constructor
   end type marbl_tracer_index_type
 
+  !*****************************************************************************
+
+  type, public :: marbl_surface_saved_state_indexing_type
+    integer :: ph_surf = 0
+    integer :: ph_alt_co2_surf = 0
+  end type marbl_surface_saved_state_indexing_type
+
+  !*****************************************************************************
+
+  type, public :: marbl_interior_saved_state_indexing_type
+    integer :: ph_col = 0
+    integer :: ph_alt_co2_col = 0
+  end type marbl_interior_saved_state_indexing_type
+
   !***********************************************************************
 
 contains

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -1472,6 +1472,7 @@ contains
        domain,                           &
        interior_forcing_input,           &
        saved_state,                      &
+       saved_state_ind,                  &
        interior_restore,                 &
        tracers,                          &
        dtracers,                         &
@@ -1489,6 +1490,7 @@ contains
 
     use marbl_ciso_mod , only : marbl_ciso_set_interior_forcing
     use marbl_sizes    , only : marbl_total_tracer_cnt
+    use marbl_interface_types, only : marbl_interior_saved_state_indexing_type
 
     implicit none 
 
@@ -1499,6 +1501,7 @@ contains
     real    (r8)                                , intent(in)    :: tracers(:,: )         ! (marbl_total_tracer_cnt, km) tracer values 
     type    (marbl_PAR_type)                    , intent(inout) :: marbl_PAR
     type    (marbl_saved_state_type)            , intent(inout) :: saved_state
+    type    (marbl_interior_saved_state_indexing_type), intent(in) :: saved_state_ind
     real    (r8)                                , intent(out)   :: dtracers(:,:)          ! (marbl_total_tracer_cnt, km) computed source/sink terms
     type    (marbl_tracer_index_type)           , intent(in)    :: marbl_tracer_indices
     ! FIXME #17: intent is inout due to DIC_Loc
@@ -1584,8 +1587,8 @@ contains
          dust                => marbl_particulate_share%dust,       &
          P_iron              => marbl_particulate_share%P_iron,     &
 
-         ph_prev_col         => saved_state%ph_prev_col,            &
-         ph_prev_alt_co2_col => saved_state%ph_prev_alt_co2_col,    &
+         ph_prev_col         => saved_state%state(saved_state_ind%ph_col)%field_3d(:,1), &
+         ph_prev_alt_co2_col => saved_state%state(saved_state_ind%ph_alt_co2_col)%field_3d(:,1), &
 
          dust_flux_in        => interior_forcing_input%dust_flux,   &
          temperature         => interior_forcing_input%temperature, &
@@ -2568,6 +2571,7 @@ contains
        surface_tracer_fluxes,           &
        marbl_tracer_indices,            &
        saved_state,                     &
+       saved_state_ind,                 &
        surface_forcing_output,          &
        surface_forcing_internal,        &
        surface_forcing_share,           &
@@ -2576,6 +2580,7 @@ contains
 
     !  Compute surface forcing fluxes 
 
+    use marbl_interface_types , only : marbl_surface_saved_state_indexing_type
     use marbl_interface_types , only : sfo_ind
     use marbl_schmidt_number_mod , only : schmidt_co2_surf  
     use marbl_oxygen             , only : schmidt_o2_surf
@@ -2615,6 +2620,7 @@ contains
     real (r8)                                 , intent(out)   :: surface_tracer_fluxes(:,:)
     type(marbl_tracer_index_type)             , intent(in)    :: marbl_tracer_indices
     type(marbl_saved_state_type)              , intent(inout) :: saved_state
+    type(marbl_surface_saved_state_indexing_type), intent(in) :: saved_state_ind
     type(marbl_surface_forcing_internal_type) , intent(inout) :: surface_forcing_internal
     type(marbl_surface_forcing_output_type)   , intent(inout) :: surface_forcing_output
     type(marbl_surface_forcing_share_type)    , intent(inout) :: surface_forcing_share
@@ -2683,8 +2689,8 @@ contains
 
          stf                  => surface_tracer_fluxes(:,:),                                        &
 
-         ph_prev_surf         => saved_state%ph_prev_surf,                                          &
-         ph_prev_alt_co2_surf => saved_state%ph_prev_alt_co2_surf,                                  &
+         ph_prev_surf         => saved_state%state(saved_state_ind%ph_surf)%field_2d,               &
+         ph_prev_alt_co2_surf => saved_state%state(saved_state_ind%ph_alt_co2_surf)%field_2d,       &
 
          po4_ind           => marbl_tracer_indices%po4_ind,                                     &
          no3_ind           => marbl_tracer_indices%no3_ind,                                     &
@@ -3016,6 +3022,7 @@ contains
          surface_tracer_fluxes    = stf,                      &
          marbl_tracer_indices     = marbl_tracer_indices,     &
          saved_state              = saved_state,              & 
+         saved_state_ind          = saved_state_ind,          & 
          surface_forcing_output   = surface_forcing_output,   &
          surface_forcing_diags    = surface_forcing_diags)
 

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -1548,9 +1548,9 @@ contains
     
     !  Compute time derivatives for ecosystem state variables
 
-    use marbl_ciso_mod , only : marbl_ciso_set_interior_forcing
-    use marbl_sizes    , only : marbl_total_tracer_cnt
-    use marbl_interface_types, only : marbl_interior_saved_state_indexing_type
+    use marbl_ciso_mod      , only : marbl_ciso_set_interior_forcing
+    use marbl_sizes         , only : marbl_total_tracer_cnt
+    use marbl_internal_types, only : marbl_interior_saved_state_indexing_type
 
     implicit none 
 
@@ -2643,8 +2643,8 @@ contains
 
     !  Compute surface forcing fluxes 
 
-    use marbl_interface_types , only : marbl_surface_saved_state_indexing_type
-    use marbl_interface_types , only : sfo_ind
+    use marbl_interface_types    , only : sfo_ind
+    use marbl_internal_types     , only : marbl_surface_saved_state_indexing_type
     use marbl_schmidt_number_mod , only : schmidt_co2_surf  
     use marbl_oxygen             , only : schmidt_o2_surf
     use marbl_co2calc_mod        , only : marbl_co2calc_surf

--- a/src/marbl_saved_state_mod.F90
+++ b/src/marbl_saved_state_mod.F90
@@ -32,7 +32,7 @@ Contains
     character(len=char_len) :: lname, sname, units, vgrid
     integer :: rank
 
-    call surface_state%construct(2, num_surface_elements, num_levels)
+    call surface_state%construct(num_surface_elements, num_levels)
 
     lname = 'surface pH'
     sname = 'PH_SURF'
@@ -58,7 +58,7 @@ Contains
       return
     end if
 
-    call interior_state%construct(2, num_interior_forcing, num_levels)
+    call interior_state%construct(num_interior_forcing, num_levels)
     lname = '3D pH'
     sname = 'PH_3D'
     units = 'pH'

--- a/src/marbl_saved_state_mod.F90
+++ b/src/marbl_saved_state_mod.F90
@@ -13,8 +13,8 @@ Contains
              num_interior_forcing, marbl_status_log)
 
     use marbl_interface_types , only : marbl_saved_state_type
-    use marbl_interface_types , only : marbl_surface_saved_state_indexing_type
-    use marbl_interface_types , only : marbl_interior_saved_state_indexing_type
+    use marbl_internal_types  , only : marbl_surface_saved_state_indexing_type
+    use marbl_internal_types  , only : marbl_interior_saved_state_indexing_type
     use marbl_logging         , only : marbl_log_type
     use marbl_kinds_mod       , only : char_len
 
@@ -59,6 +59,7 @@ Contains
     end if
 
     call interior_state%construct(num_interior_forcing, num_levels)
+
     lname = '3D pH'
     sname = 'PH_3D'
     units = 'pH'

--- a/src/marbl_saved_state_mod.F90
+++ b/src/marbl_saved_state_mod.F90
@@ -1,0 +1,88 @@
+module marbl_saved_state_mod
+
+  Implicit None
+  Private
+  Save
+
+  public :: marbl_saved_state_init
+
+Contains
+
+  subroutine marbl_saved_state_init(surface_state, interior_state, surf_ind,  &
+             interior_ind, num_levels, num_surface_elements,                  &
+             num_interior_forcing, marbl_status_log)
+
+    use marbl_interface_types , only : marbl_saved_state_type
+    use marbl_interface_types , only : marbl_surface_saved_state_indexing_type
+    use marbl_interface_types , only : marbl_interior_saved_state_indexing_type
+    use marbl_logging         , only : marbl_log_type
+    use marbl_kinds_mod       , only : char_len
+
+
+    type(marbl_saved_state_type), intent(inout) :: surface_state
+    type(marbl_saved_state_type), intent(inout) :: interior_state
+    type(marbl_surface_saved_state_indexing_type),  intent(inout) :: surf_ind
+    type(marbl_interior_saved_state_indexing_type), intent(inout) :: interior_ind
+    integer,                      intent(in)    :: num_levels
+    integer,                      intent(in)    :: num_surface_elements
+    integer,                      intent(in)    :: num_interior_forcing
+    type(marbl_log_type),         intent(inout) :: marbl_status_log
+
+    character(*), parameter :: subname = 'marbl_saved_state_mod:marbl_saved_state_init'
+    character(len=char_len) :: lname, sname, units, vgrid
+    integer :: rank
+
+    call surface_state%construct(2, num_surface_elements, num_levels)
+
+    lname = 'surface pH'
+    sname = 'PH_SURF'
+    units = 'pH'
+    vgrid = 'none'
+    rank  = 2
+    call surface_state%add_state(lname, sname, units, vgrid, rank,            &
+         surf_ind%ph_surf, marbl_status_log)
+    if (marbl_status_log%labort_marbl) then
+      call marbl_status_log%log_error_trace("add_state(PH_SURF)", subname)
+      return
+    end if
+
+    lname = 'surface pH (alternate CO2)'
+    sname = 'PH_SURF_ALT_CO2'
+    units = 'pH'
+    vgrid = 'none'
+    rank  = 2
+    call surface_state%add_state(lname, sname, units, vgrid, rank,            &
+         surf_ind%ph_alt_co2_surf, marbl_status_log)
+    if (marbl_status_log%labort_marbl) then
+      call marbl_status_log%log_error_trace("add_state(PH_SURF_ALT_CO2)", subname)
+      return
+    end if
+
+    call interior_state%construct(2, num_interior_forcing, num_levels)
+    lname = '3D pH'
+    sname = 'PH_3D'
+    units = 'pH'
+    vgrid = 'layer_avg'
+    rank  = 3
+    call interior_state%add_state(lname, sname, units, vgrid, rank,           &
+         interior_ind%ph_col, marbl_status_log)
+    if (marbl_status_log%labort_marbl) then
+      call marbl_status_log%log_error_trace("add_state(PH_3D)", subname)
+      return
+    end if
+
+    lname = '3D pH (alternate CO2)'
+    sname = 'PH_3D_ALT_CO2'
+    units = 'pH'
+    vgrid = 'layer_avg'
+    rank  = 3
+    call interior_state%add_state(lname, sname, units, vgrid, rank,           &
+         interior_ind%ph_alt_co2_col, marbl_status_log)
+    if (marbl_status_log%labort_marbl) then
+      call marbl_status_log%log_error_trace("add_state(PH_3D_ALT_CO2)", subname)
+      return
+    end if
+
+  end subroutine marbl_saved_state_init
+
+end module marbl_saved_state_mod


### PR DESCRIPTION
This branch generalizes the saved state datatype. It requires

https://svn-ccsm-models.cgd.ucar.edu/pop2/branch_tags/marbl_dev_levy_tags/marbl_dev_levy_n19_marbl_dev_n10_cesm_pop_2_1_20160513

and passes all aux_pop_MARBL tests (yellowstone_intel, yellowstone_gnu, and hobart_nag).

@klindsay28 I'm hoping we can talk about this on Friday or Monday.
