### PR TITLE
Tag Summary: implement global averages, scalar running means, ladjust…

### DIFF
--- a/src/marbl_ciso_mod.F90
+++ b/src/marbl_ciso_mod.F90
@@ -1494,7 +1494,6 @@ contains
     !----------------------------------------------------------------------------------------
     
     use marbl_parms     , only : denitrif_C_N
-    use marbl_parms     , only : parm_POMbury
     use marbl_parms     , only : spd
 
     implicit none
@@ -1516,7 +1515,7 @@ contains
     !-----------------------------------------------------------------------
     !  local variables
     !-----------------------------------------------------------------------
-    character(*), parameter :: subname = 'marbl_ciso_mod:ciso_compute_particulate_terms'
+    character(*), parameter :: subname = 'marbl_ciso_mod:compute_particulate_terms'
     character(len=char_len) :: log_message
 
     real (r8) ::              &
@@ -1541,7 +1540,8 @@ contains
          POC_sflux_out     => marbl_particulate_share%POC_sflux_out_fields  , & ! IN
          POC_hflux_out     => marbl_particulate_share%POC_hflux_out_fields  , & ! IN
          POC_remin         => marbl_particulate_share%POC_remin_fields      , & ! IN
-         P_CaCO3_remin     => marbl_particulate_share%P_CaCO3_remin_fields    & ! IN
+         P_CaCO3_remin     => marbl_particulate_share%P_CaCO3_remin_fields  , & ! IN
+         POC_bury_coeff    => marbl_particulate_share%POC_bury_coeff          & ! IN
          )
 
     !-----------------------------------------------------------------------
@@ -1710,7 +1710,7 @@ contains
        if (flux > c0) then
           flux_alt = flux * mpercm * spd ! convert to mmol/m^2/day
 
-          POC_ciso%sed_loss(k) = flux * min(0.8_r8, parm_POMbury &
+          POC_ciso%sed_loss(k) = flux * min(0.8_r8, POC_bury_coeff &
                * (0.013_r8 + 0.53_r8 * flux_alt*flux_alt / (7.0_r8 + flux_alt)**2))
 
 

--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -36,6 +36,7 @@ module marbl_interface
   use marbl_interface_types , only : marbl_surface_forcing_indexing_type
   use marbl_interface_types , only : marbl_forcing_fields_type
   use marbl_interface_types , only : marbl_saved_state_type
+  use marbl_interface_types , only : marbl_running_mean_0d_type
 
   use marbl_internal_types  , only : marbl_PAR_type
   use marbl_internal_types  , only : marbl_interior_share_type
@@ -90,6 +91,22 @@ module marbl_interface
      type(marbl_surface_forcing_output_type)   , public               :: surface_forcing_output      ! output
      type(marbl_diagnostics_type)              , public               :: surface_forcing_diags       ! output
 
+     ! public data - global averages
+     real (r8)                                 , public, allocatable  :: glo_avg_fields_interior(:)   ! output (nfields)
+     real (r8)                                 , public, allocatable  :: glo_avg_averages_interior(:) ! input (nfields)
+     real (r8)                                 , public, allocatable  :: glo_avg_fields_surface(:,:)  ! output (num_elements,nfields)
+     real (r8)                                 , public, allocatable  :: glo_avg_averages_surface(:)  ! input (nfields)
+
+     ! FIXME
+     ! for now, running means are being computed in the driver
+     ! they will eventually be moved from the interface to inside MARBL
+     real (r8)                                 , public, allocatable  :: glo_scalar_interior(:)
+     real (r8)                                 , public, allocatable  :: glo_scalar_surface(:)
+
+     type(marbl_running_mean_0d_type)          , public, allocatable  :: glo_avg_rmean_interior(:)
+     type(marbl_running_mean_0d_type)          , public, allocatable  :: glo_avg_rmean_surface(:)
+     type(marbl_running_mean_0d_type)          , public, allocatable  :: glo_scalar_rmean_interior(:)
+     type(marbl_running_mean_0d_type)          , public, allocatable  :: glo_scalar_rmean_surface(:)
 
      ! private data 
      logical (log_kind)                        , private              :: ciso_on
@@ -107,11 +124,13 @@ module marbl_interface
      procedure, public :: get_tracer_index
      procedure, public :: set_interior_forcing     
      procedure, public :: set_surface_forcing
+     procedure, public :: set_global_scalars
      procedure, public :: shutdown         
 
   end type marbl_interface_class
   
   private :: init
+  private :: glo_vars_init
   private :: set_interior_forcing
   private :: set_surface_forcing
   private :: shutdown
@@ -141,6 +160,7 @@ contains
     use marbl_mod             , only : marbl_init_nml
     use marbl_mod             , only : marbl_init_surface_forcing_fields
     use marbl_mod             , only : marbl_init_tracer_metadata
+    use marbl_mod             , only : marbl_init_bury_coeff
     use marbl_mod             , only : marbl_update_tracer_file_metadata
     use marbl_diagnostics_mod , only : marbl_diagnostics_init
     use marbl_parms           , only : autotrophs
@@ -162,7 +182,7 @@ contains
     real      (r8)                         , intent(in)    :: gcm_zw(gcm_num_levels) ! thickness of layer k
     real      (r8)                         , intent(in)    :: gcm_zt(gcm_num_levels) ! thickness of layer k
 
-    character(*), parameter :: subname = 'marbl_interface:marbl_init'
+    character(*), parameter :: subname = 'marbl_interface:init'
     integer :: i
     !--------------------------------------------------------------------
 
@@ -248,6 +268,14 @@ contains
     allocate(this%column_dtracers(marbl_total_tracer_cnt, num_levels))
 
     allocate(this%column_restore(marbl_total_tracer_cnt, gcm_num_levels))
+
+    call marbl_init_bury_coeff(this%particulate_share, this%StatusLog)
+    if (this%StatusLog%labort_marbl) then
+      call this%StatusLog%log_error_trace('marbl_init_bury_coeff', subname)
+      return
+    end if
+
+    call glo_vars_init(this, num_surface_elements)
 
     !--------------------------------------------------------------------
     ! Initialize public data / general tracer metadata
@@ -340,6 +368,48 @@ contains
 
   !***********************************************************************
   
+  subroutine glo_vars_init(this, num_surface_elements)
+
+    use marbl_mod, only : marbl_set_glo_vars_cnt
+    use marbl_mod, only : marbl_set_rmean_init_vals
+
+    class (marbl_interface_class), intent(inout) :: this
+    integer (int_kind)           , intent(in)    :: num_surface_elements
+
+    integer (int_kind) :: glo_avg_field_cnt_interior
+    integer (int_kind) :: glo_avg_field_cnt_surface
+    integer (int_kind) :: glo_scalar_cnt_interior
+    integer (int_kind) :: glo_scalar_cnt_surface
+
+    call marbl_set_glo_vars_cnt(glo_avg_field_cnt_interior, &
+                                glo_avg_field_cnt_surface,  &
+                                glo_scalar_cnt_interior,    &
+                                glo_scalar_cnt_surface)
+
+    allocate(this%glo_avg_fields_interior(glo_avg_field_cnt_interior))
+    allocate(this%glo_avg_averages_interior(glo_avg_field_cnt_interior))
+
+    allocate(this%glo_avg_fields_surface(num_surface_elements, glo_avg_field_cnt_surface))
+    allocate(this%glo_avg_averages_surface(glo_avg_field_cnt_surface))
+
+    allocate(this%glo_scalar_interior(glo_scalar_cnt_interior))
+
+    allocate(this%glo_scalar_surface(glo_scalar_cnt_surface))
+
+    allocate(this%glo_avg_rmean_interior(glo_avg_field_cnt_interior))
+    allocate(this%glo_avg_rmean_surface(glo_avg_field_cnt_surface))
+    allocate(this%glo_scalar_rmean_interior(glo_scalar_cnt_interior))
+    allocate(this%glo_scalar_rmean_surface(glo_scalar_cnt_surface))
+
+    call marbl_set_rmean_init_vals(this%glo_avg_rmean_interior,    &
+                                   this%glo_avg_rmean_surface,     &
+                                   this%glo_scalar_rmean_interior, &
+                                   this%glo_scalar_rmean_surface)
+
+  end subroutine glo_vars_init
+
+  !***********************************************************************
+  
   subroutine set_interior_forcing(this)
 
     use marbl_mod, only : marbl_set_interior_forcing
@@ -356,22 +426,23 @@ contains
          this%column_restore)
 
     call marbl_set_interior_forcing(   &
-         ciso_on                 = this%ciso_on,                 &
-         domain                  = this%domain,                  &
-         interior_forcing_input  = this%interior_forcing_input,  &
-         saved_state             = this%saved_state,             &
-         interior_restore        = this%column_restore,          &
-         tracers                 = this%column_tracers,          &
-         dtracers                = this%column_dtracers,         &
-         marbl_tracer_indices    = this%tracer_indices,          &
-         marbl_PAR               = this%PAR,                     &
-         marbl_interior_share    = this%interior_share,          &
-         marbl_zooplankton_share = this%zooplankton_share,       &
-         marbl_autotroph_share   = this%autotroph_share,         &
-         marbl_particulate_share = this%particulate_share,       &
-         interior_forcing_diags  = this%interior_forcing_diags,  &
-         interior_restore_diags  = this%interior_restore_diags,  &
-         marbl_status_log        = this%StatusLog)
+         ciso_on                   = this%ciso_on,                   &
+         domain                    = this%domain,                    &
+         interior_forcing_input    = this%interior_forcing_input,    &
+         saved_state               = this%saved_state,               &
+         interior_restore          = this%column_restore,            &
+         tracers                   = this%column_tracers,            &
+         dtracers                  = this%column_dtracers,           &
+         marbl_tracer_indices      = this%tracer_indices,            &
+         marbl_PAR                 = this%PAR,                       &
+         marbl_interior_share      = this%interior_share,            &
+         marbl_zooplankton_share   = this%zooplankton_share,         &
+         marbl_autotroph_share     = this%autotroph_share,           &
+         marbl_particulate_share   = this%particulate_share,         &
+         interior_forcing_diags    = this%interior_forcing_diags,    &
+         interior_restore_diags    = this%interior_restore_diags,    &
+         glo_avg_fields_interior   = this%glo_avg_fields_interior,   &
+         marbl_status_log          = this%StatusLog)
 
     if (this%StatusLog%labort_marbl) then
        call this%StatusLog%log_error_trace("marbl_set_interior_forcing()", subname)
@@ -403,12 +474,36 @@ contains
          surface_forcing_internal = this%surface_forcing_internal,            &
          surface_forcing_share    = this%surface_forcing_share,               &
          surface_forcing_diags    = this%surface_forcing_diags,               &
+         glo_avg_fields_surface   = this%glo_avg_fields_surface,              &
          marbl_status_log         = this%statuslog)
 
   end subroutine set_surface_forcing
   
   !***********************************************************************
   
+  subroutine set_global_scalars(this, field_source)
+
+    use marbl_mod, only : marbl_set_global_scalars_interior
+
+    implicit none
+
+    class(marbl_interface_class), intent(inout) :: this
+    character (*)               , intent(in)    :: field_source ! 'interior' or 'surface'
+
+    if (field_source == 'interior') then
+       call marbl_set_global_scalars_interior(                          &
+            marbl_particulate_share   = this%particulate_share,         &
+            glo_avg_rmean_interior    = this%glo_avg_rmean_interior,    &
+            glo_avg_rmean_surface     = this%glo_avg_rmean_surface,     &
+            glo_scalar_rmean_interior = this%glo_scalar_rmean_interior, &
+            glo_scalar_rmean_surface  = this%glo_scalar_rmean_surface,  &
+            glo_scalar_interior       = this%glo_scalar_interior)
+    end if
+
+  end subroutine set_global_scalars
+
+  !***********************************************************************
+
   subroutine shutdown(this)
 
     implicit none

--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -120,12 +120,13 @@ module marbl_interface
 
    contains
 
-     procedure, public :: init             
-     procedure, public :: get_tracer_index
-     procedure, public :: set_interior_forcing     
-     procedure, public :: set_surface_forcing
-     procedure, public :: set_global_scalars
-     procedure, public :: shutdown         
+     procedure, public  :: init             
+     procedure, private :: glo_vars_init
+     procedure, public  :: get_tracer_index
+     procedure, public  :: set_interior_forcing     
+     procedure, public  :: set_surface_forcing
+     procedure, public  :: set_global_scalars
+     procedure, public  :: shutdown         
 
   end type marbl_interface_class
   
@@ -275,7 +276,7 @@ contains
       return
     end if
 
-    call glo_vars_init(this, num_surface_elements)
+    call this%glo_vars_init(num_surface_elements)
 
     !--------------------------------------------------------------------
     ! Initialize public data / general tracer metadata

--- a/src/marbl_interface_types.F90
+++ b/src/marbl_interface_types.F90
@@ -280,6 +280,20 @@ module marbl_interface_types
 
   !*****************************************************************************
 
+  ! FIXME : move to marbl_internal_types.F90 when running means are moved to MARBL
+
+  type, public :: marbl_running_mean_0d_type
+     character(char_len) :: sname
+     real(kind=r8)       :: timescale
+     real(kind=r8)       :: rmean
+
+     ! FIXME : perhaps the following get removed from the type when running means are moved to MARBL
+     logical(log_kind)   :: linit_by_val
+     real(kind=r8)       :: init_val
+  end type marbl_running_mean_0d_type
+
+  !*****************************************************************************
+
 contains
 
   !*****************************************************************************

--- a/src/marbl_internal_types.F90
+++ b/src/marbl_internal_types.F90
@@ -195,6 +195,10 @@ module marbl_internal_types
      real(r8), allocatable :: POC_hflux_out_fields     (:) ! POC_hflux_out from ecosys before getting set to zero for k=KMT
      real(r8), allocatable :: POC_remin_fields         (:) ! POC remin from ecosys before it gets modified for k=KMT
      real(r8), allocatable :: POC_prod_avail_fields    (:) ! POC production available for excess POC flux
+
+     real(r8)              :: POC_bury_coeff
+     real(r8)              :: POP_bury_coeff
+     real(r8)              :: bSi_bury_coeff
    contains
      procedure, public :: construct => marbl_particulate_share_constructor
      procedure, public :: destruct  => marbl_particulate_share_destructor
@@ -546,7 +550,7 @@ contains
     type(marbl_log_type),           intent(inout) :: marbl_status_log
 
     integer :: n
-    character(*), parameter :: subname='marbl_parms:tracer_index_constructor'
+    character(*), parameter :: subname='marbl_internal_types:tracer_index_constructor'
     character(len=char_len) :: log_message
 
     associate(tracer_cnt      => marbl_total_tracer_cnt)

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -96,8 +96,6 @@ module marbl_mod
   use marbl_parms, only : f_qsw_par
   use marbl_parms, only : parm_Fe_bioavail
   use marbl_parms, only : dust_to_Fe
-  use marbl_parms, only : parm_BSIbury
-  use marbl_parms, only : parm_POMbury
   use marbl_parms, only : denitrif_C_N
   use marbl_parms, only : parm_Red_Fe_C
   use marbl_parms, only : Q
@@ -191,6 +189,7 @@ module marbl_mod
   use marbl_interface_types , only : marbl_forcing_fields_type
   use marbl_interface_types , only : marbl_forcing_monthly_every_ts_type
   use marbl_interface_types , only : marbl_diagnostics_type
+  use marbl_interface_types , only : marbl_running_mean_0d_type
 
   use marbl_diagnostics_mod , only : marbl_diagnostics_set_surface_forcing
   use marbl_diagnostics_mod , only : marbl_diagnostics_set_interior_forcing
@@ -207,9 +206,13 @@ module marbl_mod
   public  :: marbl_init_nml
   public  :: marbl_init_surface_forcing_fields
   public  :: marbl_init_tracer_metadata
+  public  :: marbl_init_bury_coeff
+  public  :: marbl_set_glo_vars_cnt
+  public  :: marbl_set_rmean_init_vals
   public  :: marbl_update_tracer_file_metadata
   public  :: marbl_set_interior_forcing
   public  :: marbl_set_surface_forcing
+  public  :: marbl_set_global_scalars_interior
 
   private :: marbl_init_non_autotroph_tracer_metadata
   private :: marbl_init_surface_forcing_metadata
@@ -256,6 +259,10 @@ module marbl_mod
 
   !-----------------------------------------------------------------------
   !  bury to sediment options
+  !  bury coefficients (POC_bury_coeff, POP_bury_coeff, bSi_bury_coeff) reside in marbl_particulate_share_type
+  !  when ladjust_bury_coeff is .true., bury coefficients are adjusted
+  !  to preserve C, P, Si inventories on timescales exceeding bury_coeff_rmean_timescale_years
+  !  this is done primarily in spinup runs
   !-----------------------------------------------------------------------
 
   ! option of threshold of caco3 burial ['fixed_depth', 'omega_calc']
@@ -270,15 +277,32 @@ module marbl_mod
   ! threshold depth for caco3_bury_thres_opt='fixed_depth'
   real (r8) :: caco3_bury_thres_depth  
 
+  character(char_len) :: init_bury_coeff_opt
+
+  logical (log_kind) :: ladjust_bury_coeff
+
+  real (r8) :: bury_coeff_rmean_timescale_years
+
+  integer (int_kind) :: glo_avg_field_ind_interior_CaCO3_bury = 0
+  integer (int_kind) :: glo_avg_field_ind_interior_POC_bury = 0
+  integer (int_kind) :: glo_avg_field_ind_interior_POP_bury = 0
+  integer (int_kind) :: glo_avg_field_ind_interior_bSi_bury = 0
+  integer (int_kind) :: glo_avg_field_ind_interior_d_POC_bury_d_bury_coeff = 0
+  integer (int_kind) :: glo_avg_field_ind_interior_d_POP_bury_d_bury_coeff = 0
+  integer (int_kind) :: glo_avg_field_ind_interior_d_bSi_bury_d_bury_coeff = 0
+
+  integer (int_kind) :: glo_avg_field_ind_surface_C_input = 0
+  integer (int_kind) :: glo_avg_field_ind_surface_P_input = 0
+  integer (int_kind) :: glo_avg_field_ind_surface_Si_input = 0
+
+  integer (int_kind) :: glo_scalar_ind_interior_POC_bury_coeff = 0
+  integer (int_kind) :: glo_scalar_ind_interior_POP_bury_coeff = 0
+  integer (int_kind) :: glo_scalar_ind_interior_bSi_bury_coeff = 0
+
   ! PON_sed_loss = PON_bury_coeff * Q * POC_sed_loss
   ! factor is used to avoid overburying PON like POC
   ! is when total C burial is matched to C riverine input
   real (r8) :: PON_bury_coeff 
-
-  ! POP_sed_loss = POP_bury_coeff * Qp_zoo_pom * POC_sed_loss
-  ! factor is used to enable forced closure of the P cycle
-  ! i.e. POP_sed_loss = P inputs (riverine + atm dep)
-  real (r8) :: POP_bury_coeff 
 
   !-----------------------------------------------------------------------
   ! pH parameters
@@ -442,8 +466,9 @@ contains
          nutr_variable_rest_file_fmt, atm_co2_opt, atm_co2_const,         &
          atm_alt_co2_opt, atm_alt_co2_const,                              &
          liron_patch, iron_patch_flux_filename, iron_patch_month,         &
-         caco3_bury_thres_opt, caco3_bury_thres_depth, &
-         PON_bury_coeff, &
+         caco3_bury_thres_opt, caco3_bury_thres_depth,                    &
+         init_bury_coeff_opt, ladjust_bury_coeff,                         &
+         bury_coeff_rmean_timescale_years, PON_bury_coeff,                &
          lecovars_full_depth_tavg
 
     !-----------------------------------------------------------------------
@@ -605,8 +630,11 @@ contains
     caco3_bury_thres_opt = 'omega_calc'
     caco3_bury_thres_depth = 3000.0e2
 
+    init_bury_coeff_opt = 'nml'
+    ladjust_bury_coeff = .false.
+    bury_coeff_rmean_timescale_years = 10.0_r8
+
     PON_bury_coeff = 0.5_r8
-    POP_bury_coeff = 1.0_r8
 
     lecovars_full_depth_tavg = .false.
 
@@ -1527,6 +1555,236 @@ contains
 
   !***********************************************************************
 
+  subroutine marbl_init_bury_coeff(marbl_particulate_share, marbl_status_log)
+
+    use marbl_logging, only : marbl_log_type
+    use marbl_parms  , only : parm_init_POC_bury_coeff
+    use marbl_parms  , only : parm_init_POP_bury_coeff
+    use marbl_parms  , only : parm_init_bSi_bury_coeff
+
+    type(marbl_particulate_share_type), intent(inout) :: marbl_particulate_share
+    type(marbl_log_type)              , intent(inout) :: marbl_status_log
+
+    !---------------------------------------------------------------------------
+    !   local variables
+    !---------------------------------------------------------------------------
+    character(len=*), parameter :: subname = 'marbl_mod:marbl_init_bury_coeff'
+
+    !---------------------------------------------------------------------------
+
+    ! if ladjust_bury_coeff is true, then bury coefficients are set at runtime
+    ! so they do not need to be initialized here
+
+    if (.not. ladjust_bury_coeff) then
+       if (init_bury_coeff_opt == 'nml') then
+          marbl_particulate_share%POC_bury_coeff = parm_init_POC_bury_coeff
+          marbl_particulate_share%POP_bury_coeff = parm_init_POP_bury_coeff
+          marbl_particulate_share%bSi_bury_coeff = parm_init_bSi_bury_coeff
+       else
+          call marbl_status_log%log_error("ladjust_bury_coeff=.false., init_bury_coeff_opt='restfile' not implemented", subname)
+          return
+       end if
+    end if
+
+  end subroutine marbl_init_bury_coeff
+
+  !***********************************************************************
+
+  subroutine marbl_set_glo_vars_cnt(   &
+       glo_avg_field_cnt_interior, &
+       glo_avg_field_cnt_surface,  &
+       glo_scalar_cnt_interior,    &
+       glo_scalar_cnt_surface)
+
+    integer (int_kind), intent(out) :: glo_avg_field_cnt_interior
+    integer (int_kind), intent(out) :: glo_avg_field_cnt_surface
+    integer (int_kind), intent(out) :: glo_scalar_cnt_interior
+    integer (int_kind), intent(out) :: glo_scalar_cnt_surface
+
+    glo_avg_field_cnt_interior = 0
+    glo_avg_field_cnt_surface  = 0
+    glo_scalar_cnt_interior    = 0
+    glo_scalar_cnt_surface     = 0
+
+    if (ladjust_bury_coeff) then
+       glo_avg_field_cnt_interior = glo_avg_field_cnt_interior + 1
+       glo_avg_field_ind_interior_CaCO3_bury = glo_avg_field_cnt_interior
+
+       glo_avg_field_cnt_interior = glo_avg_field_cnt_interior + 1
+       glo_avg_field_ind_interior_POC_bury = glo_avg_field_cnt_interior
+
+       glo_avg_field_cnt_interior = glo_avg_field_cnt_interior + 1
+       glo_avg_field_ind_interior_POP_bury = glo_avg_field_cnt_interior
+
+       glo_avg_field_cnt_interior = glo_avg_field_cnt_interior + 1
+       glo_avg_field_ind_interior_bSi_bury = glo_avg_field_cnt_interior
+
+       glo_avg_field_cnt_interior = glo_avg_field_cnt_interior + 1
+       glo_avg_field_ind_interior_d_POC_bury_d_bury_coeff = glo_avg_field_cnt_interior
+
+       glo_avg_field_cnt_interior = glo_avg_field_cnt_interior + 1
+       glo_avg_field_ind_interior_d_POP_bury_d_bury_coeff = glo_avg_field_cnt_interior
+
+       glo_avg_field_cnt_interior = glo_avg_field_cnt_interior + 1
+       glo_avg_field_ind_interior_d_bSi_bury_d_bury_coeff = glo_avg_field_cnt_interior
+
+
+       glo_avg_field_cnt_surface = glo_avg_field_cnt_surface + 1
+       glo_avg_field_ind_surface_C_input = glo_avg_field_cnt_surface
+
+       glo_avg_field_cnt_surface = glo_avg_field_cnt_surface + 1
+       glo_avg_field_ind_surface_P_input = glo_avg_field_cnt_surface
+
+       glo_avg_field_cnt_surface = glo_avg_field_cnt_surface + 1
+       glo_avg_field_ind_surface_Si_input = glo_avg_field_cnt_surface
+
+
+       glo_scalar_cnt_interior = glo_scalar_cnt_interior + 1
+       glo_scalar_ind_interior_POC_bury_coeff = glo_scalar_cnt_interior
+
+       glo_scalar_cnt_interior = glo_scalar_cnt_interior + 1
+       glo_scalar_ind_interior_POP_bury_coeff = glo_scalar_cnt_interior
+
+       glo_scalar_cnt_interior = glo_scalar_cnt_interior + 1
+       glo_scalar_ind_interior_bSi_bury_coeff = glo_scalar_cnt_interior
+    end if
+
+  end subroutine marbl_set_glo_vars_cnt
+
+  !***********************************************************************
+
+  subroutine marbl_set_rmean_init_vals(      &
+       glo_avg_rmean_interior,    &
+       glo_avg_rmean_surface,     &
+       glo_scalar_rmean_interior, &
+       glo_scalar_rmean_surface)
+
+    use marbl_interface_types, only : marbl_running_mean_0d_type
+    use marbl_parms          , only : parm_init_POC_bury_coeff
+    use marbl_parms          , only : parm_init_POP_bury_coeff
+    use marbl_parms          , only : parm_init_bSi_bury_coeff
+
+    type(marbl_running_mean_0d_type), intent(out) :: glo_avg_rmean_interior(:)
+    type(marbl_running_mean_0d_type), intent(out) :: glo_avg_rmean_surface(:)
+    type(marbl_running_mean_0d_type), intent(out) :: glo_scalar_rmean_interior(:)
+    type(marbl_running_mean_0d_type), intent(out) :: glo_scalar_rmean_surface(:)
+
+    !-----------------------------------------------------------------------
+
+    integer (int_kind) :: glo_ind
+    real (r8)          :: bury_coeff_rmean_timescale_sec
+
+    real (r8) :: rmean_CaCO3_bury_integral
+    real (r8) :: rmean_C_input_integral
+    real (r8) :: rmean_P_input_integral
+    real (r8) :: rmean_Si_input_integral
+
+    real (r8) :: rmean_POC_bury_integral
+    real (r8) :: rmean_d_POC_bury_d_bury_coeff_integral
+
+    real (r8) :: rmean_POP_bury_integral
+    real (r8) :: rmean_d_POP_bury_d_bury_coeff_integral
+
+    real (r8) :: rmean_bSi_bury_integral
+    real (r8) :: rmean_d_bSi_bury_d_bury_coeff_integral
+
+    !-----------------------------------------------------------------------
+
+    if (ladjust_bury_coeff) then
+       ! FIXME : change 365*spd to spy
+       bury_coeff_rmean_timescale_sec = bury_coeff_rmean_timescale_years * 365.0_r8 * spd
+
+       glo_avg_rmean_interior(:)%timescale       = bury_coeff_rmean_timescale_sec
+       glo_avg_rmean_interior(:)%linit_by_val    = (init_bury_coeff_opt == 'nml')
+
+       glo_avg_rmean_surface(:)%timescale        = bury_coeff_rmean_timescale_sec
+       glo_avg_rmean_surface(:)%linit_by_val     = (init_bury_coeff_opt == 'nml')
+
+       glo_scalar_rmean_interior(:)%timescale    = bury_coeff_rmean_timescale_sec
+       glo_scalar_rmean_interior(:)%linit_by_val = (init_bury_coeff_opt == 'nml')
+
+       glo_scalar_rmean_surface(:)%timescale     = bury_coeff_rmean_timescale_sec
+       glo_scalar_rmean_surface(:)%linit_by_val  = (init_bury_coeff_opt == 'nml')
+
+
+       ! these initial values are only used if linit_by_val is .true. (i.e., if init_bury_coeff_opt == 'nml')
+       ! always set them, for simpler code
+
+!      rmean_ALK_nonN_input_integral = 1.62e-4_r8 ! GNEWS2000 value on gx1v6 grid [neq/cm^2/s]
+       rmean_CaCO3_bury_integral     = 1.62e-4_r8 ! matches rmean_ALK_nonN_input_integral
+       rmean_C_input_integral        = 2.69e-4_r8 ! GNEWS2000 value on gx1v6 grid [nmol C/cm^2/s]
+       rmean_P_input_integral        = 9.66e-7_r8 ! GNEWS2000 value on gx1v6 grid [nmol P/cm^2/s]
+       rmean_Si_input_integral       = 4.10e-5_r8 ! GNEWS2000 value on gx1v6 grid [nmol Si/cm^2/s]
+
+       rmean_POC_bury_integral = (rmean_C_input_integral - rmean_CaCO3_bury_integral)
+       rmean_d_POC_bury_d_bury_coeff_integral = rmean_POC_bury_integral / parm_init_POC_bury_coeff
+
+       rmean_POP_bury_integral = rmean_P_input_integral
+       rmean_d_POP_bury_d_bury_coeff_integral = rmean_POP_bury_integral / parm_init_POP_bury_coeff
+
+       rmean_bSi_bury_integral = rmean_Si_input_integral
+       rmean_d_bSi_bury_d_bury_coeff_integral = rmean_bSi_bury_integral / parm_init_bSi_bury_coeff
+
+
+       glo_ind = glo_avg_field_ind_interior_CaCO3_bury
+       glo_avg_rmean_interior(glo_ind)%sname    = 'MARBL_rmean_glo_avg_CaCO3_bury'
+       glo_avg_rmean_interior(glo_ind)%init_val = rmean_CaCO3_bury_integral
+
+       glo_ind = glo_avg_field_ind_interior_POC_bury
+       glo_avg_rmean_interior(glo_ind)%sname    = 'MARBL_rmean_glo_avg_POC_bury'
+       glo_avg_rmean_interior(glo_ind)%init_val = rmean_POC_bury_integral
+
+       glo_ind = glo_avg_field_ind_interior_POP_bury
+       glo_avg_rmean_interior(glo_ind)%sname    = 'MARBL_rmean_glo_avg_POP_bury'
+       glo_avg_rmean_interior(glo_ind)%init_val = rmean_POP_bury_integral
+
+       glo_ind = glo_avg_field_ind_interior_bSi_bury
+       glo_avg_rmean_interior(glo_ind)%sname    = 'MARBL_rmean_glo_avg_bSi_bury'
+       glo_avg_rmean_interior(glo_ind)%init_val = rmean_bSi_bury_integral
+
+       glo_ind = glo_avg_field_ind_interior_d_POC_bury_d_bury_coeff
+       glo_avg_rmean_interior(glo_ind)%sname    = 'MARBL_rmean_glo_avg_d_POC_bury_d_bury_coeff'
+       glo_avg_rmean_interior(glo_ind)%init_val = rmean_d_POC_bury_d_bury_coeff_integral
+
+       glo_ind = glo_avg_field_ind_interior_d_POP_bury_d_bury_coeff
+       glo_avg_rmean_interior(glo_ind)%sname    = 'MARBL_rmean_glo_avg_d_POP_bury_d_bury_coeff'
+       glo_avg_rmean_interior(glo_ind)%init_val = rmean_d_POP_bury_d_bury_coeff_integral
+
+       glo_ind = glo_avg_field_ind_interior_d_bSi_bury_d_bury_coeff
+       glo_avg_rmean_interior(glo_ind)%sname    = 'MARBL_rmean_glo_avg_d_bSi_bury_d_bury_coeff'
+       glo_avg_rmean_interior(glo_ind)%init_val = rmean_d_bSi_bury_d_bury_coeff_integral
+
+
+       glo_ind = glo_avg_field_ind_surface_C_input
+       glo_avg_rmean_surface(glo_ind)%sname    = 'MARBL_rmean_glo_avg_C_input'
+       glo_avg_rmean_surface(glo_ind)%init_val = rmean_C_input_integral
+
+       glo_ind = glo_avg_field_ind_surface_P_input
+       glo_avg_rmean_surface(glo_ind)%sname    = 'MARBL_rmean_glo_avg_P_input'
+       glo_avg_rmean_surface(glo_ind)%init_val = rmean_P_input_integral
+
+       glo_ind = glo_avg_field_ind_surface_Si_input
+       glo_avg_rmean_surface(glo_ind)%sname    = 'MARBL_rmean_glo_avg_Si_input'
+       glo_avg_rmean_surface(glo_ind)%init_val = rmean_Si_input_integral
+
+
+       glo_ind = glo_scalar_ind_interior_POC_bury_coeff
+       glo_scalar_rmean_interior(glo_ind)%sname    = 'MARBL_rmean_glo_scalar_POC_bury_coeff'
+       glo_scalar_rmean_interior(glo_ind)%init_val = parm_init_POC_bury_coeff
+
+       glo_ind = glo_scalar_ind_interior_POP_bury_coeff
+       glo_scalar_rmean_interior(glo_ind)%sname    = 'MARBL_rmean_glo_scalar_POP_bury_coeff'
+       glo_scalar_rmean_interior(glo_ind)%init_val = parm_init_POP_bury_coeff
+
+       glo_ind = glo_scalar_ind_interior_bSi_bury_coeff
+       glo_scalar_rmean_interior(glo_ind)%sname    = 'MARBL_rmean_glo_scalar_bSi_bury_coeff'
+       glo_scalar_rmean_interior(glo_ind)%init_val = parm_init_bSi_bury_coeff
+    end if
+
+  end subroutine marbl_set_rmean_init_vals
+
+  !***********************************************************************
+
   subroutine marbl_set_interior_forcing( &
        ciso_on,                          &
        domain,                           &
@@ -1543,6 +1801,7 @@ contains
        marbl_particulate_share,          &
        interior_forcing_diags,           &
        interior_restore_diags,           &
+       glo_avg_fields_interior,          &
        marbl_status_log)
     
     !  Compute time derivatives for ecosystem state variables
@@ -1568,6 +1827,7 @@ contains
     type    (marbl_particulate_share_type)      , intent(inout) :: marbl_particulate_share
     type    (marbl_diagnostics_type)            , intent(inout) :: interior_forcing_diags
     type    (marbl_diagnostics_type)            , intent(inout) :: interior_restore_diags
+    real    (r8)                                , intent(out)   :: glo_avg_fields_interior(:)
     type(marbl_log_type)                        , intent(inout) :: marbl_status_log
 
     !-----------------------------------------------------------------------
@@ -1696,7 +1956,7 @@ contains
 
     if (marbl_status_log%labort_marbl) then
        call marbl_status_log%log_error_trace(&
-            'marbl_check_ecosys_tracer_count_consistency()', subname)
+            'marbl_compute_carbonate_chemistry()', subname)
        return
     end if
 
@@ -1769,6 +2029,7 @@ contains
             POP_sed_loss(k), QA_dust_def(k), temperature(k),                  &
             tracer_local(:, k), carbonate(k), sed_denitrif(k),                &
             other_remin(k), fesedflux(k), ciso_on, marbl_tracer_indices,      &
+            glo_avg_fields_interior,                                          &
             marbl_status_log)
 
        if (marbl_status_log%labort_marbl) then
@@ -2043,6 +2304,7 @@ contains
              PON_remin, PON_sed_loss, POP_remin, POP_sed_loss, QA_dust_def,   &
              temperature, tracer_local, carbonate, sed_denitrif, other_remin, &
              fesedflux, lexport_shared_vars, marbl_tracer_indices,            &
+             glo_avg_fields_interior,                                         &
              marbl_status_log)
 
     !  Compute outgoing fluxes and remineralization terms. Assumes that
@@ -2116,6 +2378,7 @@ contains
     real (r8)                               , intent(out)   :: other_remin         ! sedimentary remin not due to oxic or denitrification
     type(marbl_particulate_share_type)      , intent(inout) :: marbl_particulate_share
     type(marbl_tracer_index_type)           , intent(in)    :: marbl_tracer_indices
+    real (r8)                               , intent(inout) :: glo_avg_fields_interior(:)
     type(marbl_log_type)                    , intent(inout) :: marbl_status_log
 
     !-----------------------------------------------------------------------
@@ -2146,6 +2409,7 @@ contains
          scalelength,        & ! used to scale dissolution length scales as function of depth
          o2_scalefactor,     & ! used to scale dissolution length scales as function of o2
          flux, flux_alt,     & ! temp variables used to update sinking flux
+         bury_frac,          & ! fraction of flux hitting floor that gets buried
          dz_loc, dzr_loc       ! dz, dzr at a particular i, j location
 
     real (r8), parameter :: &  ! o2_sf is an abbreviation for o2_scalefactor
@@ -2175,7 +2439,10 @@ contains
          POC_hflux_out_fields     => marbl_particulate_share%POC_hflux_out_fields,     & ! IN/OUT
          POC_remin_fields         => marbl_particulate_share%POC_remin_fields,         & ! IN/OUT
          P_CaCO3_remin_fields     => marbl_particulate_share%P_CaCO3_remin_fields,     & ! IN/OUT
-         DECAY_Hard_fields        => marbl_particulate_share%DECAY_Hard_fields         & ! IN/OUT
+         DECAY_Hard_fields        => marbl_particulate_share%DECAY_Hard_fields,        & ! IN/OUT
+         POC_bury_coeff           => marbl_particulate_share%POC_bury_coeff,           & ! IN/OUT
+         POP_bury_coeff           => marbl_particulate_share%POP_bury_coeff,           & ! IN/OUT
+         bSi_bury_coeff           => marbl_particulate_share%bSi_bury_coeff            & ! IN/OUT
          )
 
     !-----------------------------------------------------------------------
@@ -2501,12 +2768,29 @@ contains
        if (flux > c0) then
           flux_alt = flux*mpercm*spd ! convert to mmol/m^2/day
 
-          POC%sed_loss(k) = flux * min(0.8_r8, parm_POMbury &
-               * (0.013_r8 + 0.53_r8 * flux_alt*flux_alt / (7.0_r8 + flux_alt)**2))
+          ! first compute burial efficiency, then compute loss to sediments
+          bury_frac = 0.013_r8 + 0.53_r8 * flux_alt*flux_alt / (7.0_r8 + flux_alt)**2
+          POC%sed_loss(k) = flux * min(0.8_r8, POC_bury_coeff * bury_frac)
 
           PON_sed_loss = PON_bury_coeff * Q * POC%sed_loss(k)
 
-          POP_sed_loss = POP_bury_coeff * Qp_zoo_pom * POC%sed_loss(k)
+          POP_sed_loss = Qp_zoo_pom * (flux * min(0.8_r8, POP_bury_coeff * bury_frac))
+
+          if (ladjust_bury_coeff) then
+             glo_avg_fields_interior(glo_avg_field_ind_interior_POC_bury) = POC%sed_loss(k)
+             if (POC_bury_coeff * bury_frac < 0.8_r8) then
+                glo_avg_fields_interior(glo_avg_field_ind_interior_d_POC_bury_d_bury_coeff) = flux * bury_frac
+             else
+                glo_avg_fields_interior(glo_avg_field_ind_interior_d_POC_bury_d_bury_coeff) = c0
+             endif
+
+             glo_avg_fields_interior(glo_avg_field_ind_interior_POP_bury) = POP_sed_loss
+             if (POP_bury_coeff * bury_frac < 0.8_r8) then
+                glo_avg_fields_interior(glo_avg_field_ind_interior_d_POP_bury_d_bury_coeff) = Qp_zoo_pom * flux * bury_frac
+             else
+                glo_avg_fields_interior(glo_avg_field_ind_interior_d_POP_bury_d_bury_coeff) = c0
+             endif
+          endif
 
           sed_denitrif = dzr_loc * flux &
                * (0.06_r8 + 0.19_r8 * 0.99_r8**(O2_loc-NO3_loc))
@@ -2531,11 +2815,16 @@ contains
        flux_alt = flux*mpercm*spd ! convert to mmol/m^2/day
        ! first compute burial efficiency, then compute loss to sediments
        if (flux_alt > c2) then
-          P_SiO2%sed_loss(k) = 0.2_r8
+          bury_frac = 0.2_r8
        else
-          P_SiO2%sed_loss(k) = 0.04_r8
+          bury_frac = 0.04_r8
        endif
-       P_SiO2%sed_loss(k) = flux * parm_BSIbury * P_SiO2%sed_loss(k)
+       P_SiO2%sed_loss(k) = flux * bSi_bury_coeff * bury_frac
+
+       if (ladjust_bury_coeff) then
+          glo_avg_fields_interior(glo_avg_field_ind_interior_bSi_bury) = P_SiO2%sed_loss(k)
+          glo_avg_fields_interior(glo_avg_field_ind_interior_d_bSi_bury_d_bury_coeff) = flux * bury_frac
+       endif
 
        if (caco3_bury_thres_iopt == caco3_bury_thres_iopt_fixed_depth) then
           if (zw(k) < caco3_bury_thres_depth) then
@@ -2545,6 +2834,10 @@ contains
           if (carbonate%CO3 > carbonate%CO3_sat_calcite) then
              P_CaCO3%sed_loss(k) = P_CaCO3%sflux_out(k) + P_CaCO3%hflux_out(k)
           endif
+       endif
+
+       if (ladjust_bury_coeff) then
+          glo_avg_fields_interior(glo_avg_field_ind_interior_CaCO3_bury) = P_CaCO3%sed_loss(k)
        endif
 
        !----------------------------------------------------------------------------------
@@ -2622,6 +2915,87 @@ contains
 
   !***********************************************************************
 
+  subroutine marbl_set_global_scalars_interior(marbl_particulate_share, &
+       glo_avg_rmean_interior, glo_avg_rmean_surface,                   &
+       glo_scalar_rmean_interior, glo_scalar_rmean_surface,             &
+       glo_scalar_interior)
+
+    type (marbl_particulate_share_type), intent(inout) :: marbl_particulate_share
+    type (marbl_running_mean_0d_type)  , intent(in)    :: glo_avg_rmean_interior(:)
+    type (marbl_running_mean_0d_type)  , intent(in)    :: glo_avg_rmean_surface(:)
+    type (marbl_running_mean_0d_type)  , intent(in)    :: glo_scalar_rmean_interior(:)
+    type (marbl_running_mean_0d_type)  , intent(in)    :: glo_scalar_rmean_surface(:)
+    real (r8)                          , intent(out)   :: glo_scalar_interior(:)
+
+    if (ladjust_bury_coeff) then
+       call marbl_adjust_bury_coeff(marbl_particulate_share, &
+            glo_avg_rmean_interior, glo_avg_rmean_surface,   &
+            glo_scalar_rmean_interior, glo_scalar_interior)
+    end if
+
+  end subroutine marbl_set_global_scalars_interior
+
+  !***********************************************************************
+
+  subroutine marbl_adjust_bury_coeff(marbl_particulate_share, &
+       glo_avg_rmean_interior, glo_avg_rmean_surface,         &
+       glo_scalar_rmean_interior, glo_scalar_interior)
+
+    type (marbl_particulate_share_type), intent(inout) :: marbl_particulate_share
+    type (marbl_running_mean_0d_type)  , intent(in)    :: glo_avg_rmean_interior(:)
+    type (marbl_running_mean_0d_type)  , intent(in)    :: glo_avg_rmean_surface(:)
+    type (marbl_running_mean_0d_type)  , intent(in)    :: glo_scalar_rmean_interior(:)
+    real (r8)                          , intent(inout) :: glo_scalar_interior(:)
+
+    !-----------------------------------------------------------------------
+
+    associate( &
+         POC_bury_coeff           => marbl_particulate_share%POC_bury_coeff, &
+         POP_bury_coeff           => marbl_particulate_share%POP_bury_coeff, &
+         bSi_bury_coeff           => marbl_particulate_share%bSi_bury_coeff, &
+         rmean_CaCO3_bury_avg     => glo_avg_rmean_interior(glo_avg_field_ind_interior_CaCO3_bury)%rmean, &
+         rmean_POC_bury_avg       => glo_avg_rmean_interior(glo_avg_field_ind_interior_POC_bury)%rmean, &
+         rmean_POP_bury_avg       => glo_avg_rmean_interior(glo_avg_field_ind_interior_POP_bury)%rmean, &
+         rmean_bSi_bury_avg       => glo_avg_rmean_interior(glo_avg_field_ind_interior_bSi_bury)%rmean, &
+         rmean_POC_bury_deriv_avg => glo_avg_rmean_interior(glo_avg_field_ind_interior_d_POC_bury_d_bury_coeff)%rmean, &
+         rmean_POP_bury_deriv_avg => glo_avg_rmean_interior(glo_avg_field_ind_interior_d_POP_bury_d_bury_coeff)%rmean, &
+         rmean_bSi_bury_deriv_avg => glo_avg_rmean_interior(glo_avg_field_ind_interior_d_bSi_bury_d_bury_coeff)%rmean, &
+         rmean_C_input_avg        => glo_avg_rmean_surface(glo_avg_field_ind_surface_C_input)%rmean, &
+         rmean_P_input_avg        => glo_avg_rmean_surface(glo_avg_field_ind_surface_P_input)%rmean, &
+         rmean_Si_input_avg       => glo_avg_rmean_surface(glo_avg_field_ind_surface_Si_input)%rmean, &
+         rmean_POC_bury_coeff     => glo_scalar_rmean_interior(glo_scalar_ind_interior_POC_bury_coeff)%rmean, &
+         rmean_POP_bury_coeff     => glo_scalar_rmean_interior(glo_scalar_ind_interior_POP_bury_coeff)%rmean, &
+         rmean_bSi_bury_coeff     => glo_scalar_rmean_interior(glo_scalar_ind_interior_bSi_bury_coeff)%rmean &
+         )
+
+    ! Newton's method for POC_bury(coeff) + CaCO3_bury - C_input = 0
+
+    POC_bury_coeff = rmean_POC_bury_coeff &
+       - (rmean_POC_bury_avg + rmean_CaCO3_bury_avg - rmean_C_input_avg) &
+         / rmean_POC_bury_deriv_avg
+
+    ! Newton's method for POP_bury(coeff) - P_input = 0
+
+    POP_bury_coeff = rmean_POP_bury_coeff &
+       - (rmean_POP_bury_avg - rmean_P_input_avg) / rmean_POP_bury_coeff
+
+    ! Newton's method for bSi_bury(coeff) - Si_input = 0
+
+    bSi_bury_coeff = rmean_bSi_bury_coeff &
+       - (rmean_bSi_bury_avg - rmean_Si_input_avg) / rmean_bSi_bury_deriv_avg
+
+    ! copy computed bury coefficients into output argument
+
+    glo_scalar_interior(glo_scalar_ind_interior_POC_bury_coeff) = POC_bury_coeff
+    glo_scalar_interior(glo_scalar_ind_interior_POP_bury_coeff) = POP_bury_coeff
+    glo_scalar_interior(glo_scalar_ind_interior_bSi_bury_coeff) = bSi_bury_coeff
+
+    end associate
+
+  end subroutine marbl_adjust_bury_coeff
+
+  !***********************************************************************
+
   subroutine marbl_set_surface_forcing( &
        ciso_on,                         &
        num_elements,                    &
@@ -2635,6 +3009,7 @@ contains
        surface_forcing_internal,        &
        surface_forcing_share,           &
        surface_forcing_diags,           &
+       glo_avg_fields_surface,          &
        marbl_status_log)
 
     !  Compute surface forcing fluxes 
@@ -2685,6 +3060,7 @@ contains
     type(marbl_surface_forcing_output_type)   , intent(inout) :: surface_forcing_output
     type(marbl_surface_forcing_share_type)    , intent(inout) :: surface_forcing_share
     type(marbl_diagnostics_type)              , intent(inout) :: surface_forcing_diags
+    real (r8)                                 , intent(out)   :: glo_avg_fields_surface(:,:)
     type(marbl_log_type)                      , intent(inout) :: marbl_status_log
 
     !-----------------------------------------------------------------------
@@ -3111,6 +3487,19 @@ contains
             marbl_surface_forcing_diags = surface_forcing_diags)
     end if
 
+    !-----------------------------------------------------------------------
+
+    if (ladjust_bury_coeff) then
+       glo_avg_fields_surface(:,glo_avg_field_ind_surface_C_input) = &
+          stf(:,dic_ind) - flux_co2_loc(:) + stf(:,doc_ind) + stf(:,docr_ind)
+
+       glo_avg_fields_surface(:,glo_avg_field_ind_surface_P_input) = &
+          stf(:,po4_ind) + stf(:,dop_ind) + stf(:,dopr_ind)
+
+       glo_avg_fields_surface(:,glo_avg_field_ind_surface_Si_input) = &
+          stf(:,sio3_ind)
+    end if
+
     end associate
 
   end subroutine marbl_set_surface_forcing
@@ -3306,7 +3695,7 @@ contains
          auto_ind,        & ! autotroph functional group index
          zoo_ind            ! zooplankton functional group index
 
-    character(*), parameter :: subname = 'marbl_mod:check_ecosys_tracer_count_consistency'
+    character(*), parameter :: subname = 'marbl_mod:marbl_check_ecosys_tracer_count_consistency'
     character(len=char_len) :: log_message
 
     !-----------------------------------------------------------------------

--- a/src/marbl_parms.F90
+++ b/src/marbl_parms.F90
@@ -142,8 +142,9 @@ module marbl_parms
        parm_kappa_nitrif,     & ! nitrification inverse time constant (1/sec)
        parm_nitrif_par_lim,   & ! PAR limit for nitrif. (W/m^2)
        parm_labile_ratio,     & ! fraction of loss to DOC that routed directly to DIC (non-dimensional)
-       parm_POMbury,          & ! scale factor for burial of POC, PON, and POP
-       parm_BSIbury,          & ! scale factor burial of bSi
+       parm_init_POC_bury_coeff,& ! initial scale factor for burial of POC, PON
+       parm_init_POP_bury_coeff,& ! initial scale factor for burial of POP
+       parm_init_bSi_bury_coeff,& ! initial scale factor burial of bSi
        parm_fe_scavenge_rate0,& ! base scavenging rate
        parm_f_prod_sp_CaCO3,  & !fraction of sp prod. as CaCO3 prod.
        parm_POC_diss,         & ! base POC diss len scale
@@ -313,8 +314,9 @@ contains
     parm_kappa_nitrif      = 0.06_r8 * dps  ! (= 1/( days))
     parm_nitrif_par_lim    = 1.0_r8
     parm_labile_ratio      = 0.94_r8
-    parm_POMbury           = 1.1_r8         ! x1 default
-    parm_BSIbury           = 1.0_r8         ! x1 default
+    parm_init_POC_bury_coeff=1.1_r8         ! x1 default
+    parm_init_POP_bury_coeff=1.1_r8         ! x1 default
+    parm_init_bSi_bury_coeff=1.0_r8         ! x1 default
     parm_fe_scavenge_rate0 = 1.9_r8         ! x1 default
     parm_f_prod_sp_CaCO3   = 0.065_r8       ! x1 default
     parm_POC_diss          = 90.0e2_r8
@@ -495,8 +497,9 @@ contains
          parm_kappa_nitrif, &
          parm_nitrif_par_lim, &
          parm_labile_ratio, &
-         parm_POMbury, &
-         parm_BSIbury, &
+         parm_init_POC_bury_coeff, &
+         parm_init_POP_bury_coeff, &
+         parm_init_bSi_bury_coeff, &
          parm_fe_scavenge_rate0, &
          parm_f_prod_sp_CaCO3, &
          parm_POC_diss, &
@@ -552,8 +555,9 @@ contains
     write(stdout, *) 'parm_kappa_nitrif      = ', parm_kappa_nitrif
     write(stdout, *) 'parm_nitrif_par_lim    = ', parm_nitrif_par_lim
     write(stdout, *) 'parm_labile_ratio      = ', parm_labile_ratio
-    write(stdout, *) 'parm_POMbury           = ', parm_POMbury
-    write(stdout, *) 'parm_BSIbury           = ', parm_BSIbury
+    write(stdout, *) 'parm_init_POC_bury_coeff=', parm_init_POC_bury_coeff
+    write(stdout, *) 'parm_init_POP_bury_coeff=', parm_init_POP_bury_coeff
+    write(stdout, *) 'parm_init_bSi_bury_coeff=', parm_init_bSi_bury_coeff
     write(stdout, *) 'parm_fe_scavenge_rate0 = ', parm_fe_scavenge_rate0
     write(stdout, *) 'parm_f_prod_sp_CaCO3   = ', parm_f_prod_sp_CaCO3
     write(stdout, *) 'parm_POC_diss          = ', parm_POC_diss


### PR DESCRIPTION
…_bury_coeff

global averages and scalar running means are computed in the GCM
   running means will be moved to MARBL later
introduce set_global_scalars to interface for consistent setting of time-varying scalars in MARBL
introduce ladjust_bury_coeff
   If true, then model tracks running mean of C, P, and Si input and burial
   averages and adjusts bury coefficients to balance losses against inputs
   on 10 year timescale. Use Newton's Method on running means to solve for
   balancing burial coefficient.

Testing:
with marbl_dev_klindsay_n09

aux_pop_MARBL (intel and gnu): (baseline comparison to n08 tag)
   all tests pass, with the following exceptions
      some nlcomp tests fail because of added namelist variables
      cice_ecosys_ladjust_bury_coeff fails baseline compare because it is a new test

aux_pop_MARBL on hobart (nag) will be done after commit
   lack of subsequent tags indicates success

Files Modified:
    modified:   src/marbl_ciso_mod.F90
    modified:   src/marbl_interface.F90
    modified:   src/marbl_interface_types.F90
    modified:   src/marbl_internal_types.F90
    modified:   src/marbl_mod.F90
    modified:   src/marbl_parms.F90
