### PR TITLE
Initialize nhx_surface_emis for land points

### DIFF
--- a/src/marbl_nhx_surface_emis_mod.F90
+++ b/src/marbl_nhx_surface_emis_mod.F90
@@ -86,6 +86,8 @@ contains
     where (surface_mask(:) /= c0)
        K(:) = c1 / (c1 / kg_nh3(:) + Hstar_nhx / kw_nh3(:))
        nhx_surface_emis(:) = (c1 - ifrac(:)) * K(:) * Hstar_nhx(:) * max(nh4(:),c0)
+    elsewhere
+       nhx_surface_emis(:) = c0
     end where
 
   end subroutine marbl_comp_nhx_surface_emis


### PR DESCRIPTION
This update addresses issue #100 

I have not done extensive testing, but did verify that a CESM DEBUG test that failed previously due to uninitialized data now passes.

---

POP was producing an error in debug mode when trying to write single precision
history files because nhx_surface_emis was causing an overflow in non-ocean
cells.