### PR TITLE
Enhancement/interior forcing spec

### DIFF
--- a/src/marbl_ciso_mod.F90
+++ b/src/marbl_ciso_mod.F90
@@ -38,7 +38,6 @@ module marbl_ciso_mod
   use marbl_interface_types , only : marbl_tracer_metadata_type
   use marbl_interface_types , only : marbl_diagnostics_type
   use marbl_interface_types , only : marbl_domain_type
-  use marbl_interface_types , only : marbl_interior_forcing_input_type
 
   use marbl_internal_types  , only : autotroph_parms_type
   use marbl_internal_types  , only : column_sinking_particle_type
@@ -209,11 +208,11 @@ contains
 
   subroutine marbl_ciso_set_interior_forcing( &
        marbl_domain,                          &
-       marbl_interior_forcing_input,          &
        marbl_interior_share,                  &
        marbl_zooplankton_share,               &
        marbl_autotroph_share,                 &
        marbl_particulate_share,               &
+       temperature,                           &
        column_tracer,                         &
        column_dtracer,                        &
        marbl_tracer_indices,                  &
@@ -236,12 +235,12 @@ contains
     implicit none
 
     type(marbl_domain_type)                 , intent(in)    :: marbl_domain                               
-    type(marbl_interior_forcing_input_type) , intent(in)    :: marbl_interior_forcing_input
     ! FIXME #17: intent is inout due to DIC_Loc
     type(marbl_interior_share_type)         , intent(inout) :: marbl_interior_share(marbl_domain%km)
     type(marbl_zooplankton_share_type)      , intent(in)    :: marbl_zooplankton_share(zooplankton_cnt, marbl_domain%km)
     type(marbl_autotroph_share_type)        , intent(in)    :: marbl_autotroph_share(autotroph_cnt, marbl_domain%km)
     type(marbl_particulate_share_type)      , intent(inout) :: marbl_particulate_share
+    real (r8)                               , intent(in)    :: temperature(:)
     real (r8)                               , intent(in)    :: column_tracer(:,:)
     real (r8)                               , intent(inout) :: column_dtracer(:,:)  ! computed source/sink terms (inout because we don't touch non-ciso tracers)
     type(marbl_tracer_index_type)           , intent(in)    :: marbl_tracer_indices
@@ -356,8 +355,6 @@ contains
          column_kmt         => marbl_domain%kmt                                , &
          column_delta_z     => marbl_domain%delta_z                            , &
          column_zw          => marbl_domain%zw                                 , &
-
-         temperature        => marbl_interior_forcing_input%temperature        , &
 
          DIC_loc            => marbl_interior_share%DIC_loc_fields             , & ! INPUT local copy of model DIC                                                       
          DOC_loc            => marbl_interior_share%DOC_loc_fields             , & ! INPUT local copy of model DOC                                                       

--- a/src/marbl_diagnostics_mod.F90
+++ b/src/marbl_diagnostics_mod.F90
@@ -4528,10 +4528,10 @@ contains
     real(kind=r8) :: m_inv
 
     if ((y(1).gt.c0).and.(y(2).gt.c0)) then
-       call marbl_status_log%log_error(subname, "can not find root, both y-values are positive!")
+       call marbl_status_log%log_error("can not find root, both y-values are positive!", subname)
        return
     else if ((y(1).lt.c0).and.(y(2).lt.c0)) then
-       call marbl_status_log%log_error(subname, "can not find root, both y-values are negative!")
+       call marbl_status_log%log_error("can not find root, both y-values are negative!", subname)
        return
     end if
 

--- a/src/marbl_diagnostics_mod.F90
+++ b/src/marbl_diagnostics_mod.F90
@@ -4028,26 +4028,12 @@ contains
           ! Note that tmp_id is a temp variable because restoring diagnostics
           ! have same indexing as the MARBL tracers
           if (count_only) then
-             ! Each tracer provides 2 fields for restoring
-             num_restore_diags = num_restore_diags + 2
+             num_restore_diags = num_restore_diags + 1
           else
              ! Field we restore to
              lname = trim(marbl_tracer_metadata(n)%long_name) // " Restoring"
              sname = trim(marbl_tracer_metadata(n)%short_name) // "_RESTORE"
              units = 'mmol/m^3'
-             vgrid = 'layer_avg'
-             call diags%add_diagnostic(lname, sname, units, vgrid, .false.,   &
-                  tmp_id, marbl_status_log)
-             if (marbl_status_log%labort_marbl) then
-               call log_add_diagnostics_error(marbl_status_log, sname, subname)
-               return
-             end if
-
-             ! [Inverse] Time Scale for restoring (1/s)
-             lname = "Inverse timescale used in " //                          &
-                     trim(marbl_tracer_metadata(n)%long_name) // " Restoring"
-             sname = trim(marbl_tracer_metadata(n)%short_name) // "_INV_TAU"
-             units = '1/s'
              vgrid = 'layer_avg'
              call diags%add_diagnostic(lname, sname, units, vgrid, .false.,   &
                   tmp_id, marbl_status_log)

--- a/src/marbl_diagnostics_mod.F90
+++ b/src/marbl_diagnostics_mod.F90
@@ -4028,11 +4028,26 @@ contains
           ! Note that tmp_id is a temp variable because restoring diagnostics
           ! have same indexing as the MARBL tracers
           if (count_only) then
-             num_restore_diags = num_restore_diags + 1
+             ! Each tracer provides 2 fields for restoring
+             num_restore_diags = num_restore_diags + 2
           else
+             ! Field we restore to
              lname = trim(marbl_tracer_metadata(n)%long_name) // " Restoring"
              sname = trim(marbl_tracer_metadata(n)%short_name) // "_RESTORE"
              units = 'mmol/m^3'
+             vgrid = 'layer_avg'
+             call diags%add_diagnostic(lname, sname, units, vgrid, .false.,   &
+                  tmp_id, marbl_status_log)
+             if (marbl_status_log%labort_marbl) then
+               call log_add_diagnostics_error(marbl_status_log, sname, subname)
+               return
+             end if
+
+             ! [Inverse] Time Scale for restoring (1/s)
+             lname = "Inverse timescale used in " //                          &
+                     trim(marbl_tracer_metadata(n)%long_name) // " Restoring"
+             sname = trim(marbl_tracer_metadata(n)%short_name) // "_INV_TAU"
+             units = '1/s'
              vgrid = 'layer_avg'
              call diags%add_diagnostic(lname, sname, units, vgrid, .false.,   &
                   tmp_id, marbl_status_log)

--- a/src/marbl_diagnostics_mod.F90
+++ b/src/marbl_diagnostics_mod.F90
@@ -4092,7 +4092,9 @@ contains
        sed_denitrif, other_remin, nitrif, denitrif,   &
        column_o2, o2_production, o2_consumption,      &
        fe_scavenge, fe_scavenge_rate,                 &
+       interior_restore,                              &
        marbl_interior_forcing_diags,                  &
+       marbl_interior_restore_diags,                  &
        marbl_status_log)
 
     use marbl_internal_types , only : marbl_interior_forcing_indexing_type
@@ -4125,7 +4127,9 @@ contains
     real (r8)                                 , intent(in) :: o2_consumption(:)
     real (r8)                                 , intent(in) :: fe_scavenge_rate(domain%km) ! annual scavenging rate of iron as % of ambient
     real (r8)                                 , intent(in) :: fe_scavenge(domain%km)      ! loss of dissolved iron, scavenging (mmol Fe/m^3/sec)
+    real (r8)                                 , intent(in) :: interior_restore(:,:)       ! (marbl_total_tracer_cnt, km) local restoring terms for nutrients (mmol ./m^3/sec)
     type (marbl_diagnostics_type)             , intent(inout) :: marbl_interior_forcing_diags
+    type (marbl_diagnostics_type)             , intent(inout) :: marbl_interior_restore_diags
     type (marbl_log_type)                     , intent(inout) :: marbl_status_log
 
     character(*), parameter :: subname = 'marbl_diagnostics_mod:marbl_diagnostics_set_interior_forcing'
@@ -4199,6 +4203,9 @@ contains
     call store_diagnostics_iron_fluxes(domain, P_iron, dust,                        &
                 interior_forcings(interior_forcing_ind%fesedflux_id)%field_1d(1,:), &
                 dtracers, marbl_tracer_indices, marbl_interior_forcing_diags)
+
+    call store_diagnostics_interior_restore(interior_restore,                 &
+                                            marbl_interior_restore_diags)
 
     end associate
 
@@ -5172,6 +5179,21 @@ contains
     end associate
 
   end subroutine store_diagnostics_iron_fluxes
+
+  !***********************************************************************
+
+  subroutine store_diagnostics_interior_restore(interior_restore, marbl_diags)
+
+    real(r8), dimension(:,:)           , intent(in)    :: interior_restore
+    type(marbl_diagnostics_type)       , intent(inout) :: marbl_diags
+
+    integer :: n
+
+    do n=1, marbl_total_tracer_cnt
+       marbl_diags%diags(n)%field_3d(:,1) = interior_restore(n,:)
+    end do
+
+  end subroutine store_diagnostics_interior_restore
 
   !*****************************************************************************
 

--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -511,22 +511,12 @@ contains
          )
 
     !-----------------------------------------------------------------------
-    !  Set up tracer restoring metadata
-    !-----------------------------------------------------------------------
-
-    call this%restoring%init(this%domain, this%tracer_metadata, this%StatusLog)
-    if (this%StatusLog%labort_marbl) then
-      call this%StatusLog%log_error_trace("this%restoring%init()", subname)
-      return
-    end if
-
-    !-----------------------------------------------------------------------
     !  Initialize surface and interior forcing (including tracer restoring)
     !-----------------------------------------------------------------------
 
     call this%surface_forcing_ind%construct(ciso_on, lflux_gas_o2, lflux_gas_co2)
     call this%interior_forcing_ind%construct(this%tracer_metadata%short_name, &
-                                   tracer_restore_vars(1:tracer_restore_cnt))
+                                   tracer_restore_vars)
 
     call this%surface_forcing_share%construct(num_surface_elements)
     call this%surface_forcing_internal%construct(num_surface_elements)
@@ -554,6 +544,20 @@ contains
     if (this%StatusLog%labort_marbl) then
       call this%StatusLog%log_error_trace("marbl_init_interior_forcing_fields()", &
                                           subname)
+      return
+    end if
+
+    !-------------------------------------------------------------------------
+    !  Set up tracer restoring metadata (points back to interior forcing data)
+    !-------------------------------------------------------------------------
+
+    call this%restoring%init(this%domain,                                     &
+                             this%tracer_metadata,                            &
+                             this%interior_input_forcings,                    &
+                             this%interior_forcing_ind%tracer_restore_id,     &
+                             this%StatusLog)
+    if (this%StatusLog%labort_marbl) then
+      call this%StatusLog%log_error_trace("this%restoring%init()", subname)
       return
     end if
 

--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -85,6 +85,7 @@ module marbl_interface
      real (r8)                                 , public, allocatable  :: column_tracers(:,:)     ! input  *
      real (r8)                                 , public, allocatable  :: column_dtracers(:,:)    ! output *
      real (r8)                                 , public, allocatable  :: column_restore(:,:)     ! input  *
+     real (r8)                                 , public, allocatable  :: column_inv_tau(:,:)     ! input  *
      type(marbl_interior_forcing_indexing_type), public               :: interior_forcing_ind         !
      type(marbl_forcing_fields_type)           , public, allocatable  :: interior_input_forcings(:)
      type(marbl_diagnostics_type)              , public               :: interior_forcing_diags  ! output
@@ -340,6 +341,7 @@ contains
     allocate(this%column_dtracers(marbl_total_tracer_cnt, num_levels))
 
     allocate(this%column_restore(marbl_total_tracer_cnt, num_levels))
+    allocate(this%column_inv_tau(marbl_total_tracer_cnt, num_levels))
 
     !--------------------------------------------------------------------
     ! set up saved state variables
@@ -650,7 +652,8 @@ contains
     call this%restoring%restore_tracers( &
          this%column_tracers,            &
          this%domain%km,                 &
-         this%column_restore)
+         this%column_restore,            &
+         this%column_inv_tau)
 
     call marbl_set_interior_forcing(                                          &
          domain                   = this%domain,                              &
@@ -658,6 +661,7 @@ contains
          saved_state              = this%interior_saved_state,                &
          saved_state_ind          = this%interior_state_ind,                  &
          interior_restore         = this%column_restore,                      &
+         interior_restore_inv_tau = this%column_inv_tau,                      &
          tracers                  = this%column_tracers,                      &
          surface_forcing_indices  = this%surface_forcing_ind,                 &
          interior_forcing_indices = this%interior_forcing_ind,                &

--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -85,7 +85,6 @@ module marbl_interface
      real (r8)                                 , public, allocatable  :: column_tracers(:,:)     ! input  *
      real (r8)                                 , public, allocatable  :: column_dtracers(:,:)    ! output *
      real (r8)                                 , public, allocatable  :: column_restore(:,:)     ! input  *
-     real (r8)                                 , public, allocatable  :: column_inv_tau(:,:)     ! input  *
      type(marbl_interior_forcing_indexing_type), public               :: interior_forcing_ind         !
      type(marbl_forcing_fields_type)           , public, allocatable  :: interior_input_forcings(:)
      type(marbl_diagnostics_type)              , public               :: interior_forcing_diags  ! output
@@ -341,7 +340,6 @@ contains
     allocate(this%column_dtracers(marbl_total_tracer_cnt, num_levels))
 
     allocate(this%column_restore(marbl_total_tracer_cnt, num_levels))
-    allocate(this%column_inv_tau(marbl_total_tracer_cnt, num_levels))
 
     !--------------------------------------------------------------------
     ! set up saved state variables
@@ -652,8 +650,7 @@ contains
     call this%restoring%restore_tracers( &
          this%column_tracers,            &
          this%domain%km,                 &
-         this%column_restore,            &
-         this%column_inv_tau)
+         this%column_restore)
 
     call marbl_set_interior_forcing(                                          &
          domain                   = this%domain,                              &
@@ -661,7 +658,6 @@ contains
          saved_state              = this%interior_saved_state,                &
          saved_state_ind          = this%interior_state_ind,                  &
          interior_restore         = this%column_restore,                      &
-         interior_restore_inv_tau = this%column_inv_tau,                      &
          tracers                  = this%column_tracers,                      &
          surface_forcing_indices  = this%surface_forcing_ind,                 &
          interior_forcing_indices = this%interior_forcing_ind,                &

--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -566,11 +566,6 @@ contains
 
     end associate
 
-    ! Set up tracer restore info in interior forcing
-!    call this%interior_forcing_input%set_restore(this%domain%km,              &
-!                                   tracer_restore_vars(1:tracer_restore_cnt))
-
-
     !--------------------------------------------------------------------
     ! Report what forcings are required from the driver
     !--------------------------------------------------------------------

--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -531,7 +531,7 @@ contains
     call marbl_init_interior_forcing_fields(                                  &
          num_elements             = num_interior_elements,                    &
          interior_forcing_indices = this%interior_forcing_ind,                &
-         tracer_names             = this%tracer_metadata%short_name,          &
+         tracer_metadata          = this%tracer_metadata,                     &
          num_PAR_subcols          = this%domain%num_PAR_subcols,              &
          num_levels               = this%domain%km,                           &
          interior_forcings        = this%interior_input_forcings,             &

--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -555,6 +555,7 @@ contains
                              this%tracer_metadata,                            &
                              this%interior_input_forcings,                    &
                              this%interior_forcing_ind%tracer_restore_id,     &
+                             this%interior_forcing_ind%inv_tau_id,            &
                              this%StatusLog)
     if (this%StatusLog%labort_marbl) then
       call this%StatusLog%log_error_trace("this%restoring%init()", subname)

--- a/src/marbl_interface_types.F90
+++ b/src/marbl_interface_types.F90
@@ -633,14 +633,14 @@ contains
       case (0)
       case (1)
         if (.not.present(dim1)) then
-          call marbl_status_log%log_error(subname, 'dim1 is required when rank=1')
+          call marbl_status_log%log_error('dim1 is required when rank=1', subname)
           return
         end if
         allocate(this%extent(1))
         this%extent(1) = dim1
       case DEFAULT
         write(log_message,"(I0,A)") rank, ' is not a valid rank for a forcing field'
-        call marbl_status_log%log_error(subname, log_message)
+        call marbl_status_log%log_error(log_message, subname)
         return
     end select
 

--- a/src/marbl_interface_types.F90
+++ b/src/marbl_interface_types.F90
@@ -84,23 +84,6 @@ module marbl_interface_types
 
   !*****************************************************************************
 
-  ! FIXME #25: update marbl_interior_forcing_input_type
-  type, public :: marbl_interior_forcing_input_type
-     real(r8), allocatable            :: temperature(:)       ! (km)
-     real(r8), allocatable            :: salinity(:)          ! (km)
-     real(r8), allocatable            :: pressure(:)          ! (km)
-     real(r8), allocatable            :: fesedflux(:)         ! (km)
-     real(r8), allocatable            :: PAR_col_frac(:)      ! column fraction occupied by each sub-column
-     real(r8), allocatable            :: surf_shortwave(:)    ! surface shortwave for each sub-column (W/m^2)
-     real(r8)                         :: dust_flux            ! (g/cm^2/s)
-     character(char_len), allocatable :: tracer_names(:)
-   contains
-     procedure, public :: construct   => marbl_interior_forcing_input_constructor
-     procedure, public :: set_restore => marbl_interior_forcing_input_set_restore
-  end type marbl_interior_forcing_input_type
-
-  !*****************************************************************************
-
   type, private :: marbl_single_diagnostic_type
      ! marbl_single_diagnostic :
      ! a private type, this contains both the metadata
@@ -171,8 +154,11 @@ module marbl_interface_types
      ! forcing data is in marbl_instance%surface_input_forcing(:,:)
      ! Note that surface_input_forcing_data(:,n) contains the data for forcing
      ! field n (i.e. varname(n) with units field_units(n)]
-     character(char_len)    :: varname
-     character(char_len)    :: field_units
+     ! Some foricng fields are elements of an array, that element index is
+     ! stored in array_ind (if array_ind is 0 then field is a scalar)
+     character(char_len) :: varname
+     character(char_len) :: field_units
+     integer             :: array_ind
   end type marbl_forcing_fields_metadata_type
 
   !*****************************************************************************
@@ -369,56 +355,6 @@ contains
     this%saved_state_cnt = id
 
   end subroutine marbl_saved_state_add
-
-  !*****************************************************************************
-
-  subroutine marbl_interior_forcing_input_constructor(this, num_levels, num_PAR_subcols)
-
-    class(marbl_interior_forcing_input_type) , intent(inout) :: this
-    integer , intent(in)    :: num_levels
-    integer , intent(in)    :: num_PAR_subcols
-
-    allocate(this%temperature      (num_levels))
-    allocate(this%salinity         (num_levels))
-    allocate(this%pressure         (num_levels))
-    allocate(this%fesedflux        (num_levels))
-    allocate(this%PAR_col_frac     (num_PAR_subcols))
-    allocate(this%surf_shortwave   (num_PAR_subcols))
-
-  end subroutine marbl_interior_forcing_input_constructor
-
-  !*****************************************************************************
-
-  subroutine marbl_interior_forcing_input_set_restore(this, num_levels,       &
-             tracer_names)
-
-    class(marbl_interior_forcing_input_type), intent(inout) :: this
-    integer,                                  intent(in)    :: num_levels
-    character(len=char_len), dimension (:),   intent(in)    :: tracer_names
-
-    integer :: n, nt, num_tracers
-    character(len=char_len), dimension(:), allocatable :: local_names
-
-    nt = size(tracer_names)
-    allocate(local_names(nt))
-
-    num_tracers = 0
-    do n=1,nt
-      if (len_trim(tracer_names(n)).gt.0) then
-        num_tracers = num_tracers + 1
-        local_names(num_tracers) = tracer_names(n)
-      end if
-    end do
-
-    allocate(this%tracer_names(num_tracers))
-
-    if (num_tracers.gt.0) then
-      do n=1,num_tracers
-        this%tracer_names(n) = local_names(n)
-      end do
-    end if
-
-  end subroutine marbl_interior_forcing_input_set_restore
 
   !*****************************************************************************
 

--- a/src/marbl_interface_types.F90
+++ b/src/marbl_interface_types.F90
@@ -165,6 +165,7 @@ module marbl_interface_types
      type(marbl_forcing_fields_metadata_type) :: metadata
      ! use pointers instead of allocatable because restoring needs to point
      ! into part of the field_1d array
+     ! Dimension in name (0d, 1d) refers to per-column dimension
      real(r8), pointer :: field_0d(:)   => NULL()  ! num_elements
      real(r8), pointer :: field_1d(:,:) => NULL()  ! num_elements x extent(1)
    contains

--- a/src/marbl_interface_types.F90
+++ b/src/marbl_interface_types.F90
@@ -165,8 +165,10 @@ module marbl_interface_types
 
   type, public :: marbl_forcing_fields_type
      type(marbl_forcing_fields_metadata_type) :: metadata
-     real(r8), allocatable :: field_0d(:)     ! num_elements
-     real(r8), allocatable :: field_1d(:,:)   ! num_elements x extent(1)
+     ! use pointers instead of allocatable because restoring needs to point
+     ! into part of the field_1d array
+     real(r8), pointer :: field_0d(:)     ! num_elements
+     real(r8), pointer :: field_1d(:,:)   ! num_elements x extent(1)
    contains
      procedure, public :: allocate_memory => marbl_forcing_fields_allocate
   end type marbl_forcing_fields_type

--- a/src/marbl_internal_types.F90
+++ b/src/marbl_internal_types.F90
@@ -438,8 +438,9 @@ module marbl_internal_types
      integer(int_kind) :: pressure_id    = 0
      integer(int_kind) :: fesedflux_id   = 0
 
-     ! Tracer restoring
+     ! Tracer restoring (field to restore and inverse timescale)
      integer(int_kind), allocatable :: tracer_restore_id(:)
+     integer(int_kind), allocatable :: inv_tau_id(:)
    contains
      procedure, public :: construct => interior_forcing_index_constructor
   end type marbl_interior_forcing_indexing_type
@@ -928,6 +929,8 @@ contains
       forcing_cnt = 0
       allocate(this%tracer_restore_id(marbl_total_tracer_cnt))
       this%tracer_restore_id = 0
+      allocate(this%inv_tau_id(marbl_total_tracer_cnt))
+      this%inv_tau_id = 0
 
       ! -------------------------------
       ! | Always request these fields |
@@ -968,6 +971,8 @@ contains
             if (trim(tracer_restore_vars(m)).eq.trim(tracer_names(n))) then
               forcing_cnt = forcing_cnt + 1
               this%tracer_restore_id(n) = forcing_cnt
+              forcing_cnt = forcing_cnt + 1
+              this%inv_tau_id(n) = forcing_cnt
               exit
             end if
           end if

--- a/src/marbl_internal_types.F90
+++ b/src/marbl_internal_types.F90
@@ -428,15 +428,17 @@ module marbl_internal_types
 
   type, public :: marbl_interior_forcing_indexing_type
      ! Surface forcing fields that affect interior forcings
-     integer(int_kind) :: dustflux_id    = 0
-     integer(int_kind), allocatable :: PAR_col_frac_id(:)
-     integer(int_kind), allocatable :: surf_shortwave_id(:)
+     integer(int_kind) :: dustflux_id        = 0
+     integer(int_kind) :: PAR_col_frac_id    = 0
+     integer(int_kind) :: surf_shortwave_id  = 0
 
      ! Column fields
      integer(int_kind) :: temperature_id = 0
      integer(int_kind) :: salinity_id    = 0
      integer(int_kind) :: pressure_id    = 0
      integer(int_kind) :: fesedflux_id   = 0
+
+     ! Tracer restoring
      integer(int_kind), allocatable :: tracer_restore_id(:)
    contains
      procedure, public :: construct => interior_forcing_index_constructor
@@ -907,78 +909,64 @@ contains
 
   !*****************************************************************************
 
-  subroutine interior_forcing_index_constructor(this, PAR_nsubcols,           &
-                                    tracer_names, tracer_restore_vars)
+  subroutine interior_forcing_index_constructor(this, tracer_names, tracer_restore_vars)
 
     ! This subroutine sets the interior forcing indexes, which are used to
     ! determine what forcing fields are required from the driver.
 
-    use marbl_sizes, only : num_interior_forcing_fields_0d
-    use marbl_sizes, only : num_interior_forcing_fields_1d
+    use marbl_sizes, only : num_interior_forcing_fields
     use marbl_sizes, only : marbl_total_tracer_cnt
 
     class(marbl_interior_forcing_indexing_type), intent(inout) :: this
-    integer,                                     intent(in)    :: PAR_nsubcols
     character(len=char_len), dimension(:),       intent(in)    :: tracer_names
     character(len=char_len), dimension(:),       intent(in)    :: tracer_restore_vars
 
     integer :: m, n
 
-    associate(                                                  &
-              forcing_cnt_0d => num_interior_forcing_fields_0d, &
-              forcing_cnt_1d => num_interior_forcing_fields_1d  &
-             )
+    associate(forcing_cnt => num_interior_forcing_fields)
 
-      forcing_cnt_0d = 0
-      forcing_cnt_1d = 0
-
-      allocate(this%PAR_col_frac_id(PAR_nsubcols))
-      allocate(this%surf_shortwave_id(PAR_nsubcols))
+      forcing_cnt = 0
       allocate(this%tracer_restore_id(marbl_total_tracer_cnt))
+      this%tracer_restore_id = 0
 
       ! -------------------------------
       ! | Always request these fields |
       ! -------------------------------
 
       ! Dust Flux
-      forcing_cnt_0d = forcing_cnt_0d + 1
-      this%dustflux_id = forcing_cnt_0d
+      forcing_cnt = forcing_cnt + 1
+      this%dustflux_id = forcing_cnt
 
       ! PAR column fraction
-      do n=1,PAR_nsubcols
-        forcing_cnt_0d = forcing_cnt_0d + 1
-        this%PAR_col_frac_id(n) = forcing_cnt_0d
-      end do
+      forcing_cnt = forcing_cnt + 1
+      this%PAR_col_frac_id = forcing_cnt
 
       ! PAR column shortwave
-      do n=1,PAR_nsubcols
-        forcing_cnt_0d = forcing_cnt_0d + 1
-        this%surf_shortwave_id(n) = forcing_cnt_0d
-      end do
+      forcing_cnt = forcing_cnt + 1
+      this%surf_shortwave_id = forcing_cnt
 
       ! Temperature
-      forcing_cnt_1d = forcing_cnt_1d + 1
-      this%temperature_id = forcing_cnt_1d
+      forcing_cnt = forcing_cnt + 1
+      this%temperature_id = forcing_cnt
 
       ! Salinity
-      forcing_cnt_1d = forcing_cnt_1d + 1
-      this%salinity_id = forcing_cnt_1d
+      forcing_cnt = forcing_cnt + 1
+      this%salinity_id = forcing_cnt
 
       ! Pressure
-      forcing_cnt_1d = forcing_cnt_1d + 1
-      this%pressure_id = forcing_cnt_1d
+      forcing_cnt = forcing_cnt + 1
+      this%pressure_id = forcing_cnt
 
       ! Iron Sediment Flux
-      forcing_cnt_1d = forcing_cnt_1d + 1
-      this%fesedflux_id = forcing_cnt_1d
+      forcing_cnt = forcing_cnt + 1
+      this%fesedflux_id = forcing_cnt
 
-      ! Tracer retoring
+      ! Tracer restoring
       do n=1,marbl_total_tracer_cnt
-        this%tracer_restore_id(n) = 0
         do m=1,size(tracer_restore_vars)
           if (trim(tracer_restore_vars(m)).eq.trim(tracer_names(n))) then
-            forcing_cnt_1d = forcing_cnt_1d + 1
-            this%tracer_restore_id(n) = forcing_cnt_1d
+            forcing_cnt = forcing_cnt + 1
+            this%tracer_restore_id(n) = forcing_cnt
             exit
           end if
         end do

--- a/src/marbl_internal_types.F90
+++ b/src/marbl_internal_types.F90
@@ -907,7 +907,8 @@ contains
 
   !*****************************************************************************
 
-  subroutine interior_forcing_index_constructor(this, PAR_nsubcols)
+  subroutine interior_forcing_index_constructor(this, PAR_nsubcols,           &
+                                    tracer_names, tracer_restore_vars)
 
     ! This subroutine sets the interior forcing indexes, which are used to
     ! determine what forcing fields are required from the driver.
@@ -918,8 +919,10 @@ contains
 
     class(marbl_interior_forcing_indexing_type), intent(inout) :: this
     integer,                                     intent(in)    :: PAR_nsubcols
+    character(len=char_len), dimension(:),       intent(in)    :: tracer_names
+    character(len=char_len), dimension(:),       intent(in)    :: tracer_restore_vars
 
-    integer :: n
+    integer :: m, n
 
     associate(                                                  &
               forcing_cnt_0d => num_interior_forcing_fields_0d, &
@@ -971,13 +974,14 @@ contains
 
       ! Tracer retoring
       do n=1,marbl_total_tracer_cnt
-        ! FIXME #25: move tracer restore info into interior_forcing type
-        if (.false.) then
-          forcing_cnt_1d = forcing_cnt_1d + 1
-          this%tracer_restore_id(n) = forcing_cnt_1d
-        else
-          this%tracer_restore_id(n) = 0
-        end if
+        this%tracer_restore_id(n) = 0
+        do m=1,size(tracer_restore_vars)
+          if (trim(tracer_restore_vars(m)).eq.trim(tracer_names(n))) then
+            forcing_cnt_1d = forcing_cnt_1d + 1
+            this%tracer_restore_id(n) = forcing_cnt_1d
+            exit
+          end if
+        end do
       end do
 
     end associate

--- a/src/marbl_internal_types.F90
+++ b/src/marbl_internal_types.F90
@@ -1011,7 +1011,7 @@ contains
           end if
         end if
 
-        ! For each element 
+        ! For each element
         do n=1,marbl_total_tracer_cnt ! loop over tracer_names
           if (trim(tracer_restore_vars(m)).eq.trim(tracer_names(n))) then
             forcing_cnt = forcing_cnt + 1

--- a/src/marbl_internal_types.F90
+++ b/src/marbl_internal_types.F90
@@ -964,10 +964,12 @@ contains
       ! Tracer restoring
       do n=1,marbl_total_tracer_cnt
         do m=1,size(tracer_restore_vars)
-          if (trim(tracer_restore_vars(m)).eq.trim(tracer_names(n))) then
-            forcing_cnt = forcing_cnt + 1
-            this%tracer_restore_id(n) = forcing_cnt
-            exit
+          if (len_trim(tracer_restore_vars(m)).ne.0) then
+            if (trim(tracer_restore_vars(m)).eq.trim(tracer_names(n))) then
+              forcing_cnt = forcing_cnt + 1
+              this%tracer_restore_id(n) = forcing_cnt
+              exit
+            end if
           end if
         end do
       end do

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -622,8 +622,8 @@ contains
 
       ! Check to see if %set_rank() returned an error
       if (marbl_status_log%labort_marbl) then
-        write(log_message, "(2A)"), trim(interior_forcings(id)%metadata%varname), &
-                                    ' set_rank()'
+        write(log_message, "(2A)") trim(interior_forcings(id)%metadata%varname), &
+                                   ' set_rank()'
         call marbl_status_log%log_error_trace(subname, log_message)
         return
       end if

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -966,7 +966,6 @@ contains
        saved_state,                      &
        saved_state_ind,                  &
        interior_restore,                 &
-       interior_restore_inv_tau,         &
        tracers,                          &
        surface_forcing_indices,          &
        interior_forcing_indices,         &
@@ -993,7 +992,6 @@ contains
     type    (marbl_domain_type)                 , intent(in)    :: domain
     type(marbl_forcing_fields_type)             , intent(in)    :: interior_forcings(:)
     real    (r8)                                , intent(in)    :: interior_restore(:,:) ! (marbl_total_tracer_cnt, km) local restoring terms for nutrients (mmol ./m^3/sec)
-    real    (r8)                                , intent(in)    :: interior_restore_inv_tau(:,:) ! (marbl_total_tracer_cnt, km) inverse time scale for local restoring (1/s)
     real    (r8)                                , intent(in)    :: tracers(:,: )         ! (marbl_total_tracer_cnt, km) tracer values
     type(marbl_surface_forcing_indexing_type)   , intent(in)    :: surface_forcing_indices
     type(marbl_interior_forcing_indexing_type)  , intent(in)    :: interior_forcing_indices
@@ -1299,11 +1297,10 @@ contains
     end if
 
     ! FIXME #119: Why isn't this in marbl_diagnostics? And why are we passing
-    ! this%column_restore & this%column_inv_tau instead of this%restoring?
+    ! this%column_restore instead of a local variable?
     ! Compute restore diagnostics
     do n = 1, ecosys_base_tracer_cnt
-       interior_restore_diags%diags(2*n-1)%field_3d(:,1) = interior_restore(n,:)
-       interior_restore_diags%diags(2*n)%field_3d(:,1) = interior_restore_inv_tau(n,:)
+       interior_restore_diags%diags(n)%field_3d(:,1) = interior_restore(n,:)
     end do
 
     !  Compute time derivatives for ecosystem carbon isotope state variables

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -494,8 +494,7 @@ contains
 
       ! All surface forcing fields are rank 0; if that changes, make this
       ! call from inside each "if (id.eq.*)" block
-      call surface_forcings(id)%metadata%set_rank(0, marbl_status_log)
-      call surface_forcings(id)%allocate_memory(num_elements)
+      call surface_forcings(id)%set_rank(num_elements, 0, marbl_status_log)
 
     end do
 
@@ -554,7 +553,7 @@ contains
         found = .true.
         interior_forcings(id)%metadata%varname     = 'Dust Flux'
         interior_forcings(id)%metadata%field_units = 'need_units'
-        call interior_forcings(id)%metadata%set_rank(0, marbl_status_log)
+        call interior_forcings(id)%set_rank(num_elements, 0, marbl_status_log)
       end if
 
       ! PAR Column Fraction and Shortwave Radiation
@@ -562,7 +561,7 @@ contains
         found = .true.
         interior_forcings(id)%metadata%varname     = 'PAR Column Fraction'
         interior_forcings(id)%metadata%field_units = 'unitless'
-        call interior_forcings(id)%metadata%set_rank(1, marbl_status_log,     &
+        call interior_forcings(id)%set_rank(num_elements, 1, marbl_status_log, &
                                                      dim1 = num_PAR_subcols)
       end if
 
@@ -570,7 +569,7 @@ contains
         found = .true.
         interior_forcings(id)%metadata%varname     = 'Surface Shortwave'
         interior_forcings(id)%metadata%field_units = 'need_units' ! W/m^2?
-        call interior_forcings(id)%metadata%set_rank(1, marbl_status_log,     &
+        call interior_forcings(id)%set_rank(num_elements, 1, marbl_status_log, &
                                                      dim1 = num_PAR_subcols)
       end if
 
@@ -580,7 +579,7 @@ contains
         found = .true.
         interior_forcings(id)%metadata%varname     = 'Temperature'
         interior_forcings(id)%metadata%field_units = 'Degrees C'
-        call interior_forcings(id)%metadata%set_rank(1, marbl_status_log,     &
+        call interior_forcings(id)%set_rank(num_elements, 1, marbl_status_log, &
                                                      dim1 = num_levels)
       end if
 
@@ -589,7 +588,7 @@ contains
         found = .true.
         interior_forcings(id)%metadata%varname     = 'Salinity'
         interior_forcings(id)%metadata%field_units = 'need_units'
-        call interior_forcings(id)%metadata%set_rank(1, marbl_status_log,     &
+        call interior_forcings(id)%set_rank(num_elements, 1, marbl_status_log, &
                                                      dim1 = num_levels)
       end if
 
@@ -598,7 +597,7 @@ contains
         found = .true.
         interior_forcings(id)%metadata%varname     = 'Pressure'
         interior_forcings(id)%metadata%field_units = 'need_units'
-        call interior_forcings(id)%metadata%set_rank(1, marbl_status_log,     &
+        call interior_forcings(id)%set_rank(num_elements, 1, marbl_status_log, &
                                                      dim1 = num_levels)
       end if
 
@@ -607,7 +606,7 @@ contains
         found = .true.
         interior_forcings(id)%metadata%varname     = 'Iron Sediment Flux'
         interior_forcings(id)%metadata%field_units = 'need_units'
-        call interior_forcings(id)%metadata%set_rank(1, marbl_status_log,     &
+        call interior_forcings(id)%set_rank(num_elements, 1, marbl_status_log, &
                                                      dim1 = num_levels)
       end if
 
@@ -618,7 +617,7 @@ contains
           write(interior_forcings(id)%metadata%varname,"(A,1X,A)")            &
                 trim(tracer_names(n)), 'Restoring'
           interior_forcings(id)%metadata%field_units = 'unitless'
-          call interior_forcings(id)%metadata%set_rank(1, marbl_status_log,   &
+          call interior_forcings(id)%set_rank(num_elements, 1, marbl_status_log, &
                                                        dim1 = num_levels)
         end if
         if (id.eq.ind%inv_tau_id(n)) then
@@ -626,7 +625,7 @@ contains
           write(interior_forcings(id)%metadata%varname,"(A,1X,A)")            &
                 trim(tracer_names(n)), 'Inverse Timescale'
           interior_forcings(id)%metadata%field_units = '1/s'
-          call interior_forcings(id)%metadata%set_rank(1, marbl_status_log,   &
+          call interior_forcings(id)%set_rank(num_elements, 1, marbl_status_log, &
                                                        dim1 = num_levels)
         end if
       end do
@@ -646,8 +645,6 @@ contains
         call marbl_status_log%log_error(log_message, subname)
         return
       end if
-
-      call interior_forcings(id)%allocate_memory(num_elements)
 
     end do
 

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -624,7 +624,7 @@ contains
       if (marbl_status_log%labort_marbl) then
         write(log_message, "(2A)") trim(interior_forcings(id)%metadata%varname), &
                                    ' set_rank()'
-        call marbl_status_log%log_error_trace(subname, log_message)
+        call marbl_status_log%log_error_trace(log_message, subname)
         return
       end if
 

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -620,7 +620,7 @@ contains
           tracer_units = tracer_metadata(n)%units
           found = .true.
           write(interior_forcings(id)%metadata%varname,"(A,1X,A)")            &
-                trim(tracer_name), 'Restoring'
+                trim(tracer_name), 'Restoring Field'
           interior_forcings(id)%metadata%field_units = tracer_units
           call interior_forcings(id)%set_rank(num_elements, 1, marbl_status_log, &
                                                        dim1 = num_levels)
@@ -628,7 +628,7 @@ contains
         if (id.eq.ind%inv_tau_id(n)) then
           found = .true.
           write(interior_forcings(id)%metadata%varname,"(A,1X,A)")            &
-                trim(tracer_name), 'Inverse Timescale'
+                trim(tracer_name), 'Restoring Inverse Timescale'
           interior_forcings(id)%metadata%field_units = '1/s'
           call interior_forcings(id)%set_rank(num_elements, 1, marbl_status_log, &
                                                        dim1 = num_levels)

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -621,6 +621,14 @@ contains
           call interior_forcings(id)%metadata%set_rank(1, marbl_status_log,   &
                                                        dim1 = num_levels)
         end if
+        if (id.eq.ind%inv_tau_id(n)) then
+          found = .true.
+          write(interior_forcings(id)%metadata%varname,"(A,1X,A)")            &
+                trim(tracer_names(n)), 'Inverse Timescale'
+          interior_forcings(id)%metadata%field_units = '1/s'
+          call interior_forcings(id)%metadata%set_rank(1, marbl_status_log,   &
+                                                       dim1 = num_levels)
+        end if
       end do
 
       ! Check to see if %set_rank() returned an error

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -507,6 +507,7 @@ contains
 
   subroutine marbl_init_interior_forcing_fields(&
        interior_forcing_indices, &
+       tracer_names, &
        interior_forcing_metadata, &
        marbl_status_log)
 
@@ -520,6 +521,7 @@ contains
     implicit none
 
     type(marbl_interior_forcing_indexing_type), intent(in)    :: interior_forcing_indices
+    character(len=char_len), dimension(:),      intent(in)    :: tracer_names
     type(marbl_forcing_fields_metadata_type)  , intent(inout) :: interior_forcing_metadata(:)
     type(marbl_log_type)                      , intent(inout) :: marbl_status_log
 
@@ -537,7 +539,7 @@ contains
     interior_forcing_metadata(:)%varname = ''
     interior_forcing_metadata(:)%array_ind = 0
 
-    ! Surface fluxes that influece interior forcing
+    ! Surface fluxes that influence interior forcing
     do id=1,num_interior_forcing_fields_0d
       found = .false.
       ! Dust Flux
@@ -573,7 +575,7 @@ contains
 
     end do
 
-    ! Surface fluxes that influece interior forcing
+    ! Interior forcings
     do id=1,num_interior_forcing_fields_1d
       found = .false.
       id2 = id + num_interior_forcing_fields_0d
@@ -607,14 +609,15 @@ contains
       end if
 
       ! Interior Tracer Restoring (still to do)
-!      do n=1,size(ind%tracer_restore_id)
-!        if (id.eq.ind%tracer_restore_id(n)) then
-!          found = .true.
-!          interior_forcing_metadata(id2)%varname     = 'Tracer Restoring'
-!          interior_forcing_metadata(id2)%field_units = 'unitless'
-!          interior_forcing_metadata(id2)%array_ind   = n
-!        end if
-!      end do
+      do n=1,size(ind%tracer_restore_id)
+        if (id.eq.ind%tracer_restore_id(n)) then
+          found = .true.
+          write(interior_forcing_metadata(id2)%varname,"(A,1X,A)")            &
+                trim(tracer_names(n)), 'Restoring'
+          interior_forcing_metadata(id2)%field_units = 'unitless'
+          interior_forcing_metadata(id2)%array_ind   = n
+        end if
+      end do
 
       if (.not.found) then
         write(log_message, "(A,I0,A)") "Index number ", id, &

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -969,6 +969,7 @@ contains
        saved_state,                      &
        saved_state_ind,                  &
        interior_restore,                 &
+       interior_restore_inv_tau,         &
        tracers,                          &
        surface_forcing_indices,          &
        interior_forcing_indices,         &
@@ -995,6 +996,7 @@ contains
     type    (marbl_domain_type)                 , intent(in)    :: domain
     type(marbl_forcing_fields_type)             , intent(in)    :: interior_forcings(:)
     real    (r8)                                , intent(in)    :: interior_restore(:,:) ! (marbl_total_tracer_cnt, km) local restoring terms for nutrients (mmol ./m^3/sec)
+    real    (r8)                                , intent(in)    :: interior_restore_inv_tau(:,:) ! (marbl_total_tracer_cnt, km) inverse time scale for local restoring (1/s)
     real    (r8)                                , intent(in)    :: tracers(:,: )         ! (marbl_total_tracer_cnt, km) tracer values
     type(marbl_surface_forcing_indexing_type)   , intent(in)    :: surface_forcing_indices
     type(marbl_interior_forcing_indexing_type)  , intent(in)    :: interior_forcing_indices
@@ -1299,9 +1301,12 @@ contains
        return
     end if
 
+    ! FIXME #119: Why isn't this in marbl_diagnostics? And why are we passing
+    ! this%column_restore & this%column_inv_tau instead of this%restoring?
     ! Compute restore diagnostics
     do n = 1, ecosys_base_tracer_cnt
-       interior_restore_diags%diags(n)%field_3d(:,1) = interior_restore(n,:)
+       interior_restore_diags%diags(2*n-1)%field_3d(:,1) = interior_restore(n,:)
+       interior_restore_diags%diags(2*n)%field_3d(:,1) = interior_restore_inv_tau(n,:)
     end do
 
     !  Compute time derivatives for ecosystem carbon isotope state variables

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -492,6 +492,9 @@ contains
         return
       end if
 
+      ! All surface forcing fields are rank 0; if that changes, make this
+      ! call from inside each "if (id.eq.*)" block
+      call surface_forcings(id)%metadata%set_rank(0, marbl_status_log)
       call surface_forcings(id)%allocate_memory(num_elements)
 
     end do

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -197,7 +197,7 @@ module marbl_mod
   use marbl_interface_types , only : marbl_tracer_metadata_type
   use marbl_interface_types , only : marbl_saved_state_type
   use marbl_interface_types , only : marbl_surface_forcing_output_type
-  use marbl_interface_types , only : marbl_forcing_fields_metadata_type
+  use marbl_interface_types , only : marbl_forcing_fields_type
   use marbl_interface_types , only : marbl_diagnostics_type
   use marbl_interface_types , only : marbl_running_mean_0d_type
 
@@ -286,10 +286,8 @@ contains
 
   !*****************************************************************************
 
-  subroutine marbl_init_surface_forcing_fields(&
-       surface_forcing_indices, &
-       surface_forcing_metadata, &
-       marbl_status_log)
+  subroutine marbl_init_surface_forcing_fields(num_elements, surface_forcing_indices, &
+                                        surface_forcings, marbl_status_log)
 
     use marbl_sizes, only : num_surface_forcing_fields
 
@@ -299,9 +297,10 @@ contains
 
     implicit none
 
-    type(marbl_surface_forcing_indexing_type) , intent(in)   :: surface_forcing_indices
-    type(marbl_forcing_fields_metadata_type)  , intent(inout)   :: surface_forcing_metadata(:)
-    type(marbl_log_type)                      , intent(inout) :: marbl_status_log
+    integer,                                   intent(in)    :: num_elements
+    type(marbl_surface_forcing_indexing_type), intent(in)    :: surface_forcing_indices
+    type(marbl_forcing_fields_type),           intent(inout) :: surface_forcings(:)
+    type(marbl_log_type),                      intent(inout) :: marbl_status_log
 
     !-----------------------------------------------------------------------
     !  local variables
@@ -314,177 +313,176 @@ contains
 
     associate(ind => surface_forcing_indices)
 
-    surface_forcing_metadata(:)%varname = ''
-    surface_forcing_metadata(:)%array_ind = 0
+    surface_forcings(:)%metadata%varname = ''
     do id=1,num_surface_forcing_fields
       found = .false.
 
       ! Surface Mask
       if (id.eq.ind%surface_mask_id) then
         found = .true.
-        surface_forcing_metadata(id)%varname       = 'surface_mask'
-        surface_forcing_metadata(id)%field_units   = 'unitless'
+        surface_forcings(id)%metadata%varname       = 'surface_mask'
+        surface_forcings(id)%metadata%field_units   = 'unitless'
       end if
 
       ! Square of 10m wind
       if (id.eq.ind%u10_sqr_id) then
         found = .true.
-        surface_forcing_metadata(id)%varname       = 'u10_sqr'
-        surface_forcing_metadata(id)%field_units   = 'cm^2/s^2'
+        surface_forcings(id)%metadata%varname       = 'u10_sqr'
+        surface_forcings(id)%metadata%field_units   = 'cm^2/s^2'
       end if
 
       ! Sea-surface salinity
       if (id.eq.ind%sss_id) then
         found = .true.
-        surface_forcing_metadata(id)%varname       = 'sss'
-        surface_forcing_metadata(id)%field_units   = 'unknown units'
+        surface_forcings(id)%metadata%varname       = 'sss'
+        surface_forcings(id)%metadata%field_units   = 'unknown units'
       end if
 
       ! Sea-surface temperature
       if (id.eq.ind%sst_id) then
         found = .true.
-        surface_forcing_metadata(id)%varname       = 'sst'
-        surface_forcing_metadata(id)%field_units   = 'degrees C'
+        surface_forcings(id)%metadata%varname       = 'sst'
+        surface_forcings(id)%metadata%field_units   = 'degrees C'
       end if
 
       ! Ice Fraction
       if (id.eq.ind%ifrac_id) then
         found = .true.
-        surface_forcing_metadata(id)%varname       = 'Ice Fraction'
-        surface_forcing_metadata(id)%field_units   = 'unitless'
+        surface_forcings(id)%metadata%varname       = 'Ice Fraction'
+        surface_forcings(id)%metadata%field_units   = 'unitless'
       end if
 
       ! Dust Flux
       if (id.eq.ind%dust_flux_id) then
         found = .true.
-        surface_forcing_metadata(id)%varname       = 'Dust Flux'
-        surface_forcing_metadata(id)%field_units   = 'g/cm^2/s'
+        surface_forcings(id)%metadata%varname       = 'Dust Flux'
+        surface_forcings(id)%metadata%field_units   = 'g/cm^2/s'
       end if
 
       ! Iron Flux
       if (id.eq.ind%iron_flux_id) then
         found = .true.
-        surface_forcing_metadata(id)%varname       = 'Iron Flux'
-        surface_forcing_metadata(id)%field_units   = 'nmol/cm^2/s'
+        surface_forcings(id)%metadata%varname       = 'Iron Flux'
+        surface_forcings(id)%metadata%field_units   = 'nmol/cm^2/s'
       end if
 
       ! NOx Flux
       if (id.eq.ind%nox_flux_id) then
         found = .true.
-        surface_forcing_metadata(id)%varname       = 'NOx Flux'
-        surface_forcing_metadata(id)%field_units   = 'unknown units'
+        surface_forcings(id)%metadata%varname       = 'NOx Flux'
+        surface_forcings(id)%metadata%field_units   = 'unknown units'
       end if
 
       ! NHy Flux
       if (id.eq.ind%nhy_flux_id) then
         found = .true.
-        surface_forcing_metadata(id)%varname       = 'NHy Flux'
-        surface_forcing_metadata(id)%field_units   = 'unknown units'
+        surface_forcings(id)%metadata%varname       = 'NHy Flux'
+        surface_forcings(id)%metadata%field_units   = 'unknown units'
       end if
 
       ! DIN River Flux
       if (id.eq.ind%din_riv_flux_id) then
         found = .true.
-        surface_forcing_metadata(id)%varname       = 'DIN River Flux'
-        surface_forcing_metadata(id)%field_units   = 'unknown units'
+        surface_forcings(id)%metadata%varname       = 'DIN River Flux'
+        surface_forcings(id)%metadata%field_units   = 'unknown units'
       end if
 
       ! DIP River Flux
       if (id.eq.ind%dip_riv_flux_id) then
         found = .true.
-        surface_forcing_metadata(id)%varname       = 'DIP River Flux'
-        surface_forcing_metadata(id)%field_units   = 'unknown units'
+        surface_forcings(id)%metadata%varname       = 'DIP River Flux'
+        surface_forcings(id)%metadata%field_units   = 'unknown units'
       end if
 
       ! DON River Flux
       if (id.eq.ind%don_riv_flux_id) then
         found = .true.
-        surface_forcing_metadata(id)%varname       = 'DON River Flux'
-        surface_forcing_metadata(id)%field_units   = 'unknown units'
+        surface_forcings(id)%metadata%varname       = 'DON River Flux'
+        surface_forcings(id)%metadata%field_units   = 'unknown units'
       end if
 
       ! DOP River Flux
       if (id.eq.ind%dop_riv_flux_id) then
         found = .true.
-        surface_forcing_metadata(id)%varname       = 'DOP River Flux'
-        surface_forcing_metadata(id)%field_units   = 'unknown units'
+        surface_forcings(id)%metadata%varname       = 'DOP River Flux'
+        surface_forcings(id)%metadata%field_units   = 'unknown units'
       end if
 
       ! DSi River Flux
       if (id.eq.ind%dsi_riv_flux_id) then
         found = .true.
-        surface_forcing_metadata(id)%varname       = 'DSi River Flux'
-        surface_forcing_metadata(id)%field_units   = 'unknown units'
+        surface_forcings(id)%metadata%varname       = 'DSi River Flux'
+        surface_forcings(id)%metadata%field_units   = 'unknown units'
       end if
 
       ! DFe River Flux
       if (id.eq.ind%dfe_riv_flux_id) then
         found = .true.
-        surface_forcing_metadata(id)%varname       = 'DFe River Flux'
-        surface_forcing_metadata(id)%field_units   = 'unknown units'
+        surface_forcings(id)%metadata%varname       = 'DFe River Flux'
+        surface_forcings(id)%metadata%field_units   = 'unknown units'
       end if
 
       ! DIC River Flux
       if (id.eq.ind%dic_riv_flux_id) then
         found = .true.
-        surface_forcing_metadata(id)%varname       = 'DIC River Flux'
-        surface_forcing_metadata(id)%field_units   = 'unknown units'
+        surface_forcings(id)%metadata%varname       = 'DIC River Flux'
+        surface_forcings(id)%metadata%field_units   = 'unknown units'
       end if
 
       ! ALK River Flux
       if (id.eq.ind%alk_riv_flux_id) then
         found = .true.
-        surface_forcing_metadata(id)%varname       = 'ALK River Flux'
-        surface_forcing_metadata(id)%field_units   = 'unknown units'
+        surface_forcings(id)%metadata%varname       = 'ALK River Flux'
+        surface_forcings(id)%metadata%field_units   = 'unknown units'
       end if
 
       ! DOC River Flux
       if (id.eq.ind%doc_riv_flux_id) then
         found = .true.
-        surface_forcing_metadata(id)%varname       = 'DOC River Flux'
-        surface_forcing_metadata(id)%field_units   = 'unknown units'
+        surface_forcings(id)%metadata%varname       = 'DOC River Flux'
+        surface_forcings(id)%metadata%field_units   = 'unknown units'
       end if
 
       ! atm pressure
       if (id.eq.ind%atm_pressure_id) then
         found = .true.
-        surface_forcing_metadata(id)%varname       = 'Atmospheric Pressure'
-        surface_forcing_metadata(id)%field_units   = 'unknown units'
+        surface_forcings(id)%metadata%varname       = 'Atmospheric Pressure'
+        surface_forcings(id)%metadata%field_units   = 'unknown units'
       end if
 
       ! xco2
       if (id.eq.ind%xco2_id) then
         found = .true.
-        surface_forcing_metadata(id)%varname       = 'xco2'
-        surface_forcing_metadata(id)%field_units   = 'unknown units'
+        surface_forcings(id)%metadata%varname       = 'xco2'
+        surface_forcings(id)%metadata%field_units   = 'unknown units'
       end if
 
       ! xco2_alt_co2
       if (id.eq.ind%xco2_alt_co2_id) then
         found = .true.
-        surface_forcing_metadata(id)%varname       = 'xco2_alt_co2'
-        surface_forcing_metadata(id)%field_units   = 'unknown units'
+        surface_forcings(id)%metadata%varname       = 'xco2_alt_co2'
+        surface_forcings(id)%metadata%field_units   = 'unknown units'
       end if
 
       ! d13c
       if (id.eq.ind%d13c_id) then
         found = .true.
-        surface_forcing_metadata(id)%varname       = 'd13c'
-        surface_forcing_metadata(id)%field_units   = 'unknown units'
+        surface_forcings(id)%metadata%varname       = 'd13c'
+        surface_forcings(id)%metadata%field_units   = 'unknown units'
       end if
 
       ! d14c
       if (id.eq.ind%d14c_id) then
         found = .true.
-        surface_forcing_metadata(id)%varname       = 'd14c'
-        surface_forcing_metadata(id)%field_units   = 'unknown units'
+        surface_forcings(id)%metadata%varname       = 'd14c'
+        surface_forcings(id)%metadata%field_units   = 'unknown units'
       end if
 
       ! d14c_gloavg
       if (id.eq.ind%d14c_glo_avg_id) then
         found = .true.
-        surface_forcing_metadata(id)%varname       = 'd14c_gloavg'
-        surface_forcing_metadata(id)%field_units   = 'unknown units'
+        surface_forcings(id)%metadata%varname       = 'd14c_gloavg'
+        surface_forcings(id)%metadata%field_units   = 'unknown units'
       end if
 
       if (.not.found) then
@@ -493,6 +491,8 @@ contains
         call marbl_status_log%log_error(log_message, subname)
         return
       end if
+
+      call surface_forcings(id)%allocate_memory(num_elements)
 
     end do
 
@@ -506,13 +506,15 @@ contains
   !*****************************************************************************
 
   subroutine marbl_init_interior_forcing_fields(&
+       num_elements, &
        interior_forcing_indices, &
        tracer_names, &
-       interior_forcing_metadata, &
+       num_PAR_subcols, &
+       num_levels, &
+       interior_forcings, &
        marbl_status_log)
 
-    use marbl_sizes, only : num_interior_forcing_fields_0d
-    use marbl_sizes, only : num_interior_forcing_fields_1d
+    use marbl_sizes, only : num_interior_forcing_fields
 
     !  Initialize the interior forcing_fields datatype with information from the
     !  namelist read
@@ -520,111 +522,122 @@ contains
 
     implicit none
 
+    integer,                                    intent(in)    :: num_elements
     type(marbl_interior_forcing_indexing_type), intent(in)    :: interior_forcing_indices
     character(len=char_len), dimension(:),      intent(in)    :: tracer_names
-    type(marbl_forcing_fields_metadata_type)  , intent(inout) :: interior_forcing_metadata(:)
-    type(marbl_log_type)                      , intent(inout) :: marbl_status_log
+    integer,                                    intent(in)    :: num_PAR_subcols
+    integer,                                    intent(in)    :: num_levels
+    type(marbl_forcing_fields_type),            intent(inout) :: interior_forcings(:)
+    type(marbl_log_type),                       intent(inout) :: marbl_status_log
 
     !-----------------------------------------------------------------------
     !  local variables
     !-----------------------------------------------------------------------
     character(*), parameter :: subname = 'marbl_mod:marbl_init_interior_forcing_fields'
     character(len=char_len) :: log_message
-    integer                 :: id, id2, n
+    integer                 :: id, n
     logical                 :: found
     !-----------------------------------------------------------------------
 
     associate(ind => interior_forcing_indices)
 
-    interior_forcing_metadata(:)%varname = ''
-    interior_forcing_metadata(:)%array_ind = 0
+    interior_forcings(:)%metadata%varname = ''
 
     ! Surface fluxes that influence interior forcing
-    do id=1,num_interior_forcing_fields_0d
+    do id=1,num_interior_forcing_fields
       found = .false.
       ! Dust Flux
       if (id.eq.ind%dustflux_id) then
         found = .true.
-        interior_forcing_metadata(id)%varname     = 'Dust Flux'
-        interior_forcing_metadata(id)%field_units = 'need_units'
+        interior_forcings(id)%metadata%varname     = 'Dust Flux'
+        interior_forcings(id)%metadata%field_units = 'need_units'
+        call interior_forcings(id)%metadata%set_rank(0, marbl_status_log)
       end if
 
       ! PAR Column Fraction and Shortwave Radiation
-      do n=1,size(ind%PAR_col_frac_id)
-        if (id.eq.ind%PAR_col_frac_id(n)) then
-          found = .true.
-          interior_forcing_metadata(id)%varname     = 'PAR Column Fraction'
-          interior_forcing_metadata(id)%field_units = 'unitless'
-          interior_forcing_metadata(id)%array_ind   = n
-        end if
-
-        if (id.eq.ind%surf_shortwave_id(n)) then
-          found = .true.
-          interior_forcing_metadata(id)%varname     = 'Surface Shortwave'
-          interior_forcing_metadata(id)%field_units = 'need_units' ! W/m^2?
-          interior_forcing_metadata(id)%array_ind   = n
-        end if
-      end do
-
-      if (.not.found) then
-        write(log_message, "(A,I0,A)") "Index number ", id, &
-             " is not associated with a forcing field!"
-        call marbl_status_log%log_error(log_message, subname)
-        return
+      if (id.eq.ind%PAR_col_frac_id) then
+        found = .true.
+        interior_forcings(id)%metadata%varname     = 'PAR Column Fraction'
+        interior_forcings(id)%metadata%field_units = 'unitless'
+        call interior_forcings(id)%metadata%set_rank(1, marbl_status_log,     &
+                                                     dim1 = num_PAR_subcols)
       end if
 
-    end do
+      if (id.eq.ind%surf_shortwave_id) then
+        found = .true.
+        interior_forcings(id)%metadata%varname     = 'Surface Shortwave'
+        interior_forcings(id)%metadata%field_units = 'need_units' ! W/m^2?
+        call interior_forcings(id)%metadata%set_rank(1, marbl_status_log,     &
+                                                     dim1 = num_PAR_subcols)
+      end if
 
-    ! Interior forcings
-    do id=1,num_interior_forcing_fields_1d
-      found = .false.
-      id2 = id + num_interior_forcing_fields_0d
 
       ! Temperature
       if (id.eq.ind%temperature_id) then
         found = .true.
-        interior_forcing_metadata(id2)%varname     = 'Temperature'
-        interior_forcing_metadata(id2)%field_units = 'Degrees C'
+        interior_forcings(id)%metadata%varname     = 'Temperature'
+        interior_forcings(id)%metadata%field_units = 'Degrees C'
+        call interior_forcings(id)%metadata%set_rank(1, marbl_status_log,     &
+                                                     dim1 = num_levels)
       end if
 
       ! Salinity
       if (id.eq.ind%salinity_id) then
         found = .true.
-        interior_forcing_metadata(id2)%varname     = 'Salinity'
-        interior_forcing_metadata(id2)%field_units = 'need_units'
+        interior_forcings(id)%metadata%varname     = 'Salinity'
+        interior_forcings(id)%metadata%field_units = 'need_units'
+        call interior_forcings(id)%metadata%set_rank(1, marbl_status_log,     &
+                                                     dim1 = num_levels)
       end if
 
       ! Pressure
       if (id.eq.ind%pressure_id) then
         found = .true.
-        interior_forcing_metadata(id2)%varname     = 'Pressure'
-        interior_forcing_metadata(id2)%field_units = 'need_units'
+        interior_forcings(id)%metadata%varname     = 'Pressure'
+        interior_forcings(id)%metadata%field_units = 'need_units'
+        call interior_forcings(id)%metadata%set_rank(1, marbl_status_log,     &
+                                                     dim1 = num_levels)
       end if
 
       ! Iron Sediment Flux
       if (id.eq.ind%fesedflux_id) then
         found = .true.
-        interior_forcing_metadata(id2)%varname     = 'Iron Sediment Flux'
-        interior_forcing_metadata(id2)%field_units = 'need_units'
+        interior_forcings(id)%metadata%varname     = 'Iron Sediment Flux'
+        interior_forcings(id)%metadata%field_units = 'need_units'
+        call interior_forcings(id)%metadata%set_rank(1, marbl_status_log,     &
+                                                     dim1 = num_levels)
       end if
 
-      ! Interior Tracer Restoring (still to do)
+      ! Interior Tracer Restoring
       do n=1,size(ind%tracer_restore_id)
         if (id.eq.ind%tracer_restore_id(n)) then
           found = .true.
-          write(interior_forcing_metadata(id2)%varname,"(A,1X,A)")            &
+          write(interior_forcings(id)%metadata%varname,"(A,1X,A)")            &
                 trim(tracer_names(n)), 'Restoring'
-          interior_forcing_metadata(id2)%field_units = 'unitless'
-          interior_forcing_metadata(id2)%array_ind   = n
+          interior_forcings(id)%metadata%field_units = 'unitless'
+          call interior_forcings(id)%metadata%set_rank(1, marbl_status_log,   &
+                                                       dim1 = num_levels)
         end if
       end do
 
+      ! Check to see if %set_rank() returned an error
+      if (marbl_status_log%labort_marbl) then
+        write(log_message, "(2A)"), trim(interior_forcings(id)%metadata%varname), &
+                                    ' set_rank()'
+        call marbl_status_log%log_error_trace(subname, log_message)
+        return
+      end if
+
+      ! Abort if there was no match between id and the restoring indices
       if (.not.found) then
         write(log_message, "(A,I0,A)") "Index number ", id, &
              " is not associated with a forcing field!"
         call marbl_status_log%log_error(log_message, subname)
         return
       end if
+
+      call interior_forcings(id)%allocate_memory(num_elements)
+
     end do
 
     end associate
@@ -941,8 +954,7 @@ contains
 
   subroutine marbl_set_interior_forcing( &
        domain,                           &
-       interior_forcings_0d,             &
-       interior_forcings_1d,             &
+       interior_forcings,                &
        saved_state,                      &
        saved_state_ind,                  &
        interior_restore,                 &
@@ -960,20 +972,19 @@ contains
        interior_restore_diags,           &
        glo_avg_fields_interior,          &
        marbl_status_log)
-    
+
     !  Compute time derivatives for ecosystem state variables
 
     use marbl_ciso_mod      , only : marbl_ciso_set_interior_forcing
     use marbl_sizes         , only : marbl_total_tracer_cnt
     use marbl_internal_types, only : marbl_interior_saved_state_indexing_type
 
-    implicit none 
+    implicit none
 
-    type    (marbl_domain_type)                 , intent(in)    :: domain                                
-    real    (r8)                                , intent(in)    :: interior_forcings_0d(:,:) ! (num_elements, num_interior_forcing_fields_0d)
-    real    (r8)                                , intent(in)    :: interior_forcings_1d(:,:,:) ! (num_elements, km, num_interior_forcing_fields_1d)
-    real    (r8)                                , intent(in)    :: interior_restore(:,:) ! (marbl_total_tracer_cnt, km) local restoring terms for nutrients (mmol ./m^3/sec) 
-    real    (r8)                                , intent(in)    :: tracers(:,: )         ! (marbl_total_tracer_cnt, km) tracer values 
+    type    (marbl_domain_type)                 , intent(in)    :: domain
+    type(marbl_forcing_fields_type)             , intent(in)    :: interior_forcings(:)
+    real    (r8)                                , intent(in)    :: interior_restore(:,:) ! (marbl_total_tracer_cnt, km) local restoring terms for nutrients (mmol ./m^3/sec)
+    real    (r8)                                , intent(in)    :: tracers(:,: )         ! (marbl_total_tracer_cnt, km) tracer values
     type(marbl_surface_forcing_indexing_type)   , intent(in)    :: surface_forcing_indices
     type(marbl_interior_forcing_indexing_type)  , intent(in)    :: interior_forcing_indices
     type    (marbl_PAR_type)                    , intent(inout) :: marbl_PAR
@@ -1056,8 +1067,8 @@ contains
     associate(                                                      &
          km                  => domain%km,                          &
          kmt                 => domain%kmt,                         &
-         num_PAR_subcols     => domain%num_PAR_subcols,             & 
-         delta_z1            => domain%delta_z(1),                  &           
+         num_PAR_subcols     => domain%num_PAR_subcols,             &
+         delta_z1            => domain%delta_z(1),                  &
 
          POC                 => marbl_particulate_share%POC,        &
          P_CaCO3             => marbl_particulate_share%P_CaCO3,    &
@@ -1069,11 +1080,11 @@ contains
          ph_prev_alt_co2_col => saved_state%state(saved_state_ind%ph_alt_co2_col)%field_3d(:,1), &
 
          ! Hard-coding in that there is only 1 column passed in at a time!
-         dust_flux_in        => interior_forcings_0d(1,interior_forcing_indices%dustflux_id),   &
-         temperature         => interior_forcings_1d(1,:,interior_forcing_indices%temperature_id),   &
-         pressure            => interior_forcings_1d(1,:,interior_forcing_indices%pressure_id),   &
-         salinity            => interior_forcings_1d(1,:,interior_forcing_indices%salinity_id),   &
-         fesedflux           => interior_forcings_1d(1,:,interior_forcing_indices%fesedflux_id),   &
+         dust_flux_in        => interior_forcings(interior_forcing_indices%dustflux_id)%field_0d(1),   &
+         temperature         => interior_forcings(interior_forcing_indices%temperature_id)%field_1d(1,:),   &
+         pressure            => interior_forcings(interior_forcing_indices%pressure_id)%field_1d(1,:),   &
+         salinity            => interior_forcings(interior_forcing_indices%salinity_id)%field_1d(1,:),   &
+         fesedflux           => interior_forcings(interior_forcing_indices%fesedflux_id)%field_1d(1,:),   &
 
          po4_ind           => marbl_tracer_indices%po4_ind,         &
          no3_ind           => marbl_tracer_indices%no3_ind,         &
@@ -1127,9 +1138,8 @@ contains
     call marbl_consistency_check_autotrophs(autotroph_cnt, kmt, marbl_tracer_indices, &
          autotroph_local(:,1:kmt))
 
-    call marbl_compute_PAR(domain, interior_forcings_0d(1,:),       &
-                           interior_forcing_indices, autotroph_cnt, &
-                           autotroph_local, PAR)
+    call marbl_compute_PAR(domain, interior_forcings, interior_forcing_indices, &
+                           autotroph_cnt, autotroph_local, PAR)
 
     do k = 1, km
 
@@ -1258,11 +1268,11 @@ contains
     call marbl_diagnostics_set_interior_forcing(            &
          domain,                                            &
          interior_forcing_indices,                          &
-         interior_forcings_1d,                              &
+         interior_forcings,                                 &
          dtracers,                                          &
          marbl_tracer_indices,                              &
          carbonate,                                         &
-         autotroph_secondary_species,                       &         
+         autotroph_secondary_species,                       &
          zooplankton_secondary_species,                     &
          dissolved_organic_matter,                          &
          marbl_particulate_share,                           &
@@ -2174,11 +2184,11 @@ contains
        glo_avg_fields_surface,          &
        marbl_status_log)
 
-    !  Compute surface forcing fluxes 
+    !  Compute surface forcing fluxes
 
     use marbl_interface_types    , only : sfo_ind
     use marbl_internal_types     , only : marbl_surface_saved_state_indexing_type
-    use marbl_schmidt_number_mod , only : schmidt_co2_surf  
+    use marbl_schmidt_number_mod , only : schmidt_co2_surf
     use marbl_oxygen             , only : schmidt_o2_surf
     use marbl_co2calc_mod        , only : marbl_co2calc_surf
     use marbl_co2calc_mod        , only : thermodynamic_coefficients_type
@@ -2196,7 +2206,7 @@ contains
 
     integer (int_kind)                        , intent(in)    :: num_elements
     type(marbl_surface_forcing_indexing_type) , intent(in)    :: surface_forcing_ind
-    real(r8)                                  , intent(in)    :: surface_input_forcings(:,:)
+    type(marbl_forcing_fields_type)           , intent(in)    :: surface_input_forcings(:)
     real (r8)                                 , intent(in)    :: surface_vals(:,:)
     real (r8)                                 , intent(out)   :: surface_tracer_fluxes(:,:)
     type(marbl_tracer_index_type)             , intent(in)    :: marbl_tracer_indices
@@ -2229,45 +2239,45 @@ contains
     associate(                                                                                      &
          ind                  => surface_forcing_ind,                                               &
 
-         surface_mask         => surface_input_forcings(:,surface_forcing_ind%surface_mask_id),     &
-         ifrac                => surface_input_forcings(:,surface_forcing_ind%ifrac_id),            &
-         sst                  => surface_input_forcings(:,surface_forcing_ind%sst_id),              &
-         sss                  => surface_input_forcings(:,surface_forcing_ind%sss_id),              &
-         xco2                 => surface_input_forcings(:,surface_forcing_ind%xco2_id),             &
-         xco2_alt_co2         => surface_input_forcings(:,surface_forcing_ind%xco2_alt_co2_id),     &
-         ap_used              => surface_input_forcings(:,surface_forcing_ind%atm_pressure_id),     &
-         u10_sqr              => surface_input_forcings(:,surface_forcing_ind%u10_sqr_id),          &
-         dust_flux_in         => surface_input_forcings(:,surface_forcing_ind%dust_flux_id),        &
-         iron_flux_in         => surface_input_forcings(:,surface_forcing_ind%iron_flux_id),        &
-         nox_flux             => surface_input_forcings(:,surface_forcing_ind%nox_flux_id),         &
-         nhy_flux             => surface_input_forcings(:,surface_forcing_ind%nhy_flux_id),         &
-         din_riv_flux         => surface_input_forcings(:,surface_forcing_ind%din_riv_flux_id),     &
-         dip_riv_flux         => surface_input_forcings(:,surface_forcing_ind%dip_riv_flux_id),     &
-         don_riv_flux         => surface_input_forcings(:,surface_forcing_ind%don_riv_flux_id),     &
-         dop_riv_flux         => surface_input_forcings(:,surface_forcing_ind%dop_riv_flux_id),     &
-         dsi_riv_flux         => surface_input_forcings(:,surface_forcing_ind%dsi_riv_flux_id),     &
-         dfe_riv_flux         => surface_input_forcings(:,surface_forcing_ind%dfe_riv_flux_id),     &
-         dic_riv_flux         => surface_input_forcings(:,surface_forcing_ind%dic_riv_flux_id),     &
-         doc_riv_flux         => surface_input_forcings(:,surface_forcing_ind%doc_riv_flux_id),     &
-         alk_riv_flux         => surface_input_forcings(:,surface_forcing_ind%alk_riv_flux_id),     &
+         surface_mask => surface_input_forcings(surface_forcing_ind%surface_mask_id)%field_0d,     &
+         ifrac        => surface_input_forcings(surface_forcing_ind%ifrac_id)%field_0d,            &
+         sst          => surface_input_forcings(surface_forcing_ind%sst_id)%field_0d,              &
+         sss          => surface_input_forcings(surface_forcing_ind%sss_id)%field_0d,              &
+         xco2         => surface_input_forcings(surface_forcing_ind%xco2_id)%field_0d,             &
+         xco2_alt_co2 => surface_input_forcings(surface_forcing_ind%xco2_alt_co2_id)%field_0d,     &
+         ap_used      => surface_input_forcings(surface_forcing_ind%atm_pressure_id)%field_0d,     &
+         u10_sqr      => surface_input_forcings(surface_forcing_ind%u10_sqr_id)%field_0d,          &
+         dust_flux_in => surface_input_forcings(surface_forcing_ind%dust_flux_id)%field_0d,        &
+         iron_flux_in => surface_input_forcings(surface_forcing_ind%iron_flux_id)%field_0d,        &
+         nox_flux     => surface_input_forcings(surface_forcing_ind%nox_flux_id)%field_0d,         &
+         nhy_flux     => surface_input_forcings(surface_forcing_ind%nhy_flux_id)%field_0d,         &
+         din_riv_flux => surface_input_forcings(surface_forcing_ind%din_riv_flux_id)%field_0d,     &
+         dip_riv_flux => surface_input_forcings(surface_forcing_ind%dip_riv_flux_id)%field_0d,     &
+         don_riv_flux => surface_input_forcings(surface_forcing_ind%don_riv_flux_id)%field_0d,     &
+         dop_riv_flux => surface_input_forcings(surface_forcing_ind%dop_riv_flux_id)%field_0d,     &
+         dsi_riv_flux => surface_input_forcings(surface_forcing_ind%dsi_riv_flux_id)%field_0d,     &
+         dfe_riv_flux => surface_input_forcings(surface_forcing_ind%dfe_riv_flux_id)%field_0d,     &
+         dic_riv_flux => surface_input_forcings(surface_forcing_ind%dic_riv_flux_id)%field_0d,     &
+         doc_riv_flux => surface_input_forcings(surface_forcing_ind%doc_riv_flux_id)%field_0d,     &
+         alk_riv_flux => surface_input_forcings(surface_forcing_ind%alk_riv_flux_id)%field_0d,     &
 
          piston_velocity      => surface_forcing_internal%piston_velocity(:),                       &
          flux_co2             => surface_forcing_internal%flux_co2(:),                              &
-         co2star              => surface_forcing_internal%co2star(:),                               & 
-         dco2star             => surface_forcing_internal%dco2star(:),                              & 
-         pco2surf             => surface_forcing_internal%pco2surf(:),                              & 
-         dpco2                => surface_forcing_internal%dpco2(:),                                 & 
-         co3                  => surface_forcing_internal%co3(:),                                   & 
-         co2star_alt          => surface_forcing_internal%co2star_alt(:),                           & 
-         dco2star_alt         => surface_forcing_internal%dco2star_alt(:),                          & 
-         pco2surf_alt         => surface_forcing_internal%pco2surf_alt(:),                          & 
-         dpco2_alt            => surface_forcing_internal%dpco2_alt(:),                             & 
-         schmidt_co2          => surface_forcing_internal%schmidt_co2(:),                           & 
-         schmidt_o2           => surface_forcing_internal%schmidt_o2(:),                            & 
-         pv_o2                => surface_forcing_internal%pv_o2(:),                                 & 
-         pv_co2               => surface_forcing_internal%pv_co2(:),                                & 
-         o2sat                => surface_forcing_internal%o2sat(:),                                 & 
-         flux_alt_co2         => surface_forcing_internal%flux_alt_co2(:),                          & 
+         co2star              => surface_forcing_internal%co2star(:),                               &
+         dco2star             => surface_forcing_internal%dco2star(:),                              &
+         pco2surf             => surface_forcing_internal%pco2surf(:),                              &
+         dpco2                => surface_forcing_internal%dpco2(:),                                 &
+         co3                  => surface_forcing_internal%co3(:),                                   &
+         co2star_alt          => surface_forcing_internal%co2star_alt(:),                           &
+         dco2star_alt         => surface_forcing_internal%dco2star_alt(:),                          &
+         pco2surf_alt         => surface_forcing_internal%pco2surf_alt(:),                          &
+         dpco2_alt            => surface_forcing_internal%dpco2_alt(:),                             &
+         schmidt_co2          => surface_forcing_internal%schmidt_co2(:),                           &
+         schmidt_o2           => surface_forcing_internal%schmidt_o2(:),                            &
+         pv_o2                => surface_forcing_internal%pv_o2(:),                                 &
+         pv_co2               => surface_forcing_internal%pv_co2(:),                                &
+         o2sat                => surface_forcing_internal%o2sat(:),                                 &
+         flux_alt_co2         => surface_forcing_internal%flux_alt_co2(:),                          &
          nhx_surface_emis     => surface_forcing_internal%nhx_surface_emis(:),                      &
 
          stf                  => surface_tracer_fluxes(:,:),                                        &
@@ -2326,7 +2336,7 @@ contains
     !-----------------------------------------------------------------------
     !  compute CO2 flux, computing disequilibrium one row at a time
     !-----------------------------------------------------------------------
-       
+
     if (lflux_gas_o2 .or. lflux_gas_co2) then
 
        !-----------------------------------------------------------------------
@@ -2365,14 +2375,14 @@ contains
        endif  ! lflux_gas_o2
 
        !-----------------------------------------------------------------------
-       !  compute CO2 flux, computing disequilibrium 
+       !  compute CO2 flux, computing disequilibrium
        !-----------------------------------------------------------------------
 
        if (lflux_gas_co2) then
 
           schmidt_co2(:) = schmidt_co2_surf(num_elements, sst, surface_mask)
 
-          where (surface_mask(:) /= c0) 
+          where (surface_mask(:) /= c0)
              pv_co2(:) = xkw_ice(:) * sqrt(660.0_r8 / schmidt_co2(:))
           elsewhere
              pv_co2(:) = c0
@@ -2390,7 +2400,7 @@ contains
              phhi(:) = phhi_surf_init
           end where
 
-          where (surface_mask(:) /= c0) 
+          where (surface_mask(:) /= c0)
              mask(:) = .true.
           elsewhere
              mask(:) = .false.
@@ -2402,14 +2412,14 @@ contains
                num_elements     = num_elements,                            &
                lcomp_co3_coeffs = .true.,                                  &
                mask       = mask,                                          &
-               dic_in     = surface_vals(:,dic_ind),                       & 
-               xco2_in    = surface_input_forcings(:,ind%xco2_id),         &
-               ta_in      = surface_vals(:,alk_ind),                       & 
-               pt_in      = surface_vals(:,po4_ind),                       & 
+               dic_in     = surface_vals(:,dic_ind),                       &
+               xco2_in    = surface_input_forcings(ind%xco2_id)%field_0d,  &
+               ta_in      = surface_vals(:,alk_ind),                       &
+               pt_in      = surface_vals(:,po4_ind),                       &
                sit_in     = surface_vals(:,sio3_ind),                      &
-               temp       = surface_input_forcings(:,ind%sst_id),          &
-               salt       = surface_input_forcings(:,ind%sss_id),          &
-               atmpres    = surface_input_forcings(:,ind%atm_pressure_id), &
+               temp       = surface_input_forcings(ind%sst_id)%field_0d,   &
+               salt       = surface_input_forcings(ind%sss_id)%field_0d,   &
+               atmpres    = surface_input_forcings(ind%atm_pressure_id)%field_0d, &
                co3_coeffs = co3_coeffs,                                    &
                co3        = co3,                                           &
                co2star    = co2star,                                       &
@@ -2463,13 +2473,13 @@ contains
                lcomp_co3_coeffs = .false.,                                 &
                mask       = mask,                                          &
                dic_in     = surface_vals(:,dic_alt_co2_ind),               &
-               xco2_in    = surface_input_forcings(:,ind%xco2_alt_co2_id), &
-               ta_in      = surface_vals(:,alk_ind),                       & 
-               pt_in      = surface_vals(:,po4_ind),                       & 
+               xco2_in    = surface_input_forcings(ind%xco2_alt_co2_id)%field_0d, &
+               ta_in      = surface_vals(:,alk_ind),                       &
+               pt_in      = surface_vals(:,po4_ind),                       &
                sit_in     = surface_vals(:,sio3_ind),                      &
-               temp       = surface_input_forcings(:,ind%sst_id),          &
-               salt       = surface_input_forcings(:,ind%sss_id),          &
-               atmpres    = surface_input_forcings(:,ind%atm_pressure_id), &
+               temp       = surface_input_forcings(ind%sst_id)%field_0d,   &
+               salt       = surface_input_forcings(ind%sss_id)%field_0d,   &
+               atmpres    = surface_input_forcings(ind%atm_pressure_id)%field_0d, &
                co3_coeffs = co3_coeffs,                                    &
                co3        = co3,                                           &
                co2star    = co2star_alt,                                   &
@@ -2644,11 +2654,11 @@ contains
        ! pass in sections of surface_input_forcings instead of associated vars because of problems with intel/15.0.3
        call marbl_ciso_set_surface_forcing(                                              &
             num_elements                = num_elements,                                  &
-            surface_mask                = surface_input_forcings(:,ind%surface_mask_id), &
-            sst                         = surface_input_forcings(:,ind%sst_id),          &
-            d13c                        = surface_input_forcings(:,ind%d13c_id),         &
-            d14c                        = surface_input_forcings(:,ind%d14c_id),         &
-            d14c_glo_avg                = surface_input_forcings(:,ind%d14c_glo_avg_id), &
+            surface_mask                = surface_input_forcings(ind%surface_mask_id)%field_0d, &
+            sst                         = surface_input_forcings(ind%sst_id)%field_0d,   &
+            d13c                        = surface_input_forcings(ind%d13c_id)%field_0d,  &
+            d14c                        = surface_input_forcings(ind%d14c_id)%field_0d,  &
+            d14c_glo_avg                = surface_input_forcings(ind%d14c_glo_avg_id)%field_0d, &
             surface_vals                = surface_vals,                                  &
             stf                         = surface_tracer_fluxes,                         &
             marbl_tracer_indices        = marbl_tracer_indices,                          &
@@ -3199,7 +3209,7 @@ contains
 
   !***********************************************************************
 
-  subroutine marbl_compute_PAR(domain, interior_forcings_0d, interior_forcing_ind, &
+  subroutine marbl_compute_PAR(domain, interior_forcings, interior_forcing_ind, &
                                auto_cnt, autotroph_local, PAR)
 
     !-----------------------------------------------------------------------
@@ -3211,8 +3221,8 @@ contains
     ! PAR is intent(inout) because it components, while entirely set here, are allocated elsewhere
 
     integer(int_kind)                         , intent(in)    :: auto_cnt
-    type(marbl_domain_type)                   , intent(in)    :: domain  
-    real(r8)                                  , intent(in)    :: interior_forcings_0d(:) ! (num_elements, num_interior_forcing_fields_0d)
+    type(marbl_domain_type)                   , intent(in)    :: domain
+    type(marbl_forcing_fields_type)           , intent(in)    :: interior_forcings(:) ! (num_elements, num_interior_forcing_fields_0d)
     type(marbl_interior_forcing_indexing_type), intent(in)    :: interior_forcing_ind
     type(autotroph_local_type)                , intent(in)    :: autotroph_local(auto_cnt, domain%km)
     type(marbl_PAR_type)                      , intent(inout) :: PAR
@@ -3236,11 +3246,11 @@ contains
     ! ignore provided shortwave where col_frac == 0
     !-----------------------------------------------------------------------
 
-    PAR%col_frac(:) = interior_forcings_0d(interior_forcing_ind%PAR_col_frac_id(:))
+    PAR%col_frac(:) = interior_forcings(interior_forcing_ind%PAR_col_frac_id)%field_1d(1,:)
 
     where (PAR%col_frac(:) > c0)
        PAR%interface(0,:) = f_qsw_par *                                       &
-              interior_forcings_0d(interior_forcing_ind%surf_shortwave_id(:))
+              interior_forcings(interior_forcing_ind%surf_shortwave_id)%field_1d(1,:)
     elsewhere
        PAR%interface(0,:) = c0
     endwhere

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -967,7 +967,6 @@ contains
        interior_forcings,                &
        saved_state,                      &
        saved_state_ind,                  &
-       interior_restore,                 &
        tracers,                          &
        surface_forcing_indices,          &
        interior_forcing_indices,         &
@@ -988,12 +987,10 @@ contains
     use marbl_ciso_mod      , only : marbl_ciso_set_interior_forcing
     use marbl_sizes         , only : marbl_total_tracer_cnt
     use marbl_internal_types, only : marbl_interior_saved_state_indexing_type
-
-    implicit none
+    use marbl_restore_mod   , only : marbl_restore_compute_interior_restore
 
     type    (marbl_domain_type)                 , intent(in)    :: domain
     type(marbl_forcing_fields_type)             , intent(in)    :: interior_forcings(:)
-    real    (r8)                                , intent(in)    :: interior_restore(:,:) ! (marbl_total_tracer_cnt, km) local restoring terms for nutrients (mmol ./m^3/sec)
     real    (r8)                                , intent(in)    :: tracers(:,: )         ! (marbl_total_tracer_cnt, km) tracer values
     type(marbl_surface_forcing_indexing_type)   , intent(in)    :: surface_forcing_indices
     type(marbl_interior_forcing_indexing_type)  , intent(in)    :: interior_forcing_indices
@@ -1016,6 +1013,7 @@ contains
     !  local variables
     !-----------------------------------------------------------------------
     character(*), parameter :: subname = 'marbl_mod:marbl_set_interior_forcing'
+    real(r8), dimension(marbl_total_tracer_cnt, domain%km) :: interior_restore
 
     integer (int_kind) :: auto_ind  ! autotroph functional group index
     integer (int_kind) :: auto_ind2 ! autotroph functional group index
@@ -1112,6 +1110,17 @@ contains
          donr_ind          => marbl_tracer_indices%donr_ind,        &
          docr_ind          => marbl_tracer_indices%docr_ind         &
          )
+
+    !-----------------------------------------------------------------------
+    !  Compute adjustment to tendencies due to tracer restoring
+    !-----------------------------------------------------------------------
+
+    call marbl_restore_compute_interior_restore(            &
+               tracers,                                     &
+               km,                                          &
+               interior_forcings,                           &
+               interior_forcing_indices,                    &
+               interior_restore)
 
     !-----------------------------------------------------------------------
     !  create local copies of model tracers

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -1288,20 +1288,15 @@ contains
          sed_denitrif, other_remin, nitrif, denitrif,       &
          tracers(o2_ind, :), o2_production, o2_consumption, &
          fe_scavenge, fe_scavenge_rate,                     &
+         interior_restore,                                  &
          interior_forcing_diags, &
+         interior_restore_diags, &
          marbl_status_log)
     if (marbl_status_log%labort_marbl) then
        call marbl_status_log%log_error_trace(&
             'marbl_diagnostics_set_interior_foricng()', subname)
        return
     end if
-
-    ! FIXME #119: Why isn't this in marbl_diagnostics? And why are we passing
-    ! this%column_restore instead of a local variable?
-    ! Compute restore diagnostics
-    do n = 1, ecosys_base_tracer_cnt
-       interior_restore_diags%diags(n)%field_3d(:,1) = interior_restore(n,:)
-    end do
 
     !  Compute time derivatives for ecosystem carbon isotope state variables
     if (ciso_on) then

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -537,13 +537,14 @@ contains
     !-----------------------------------------------------------------------
     character(*), parameter :: subname = 'marbl_mod:marbl_init_interior_forcing_fields'
     character(len=char_len) :: log_message
+    ! NAG didn't like associating to tracer_metadata(:)%*
+    character(len=char_len) :: tracer_name
+    character(len=char_len) :: tracer_units
     integer                 :: id, n
     logical                 :: found
     !-----------------------------------------------------------------------
 
-    associate(ind          => interior_forcing_indices,      &
-              tracer_names => tracer_metadata(:)%short_name, &
-              tracer_units => tracer_metadata(:)%units)
+    associate(ind => interior_forcing_indices)
 
     interior_forcings(:)%metadata%varname = ''
 
@@ -615,17 +616,19 @@ contains
       ! Interior Tracer Restoring
       do n=1,size(ind%tracer_restore_id)
         if (id.eq.ind%tracer_restore_id(n)) then
+          tracer_name = tracer_metadata(n)%short_name
+          tracer_units = tracer_metadata(n)%units
           found = .true.
           write(interior_forcings(id)%metadata%varname,"(A,1X,A)")            &
-                trim(tracer_names(n)), 'Restoring'
-          interior_forcings(id)%metadata%field_units = tracer_units(n)
+                trim(tracer_name), 'Restoring'
+          interior_forcings(id)%metadata%field_units = tracer_units
           call interior_forcings(id)%set_rank(num_elements, 1, marbl_status_log, &
                                                        dim1 = num_levels)
         end if
         if (id.eq.ind%inv_tau_id(n)) then
           found = .true.
           write(interior_forcings(id)%metadata%varname,"(A,1X,A)")            &
-                trim(tracer_names(n)), 'Inverse Timescale'
+                trim(tracer_name), 'Inverse Timescale'
           interior_forcings(id)%metadata%field_units = '1/s'
           call interior_forcings(id)%set_rank(num_elements, 1, marbl_status_log, &
                                                        dim1 = num_levels)

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -510,7 +510,7 @@ contains
   subroutine marbl_init_interior_forcing_fields(&
        num_elements, &
        interior_forcing_indices, &
-       tracer_names, &
+       tracer_metadata, &
        num_PAR_subcols, &
        num_levels, &
        interior_forcings, &
@@ -526,7 +526,7 @@ contains
 
     integer,                                    intent(in)    :: num_elements
     type(marbl_interior_forcing_indexing_type), intent(in)    :: interior_forcing_indices
-    character(len=char_len), dimension(:),      intent(in)    :: tracer_names
+    type(marbl_tracer_metadata_type),           intent(in)    :: tracer_metadata(:)
     integer,                                    intent(in)    :: num_PAR_subcols
     integer,                                    intent(in)    :: num_levels
     type(marbl_forcing_fields_type),            intent(inout) :: interior_forcings(:)
@@ -541,7 +541,9 @@ contains
     logical                 :: found
     !-----------------------------------------------------------------------
 
-    associate(ind => interior_forcing_indices)
+    associate(ind          => interior_forcing_indices,      &
+              tracer_names => tracer_metadata(:)%short_name, &
+              tracer_units => tracer_metadata(:)%units)
 
     interior_forcings(:)%metadata%varname = ''
 
@@ -616,7 +618,7 @@ contains
           found = .true.
           write(interior_forcings(id)%metadata%varname,"(A,1X,A)")            &
                 trim(tracer_names(n)), 'Restoring'
-          interior_forcings(id)%metadata%field_units = 'unitless'
+          interior_forcings(id)%metadata%field_units = tracer_units(n)
           call interior_forcings(id)%set_rank(num_elements, 1, marbl_status_log, &
                                                        dim1 = num_levels)
         end if

--- a/src/marbl_parms.F90
+++ b/src/marbl_parms.F90
@@ -91,7 +91,6 @@ module marbl_parms
   character(char_len), target :: ciso_fract_factors             ! option for which biological fractionation calculation to use
 
   character(len=char_len), allocatable, target, dimension(:) :: tracer_restore_vars
-  real(r8), target :: rest_time_inv_surf, rest_time_inv_deep, rest_z0, rest_z1
 
   !---------------------------------------------------------------------
   !  BGC parameters that are not part of marbl_parms_nml
@@ -208,8 +207,6 @@ module marbl_parms
   integer (int_kind)            :: caco3_bury_thres_iopt
   integer (int_kind), parameter :: caco3_bury_thres_iopt_fixed_depth = 1
   integer (int_kind), parameter :: caco3_bury_thres_iopt_omega_calc  = 2
-
-  real(r8), dimension(:), allocatable :: inv_tau
 
   ! grazing functions
   integer (kind=int_kind), parameter ::           &
@@ -434,18 +431,11 @@ contains
     ciso_fract_factors     = 'Rau'
 
     ! FIXME #69: not thread-safe!
-    if (.not.allocated(inv_tau)) &
-      allocate(inv_tau(km))
     if (.not.allocated(tracer_restore_vars)) &
       allocate(tracer_restore_vars(marbl_total_tracer_cnt))
 
     ! initialize namelist variables to default values
     tracer_restore_vars = ''
-
-    rest_time_inv_surf = c0
-    rest_time_inv_deep = c0
-    rest_z0 = c1000
-    rest_z1 = c2*c1000
 
   end subroutine marbl_parms_set_defaults
 
@@ -494,10 +484,6 @@ contains
          PON_bury_coeff, &
          ciso_fract_factors, &
          tracer_restore_vars, &
-         rest_time_inv_surf, &
-         rest_time_inv_deep, &
-         rest_z0, &
-         rest_z1, &
          bury_coeff_rmean_timescale_years, &
          parm_scalelen_z, &
          parm_scalelen_vals, &
@@ -1322,58 +1308,6 @@ contains
                                marbl_status_log)
     if (marbl_status_log%labort_marbl) then
       call marbl_status_log%log_error_trace('add_var_1d_str', subname)
-      return
-    end if
-
-    sname     = 'rest_time_inv_surf'
-    lname     = 'Restoring time scale at rest_z0'
-    units     = '1/sec'
-    datatype  = 'real'
-    group     = 'marbl_parms_nml'
-    rptr      => rest_time_inv_surf
-    call this%add_var(sname, lname, units, datatype, group,                 &
-                        marbl_status_log, rptr=rptr)
-    if (marbl_status_log%labort_marbl) then
-      call log_add_var_error(marbl_status_log, sname, subname)
-      return
-    end if
-
-    sname     = 'rest_time_inv_deep'
-    lname     = 'Restoring time scale at rest_z1'
-    units     = '1/sec'
-    datatype  = 'real'
-    group     = 'marbl_parms_nml'
-    rptr      => rest_time_inv_deep
-    call this%add_var(sname, lname, units, datatype, group,                 &
-                        marbl_status_log, rptr=rptr)
-    if (marbl_status_log%labort_marbl) then
-      call log_add_var_error(marbl_status_log, sname, subname)
-      return
-    end if
-
-    sname     = 'rest_z0'
-    lname     = 'Above this depth, restoring time scale is rest_time_inv_surf'
-    units     = 'cm'
-    datatype  = 'real'
-    group     = 'marbl_parms_nml'
-    rptr      => rest_z0
-    call this%add_var(sname, lname, units, datatype, group,                 &
-                        marbl_status_log, rptr=rptr)
-    if (marbl_status_log%labort_marbl) then
-      call log_add_var_error(marbl_status_log, sname, subname)
-      return
-    end if
-
-    sname     = 'rest_z1'
-    lname     = 'Below this depth, restoring time scale is rest_time_inv_deep'
-    units     = 'cm'
-    datatype  = 'real'
-    group     = 'marbl_parms_nml'
-    rptr      => rest_z1
-    call this%add_var(sname, lname, units, datatype, group,                 &
-                        marbl_status_log, rptr=rptr)
-    if (marbl_status_log%labort_marbl) then
-      call log_add_var_error(marbl_status_log, sname, subname)
       return
     end if
 

--- a/src/marbl_restore_mod.F90
+++ b/src/marbl_restore_mod.F90
@@ -3,147 +3,40 @@ module marbl_restore_mod
   ! Module to generalize restoring any non-autotroph tracer
   !
 
-  use marbl_kinds_mod      , only : r8, log_kind, int_kind
+  use marbl_kinds_mod      , only : r8, int_kind, char_len
   use marbl_constants_mod  , only : p5, c0, c2, c1000
   use marbl_interface_types, only : marbl_domain_type
   use marbl_sizes          , only : marbl_total_tracer_cnt
+  use marbl_sizes          , only : tracer_restore_cnt
 
   implicit none
-  private
+  public
   save
-
-  type :: marbl_single_restoring_field_type
-    ! Both the inverse timescale and the values to restore towards are provided
-    ! to MARBL by the GCM (using the interior forcing data type; in that data
-    ! type the fields are stored as 1 x km arrays (1 => num_elements)
-    real(kind=r8), dimension(:,:), pointer :: inv_tau ! 1/time_scale (s^-1)
-    real(kind=r8), dimension(:,:), pointer :: data
-    integer                                :: restore_var_ind = 0
-  end type marbl_single_restoring_field_type
-
-  type, public :: marbl_restore_type
-    type(marbl_single_restoring_field_type), allocatable, dimension(:) :: tracer_restore
-  contains
-     procedure, public :: init
-     procedure, public :: restore_tracers
-  end type marbl_restore_type
-
-  integer, public :: tracer_restore_cnt
 
 contains
 
 !*****************************************************************************
 
-subroutine init(this, domain, tracer_metadata, interior_forcings,             &
-                restoring_inds, inv_tau_inds, marbl_status_log)
-
-  ! initialize marbl_restore instance to default values, then read
-  ! namelist and setup tracers that need to be restored
-
-  use marbl_kinds_mod   , only : char_len, int_kind, i4, log_kind
-  use marbl_logging     , only : marbl_log_type
-  use marbl_interface_types, only : marbl_tracer_metadata_type
-  use marbl_interface_types, only : marbl_forcing_fields_type
-  use marbl_parms       , only : tracer_restore_vars
-
-  implicit none
-
-  !-----------------------------------------------------------------------
-  !  input / output variables
-  !-----------------------------------------------------------------------
-
-  class(marbl_restore_type), intent(inout) :: this
-  type(marbl_log_type),      intent(inout) :: marbl_status_log
-
-  !-----------------------------------------------------------------------
-  !  input variables
-  !-----------------------------------------------------------------------
-
-  type(marbl_domain_type),          intent(in) :: domain
-  type(marbl_tracer_metadata_type), intent(in) :: tracer_metadata(:)
-  type(marbl_forcing_fields_type),  intent(in) :: interior_forcings(:)
-  integer,                          intent(in) :: restoring_inds(:)
-  integer,                          intent(in) :: inv_tau_inds(:)
-
-  !-----------------------------------------------------------------------
-  !  local variables
-  !-----------------------------------------------------------------------
-
-  integer(int_kind) :: k, n, m
-  character(*), parameter :: subname = 'marbl_restore_mod:init'
-  character(len=char_len) :: log_message
-
-  !-----------------------------------------------------------------------
-
-  ! Process tracer_restore_vars to determine number of tracers to restore
-  tracer_restore_cnt = count((len_trim(tracer_restore_vars).gt.0))
-  allocate(this%tracer_restore(tracer_restore_cnt))
-
-  ! Ensure there are no duplicate tracers listed and no empty strings in
-  ! first tracer_restore_cnt elements of tracer_restore_vars
-  do n=1,tracer_restore_cnt
-    if (len_trim(tracer_restore_vars(n)).eq.0) then
-      log_message = "Empty string appears in middle of tracer_restore_vars!"
-      call marbl_status_log%log_error(log_message, subname)
-      return
-    end if
-    if (n.lt.marbl_total_tracer_cnt) then
-      if (any(tracer_restore_vars(n).eq.tracer_restore_vars(n+1:))) then
-        write(log_message,"(A,1X,A)") trim(tracer_restore_vars(n)),           &
-                              "appears in tracer_restore_vars more than once"
-        call marbl_status_log%log_error(log_message, subname)
-        return
-      end if
-    end if
-  end do
-
-  if (tracer_restore_cnt.gt.0) then
-    call marbl_status_log%log_noerror('', subname)
-    log_message = "Restoring the following tracers to data:"
-    call marbl_status_log%log_noerror(log_message, subname)
-  end if
-  do m=1, tracer_restore_cnt
-    nullify(this%tracer_restore(m)%data)
-    nullify(this%tracer_restore(m)%inv_tau)
-    do n=1,size(tracer_metadata)
-      if (trim(tracer_restore_vars(m)).eq.trim(tracer_metadata(n)%short_name)) exit
-    end do
-    if (n.le.size(tracer_metadata)) then
-      this%tracer_restore(m)%inv_tau => interior_forcings(inv_tau_inds(n))%field_1d
-      this%tracer_restore(m)%data    => interior_forcings(restoring_inds(n))%field_1d
-      this%tracer_restore(m)%restore_var_ind = n
-      write(log_message, "(2A,I0,A)") trim(tracer_metadata(n)%short_name),    &
-                                      " (tracer index: ", n, ')'
-      call marbl_status_log%log_noerror(log_message, subname)
-    else
-      write(log_message, "(2A)") "Can not find tracer named ",                &
-            trim(tracer_restore_vars(m))
-      call marbl_status_log%log_error(log_message, subname)
-      return
-    end if
-  end do
-  if (tracer_restore_cnt.gt.0) call marbl_status_log%log_noerror('', subname)
-
-end subroutine Init
-
-!*****************************************************************************
-
-subroutine restore_tracers(this, interior_tracers, km, interior_restore)
+subroutine marbl_restore_compute_interior_restore(interior_tracers, km,       &
+                                                  interior_forcings,          &
+                                                  interior_forcing_ind,       &
+                                                  interior_restore)
   !
   !  restore a variable if required
   !
-  use marbl_kinds_mod       , only : r8, int_kind, log_kind
-  use marbl_constants_mod   , only : c0
-
-  implicit none
+  use marbl_kinds_mod      , only : r8, int_kind
+  use marbl_constants_mod  , only : c0
+  use marbl_interface_types, only : marbl_forcing_fields_type
+  use marbl_internal_types , only : marbl_interior_forcing_indexing_type
 
   !-----------------------------------------------------------------------
   !  input variables
   !-----------------------------------------------------------------------
 
-  class(marbl_restore_type),     intent(inout) :: this
-  integer,                       intent(in)    :: km
-  real(kind=r8), dimension(:,:), intent(in)    :: interior_tracers
+  real(kind=r8), dimension(:,:),               intent(in) :: interior_tracers
+  integer,                                     intent(in) :: km
+  type(marbl_forcing_fields_type),             intent(in) :: interior_forcings(:)
+  type(marbl_interior_forcing_indexing_type),  intent(in) :: interior_forcing_ind
 
   !-----------------------------------------------------------------------
   !  output variables
@@ -154,20 +47,24 @@ subroutine restore_tracers(this, interior_tracers, km, interior_restore)
   !-----------------------------------------------------------------------
   !  local variables
   !-----------------------------------------------------------------------
+  integer(int_kind), pointer :: restoring_inds(:)
+  integer(int_kind), pointer :: inv_tau_inds(:)
   integer(int_kind) :: m, n
   !-----------------------------------------------------------------------
 
   interior_restore = c0
+  restoring_inds => interior_forcing_ind%tracer_restore_id
+  inv_tau_inds   => interior_forcing_ind%inv_tau_id
 
   do m=1,tracer_restore_cnt
-    n = this%tracer_restore(m)%restore_var_ind
-    associate(single_restore => this%tracer_restore(m))
-    interior_restore(n,:) = (single_restore%data(1,:) - interior_tracers(n,:)) * &
-                            single_restore%inv_tau(1,:)
+    n = interior_forcing_ind%tracer_id(m)
+    associate(restore_field => interior_forcings(restoring_inds(n))%field_1d, &
+              inv_tau       =>  interior_forcings(inv_tau_inds(n))%field_1d)
+      interior_restore(n,:) = (restore_field(1,:) - interior_tracers(n,:)) * inv_tau(1,:)
     end associate
   end do
 
-end subroutine restore_tracers
+end subroutine marbl_restore_compute_interior_restore
 
 !*****************************************************************************
 

--- a/src/marbl_restore_mod.F90
+++ b/src/marbl_restore_mod.F90
@@ -128,7 +128,7 @@ end subroutine Init
 
 !*****************************************************************************
 
-subroutine restore_tracers(this, interior_tracers, km, interior_restore, inv_tau)
+subroutine restore_tracers(this, interior_tracers, km, interior_restore)
   !
   !  restore a variable if required
   !
@@ -150,7 +150,6 @@ subroutine restore_tracers(this, interior_tracers, km, interior_restore, inv_tau
   !-----------------------------------------------------------------------
 
   real(kind=r8), dimension(marbl_total_tracer_cnt, km), intent(out) :: interior_restore
-  real(kind=r8), dimension(marbl_total_tracer_cnt, km), intent(out) :: inv_tau
 
   !-----------------------------------------------------------------------
   !  local variables
@@ -159,14 +158,12 @@ subroutine restore_tracers(this, interior_tracers, km, interior_restore, inv_tau
   !-----------------------------------------------------------------------
 
   interior_restore = c0
-  inv_tau          = c0
 
   do m=1,tracer_restore_cnt
     n = this%tracer_restore(m)%restore_var_ind
     associate(single_restore => this%tracer_restore(m))
-    inv_tau(n,:)          = single_restore%inv_tau(1,:)
     interior_restore(n,:) = (single_restore%data(1,:) - interior_tracers(n,:)) * &
-                            inv_tau(n,:)
+                            single_restore%inv_tau(1,:)
     end associate
   end do
 

--- a/src/marbl_restore_mod.F90
+++ b/src/marbl_restore_mod.F90
@@ -128,7 +128,7 @@ end subroutine Init
 
 !*****************************************************************************
 
-subroutine restore_tracers(this, interior_tracers, km, interior_restore)
+subroutine restore_tracers(this, interior_tracers, km, interior_restore, inv_tau)
   !
   !  restore a variable if required
   !
@@ -150,6 +150,7 @@ subroutine restore_tracers(this, interior_tracers, km, interior_restore)
   !-----------------------------------------------------------------------
 
   real(kind=r8), dimension(marbl_total_tracer_cnt, km), intent(out) :: interior_restore
+  real(kind=r8), dimension(marbl_total_tracer_cnt, km), intent(out) :: inv_tau
 
   !-----------------------------------------------------------------------
   !  local variables
@@ -157,13 +158,15 @@ subroutine restore_tracers(this, interior_tracers, km, interior_restore)
   integer(int_kind) :: m, n
   !-----------------------------------------------------------------------
 
-  interior_restore(:,:) = c0
+  interior_restore = c0
+  inv_tau          = c0
 
   do m=1,tracer_restore_cnt
     n = this%tracer_restore(m)%restore_var_ind
     associate(single_restore => this%tracer_restore(m))
+    inv_tau(n,:)          = single_restore%inv_tau(1,:)
     interior_restore(n,:) = (single_restore%data(1,:) - interior_tracers(n,:)) * &
-                            single_restore%inv_tau(1,:)
+                            inv_tau(n,:)
     end associate
   end do
 

--- a/src/marbl_sizes.F90
+++ b/src/marbl_sizes.F90
@@ -26,9 +26,11 @@ module marbl_sizes
   integer (KIND=int_kind), parameter :: max_prey_class_size = 9
 
   !-----------------------------------------------------------------------------
-  ! number of surface forcing fields
+  ! number of forcing fields
   !-----------------------------------------------------------------------------
 
   integer :: num_surface_forcing_fields
+  integer :: num_interior_forcing_fields_0d
+  integer :: num_interior_forcing_fields_1d
 
 end module marbl_sizes

--- a/src/marbl_sizes.F90
+++ b/src/marbl_sizes.F90
@@ -30,7 +30,6 @@ module marbl_sizes
   !-----------------------------------------------------------------------------
 
   integer :: num_surface_forcing_fields
-  integer :: num_interior_forcing_fields_0d
-  integer :: num_interior_forcing_fields_1d
+  integer :: num_interior_forcing_fields
 
 end module marbl_sizes

--- a/src/marbl_sizes.F90
+++ b/src/marbl_sizes.F90
@@ -13,6 +13,7 @@ module marbl_sizes
   integer(int_kind), parameter :: ecosys_base_tracer_cnt = ECOSYS_NT
   integer(int_kind), parameter :: ciso_tracer_cnt = 14
   integer(int_kind)            :: marbl_total_tracer_cnt = 0
+  integer(int_kind)            :: tracer_restore_cnt = 0
 
 
   !-----------------------------------------------------------------------------

--- a/tests/driver_src/marbl.F90
+++ b/tests/driver_src/marbl.F90
@@ -135,9 +135,9 @@ Program marbl
       call driver_status_log%log_noerror('', subname)
       call driver_status_log%log_noerror('Requested surface forcing fields', subname)
       call driver_status_log%log_noerror('---', subname)
-      do n=1,size(marbl_instance%surface_forcing_metadata)
-        write(log_message, "(I0, 2A)") n, '. ',                               &
-          trim(marbl_instance%surface_forcing_metadata(n)%varname)
+      do n=1,size(marbl_instance%surface_input_forcings)
+        write(log_message, "(I0, 2A)") n, '. ', &
+              trim(marbl_instance%surface_input_forcings(n)%metadata%varname)
         call driver_status_log%log_noerror(log_message, subname)
       end do
 
@@ -145,9 +145,9 @@ Program marbl
       call driver_status_log%log_noerror('', subname)
       call driver_status_log%log_noerror('Requested interior forcing fields', subname)
       call driver_status_log%log_noerror('---', subname)
-      do n=1,size(marbl_instance%interior_forcing_metadata)
+      do n=1,size(marbl_instance%interior_input_forcings)
         write(log_message, "(I0, 2A)") n, '. ',                               &
-          trim(marbl_instance%interior_forcing_metadata(n)%varname)
+             trim(marbl_instance%interior_input_forcings(n)%metadata%varname)
         call driver_status_log%log_noerror(log_message, subname)
       end do
     case ('request_restoring')

--- a/tests/driver_src/marbl.F90
+++ b/tests/driver_src/marbl.F90
@@ -49,8 +49,8 @@ Program marbl
   character(len=marbl_nl_buffer_size) :: tmp_nl_buffer
   character(len=marbl_nl_in_size)     :: nl_str, tmp_str
   integer                             :: ioerr=0
-  integer                             :: m, n, nt, restore_nt
-  character(len=256)                  :: testname, log_message
+  integer                             :: m, n, nt, cnt
+  character(len=256)                  :: testname, varname, log_message
   logical                             :: lprint_marbl_log
   logical                             :: lprint_driver_log
 
@@ -154,18 +154,22 @@ Program marbl
       lprint_marbl_log = .false.
       lprint_driver_log = .true.
       call marbl_init_namelist_test(marbl_instance, nl_buffer, nt)
-      !restore_nt = size(marbl_instance%interior_forcing_input%tracer_names)
-      restore_nt = 0
+
       ! Log tracers requested for restoring
       call driver_status_log%log_noerror('', subname)
       call driver_status_log%log_noerror('Requested tracers to restore', subname)
       call driver_status_log%log_noerror('---', subname)
-!      do n=1,restore_nt
-!        write(log_message, "(I0, 2A)") n, '. ',                               &
-!          trim(marbl_instance%interior_forcing_input%tracer_names(n))
-!        call driver_status_log%log_noerror(log_message, subname)
-!      end do
-      if (restore_nt.eq.0) then
+      cnt = 0
+      do n=1,size(marbl_instance%interior_input_forcings)
+        varname = marbl_instance%interior_input_forcings(n)%metadata%varname
+        if (index(varname, 'Restoring').gt.0) then
+          cnt = cnt + 1
+          varname = varname(1:scan(varname,' ')-1)
+          write(log_message, "(I0, 2A)") cnt, '. ', trim(varname)
+      call driver_status_log%log_noerror(log_message, subname)
+        end if
+      end do
+      if (cnt.eq.0) then
         call driver_status_log%log_noerror('No tracers to restore!', subname)
       end if
     case DEFAULT

--- a/tests/driver_src/marbl.F90
+++ b/tests/driver_src/marbl.F90
@@ -130,29 +130,41 @@ Program marbl
       lprint_marbl_log = .false.
       lprint_driver_log = .true.
       call marbl_init_namelist_test(marbl_instance, nl_buffer)
-      ! Log requested forcing fields
+
+      ! Log requested surface forcing fields
       call driver_status_log%log_noerror('', subname)
-      call driver_status_log%log_noerror('Requested forcing fields', subname)
+      call driver_status_log%log_noerror('Requested surface forcing fields', subname)
       call driver_status_log%log_noerror('---', subname)
       do n=1,size(marbl_instance%surface_forcing_metadata)
         write(log_message, "(I0, 2A)") n, '. ',                               &
           trim(marbl_instance%surface_forcing_metadata(n)%varname)
         call driver_status_log%log_noerror(log_message, subname)
       end do
+
+      ! Log requested interior forcing fields
+      call driver_status_log%log_noerror('', subname)
+      call driver_status_log%log_noerror('Requested interior forcing fields', subname)
+      call driver_status_log%log_noerror('---', subname)
+      do n=1,size(marbl_instance%interior_forcing_metadata)
+        write(log_message, "(I0, 2A)") n, '. ',                               &
+          trim(marbl_instance%interior_forcing_metadata(n)%varname)
+        call driver_status_log%log_noerror(log_message, subname)
+      end do
     case ('request_restoring')
       lprint_marbl_log = .false.
       lprint_driver_log = .true.
       call marbl_init_namelist_test(marbl_instance, nl_buffer, nt)
-      restore_nt = size(marbl_instance%interior_forcing_input%tracer_names)
+      !restore_nt = size(marbl_instance%interior_forcing_input%tracer_names)
+      restore_nt = 0
       ! Log tracers requested for restoring
       call driver_status_log%log_noerror('', subname)
       call driver_status_log%log_noerror('Requested tracers to restore', subname)
       call driver_status_log%log_noerror('---', subname)
-      do n=1,restore_nt
-        write(log_message, "(I0, 2A)") n, '. ',                               &
-          trim(marbl_instance%interior_forcing_input%tracer_names(n))
-        call driver_status_log%log_noerror(log_message, subname)
-      end do
+!      do n=1,restore_nt
+!        write(log_message, "(I0, 2A)") n, '. ',                               &
+!          trim(marbl_instance%interior_forcing_input%tracer_names(n))
+!        call driver_status_log%log_noerror(log_message, subname)
+!      end do
       if (restore_nt.eq.0) then
         call driver_status_log%log_noerror('No tracers to restore!', subname)
       end if

--- a/tests/regression_tests/init_from_namelist/marbl_in_with_restore
+++ b/tests/regression_tests/init_from_namelist/marbl_in_with_restore
@@ -4,7 +4,5 @@ testname="init_from_namelist"
 &marbl_config_nml
 /
 &marbl_parms_nml
- rest_time_inv_surf = 2.3e-6
- rest_time_inv_deep = 2.3e-6
  tracer_restore_vars = 'SiO3', 'NO3', 'PO4'
 /

--- a/tests/regression_tests/requested_forcings/marbl_in_with_restore
+++ b/tests/regression_tests/requested_forcings/marbl_in_with_restore
@@ -1,0 +1,11 @@
+&marbl_driver_nml
+testname="request_forcings"
+/
+&marbl_config_nml
+ciso_on=.true.
+/
+&marbl_parms_nml
+ rest_time_inv_surf = 2.3e-6
+ rest_time_inv_deep = 2.3e-6
+ tracer_restore_vars = 'SiO3', 'NO3', 'PO4'
+/

--- a/tests/regression_tests/requested_forcings/marbl_in_with_restore
+++ b/tests/regression_tests/requested_forcings/marbl_in_with_restore
@@ -5,7 +5,5 @@ testname="request_forcings"
 ciso_on=.true.
 /
 &marbl_parms_nml
- rest_time_inv_surf = 2.3e-6
- rest_time_inv_deep = 2.3e-6
  tracer_restore_vars = 'SiO3', 'NO3', 'PO4'
 /


### PR DESCRIPTION
I've generalized the specification of the interior forcing fields (including tracer restoring) in MARBL; at this point in time, I have not made any corresponding changes to POP so this pull request is not ready to be accepted... but I'd like to go over the MARBL changes while I work on the POP branch, in case some of the interface decisions I've made need to be changed.

I'll add a comment to this pull request once POP tests are complete. The stand-alone driver builds and runs on yellowstone (intel and gnu), hobart (nag, intel, and gnu), and my local machine (gnu); the output for the `request_forcings` test (using the `marbl_in_with_restore` namelist) is

```
Requested surface forcing fields
---
1. surface_mask
2. u10_sqr
3. sss
4. sst
5. Ice Fraction
6. Dust Flux
7. Iron Flux
8. NOx Flux
9. NHy Flux
10. DIN River Flux
11. DIP River Flux
12. DON River Flux
13. DOP River Flux
14. DSi River Flux
15. DFe River Flux
16. DIC River Flux
17. ALK River Flux
18. DOC River Flux
19. Atmospheric Pressure
20. xco2
21. xco2_alt_co2
22. d13c
23. d14c
24. d14c_gloavg

Requested interior forcing fields
---
1. Dust Flux
2. PAR Column Fraction
3. Surface Shortwave
4. Temperature
5. Salinity
6. Pressure
7. Iron Sediment Flux
8. PO4 Restoring
9. NO3 Restoring
10. SiO3 Restoring
```

The `request_restore` test currently does not work; given the appearance of restoring in the above output, maybe it's no longer needed? Alternatively, I need to rework the logic to list the requested tracers for restoring.
