### PR TITLE
Remove "dz" variable in favor of delta_z

### DIFF
--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -258,7 +258,7 @@ contains
        gcm_num_PAR_subcols,               &
        gcm_num_elements_interior_forcing, &
        gcm_num_elements_surface_forcing,  &
-       gcm_dz,                            &
+       gcm_delta_z,                       &
        gcm_zw,                            &
        gcm_zt,                            &
        gcm_nl_buffer,                     &
@@ -286,7 +286,7 @@ contains
     integer   (int_kind)                   , intent(in)    :: gcm_num_PAR_subcols
     integer   (int_kind)                   , intent(in)    :: gcm_num_elements_surface_forcing
     integer   (int_kind)                   , intent(in)    :: gcm_num_elements_interior_forcing
-    real      (r8)                         , intent(in)    :: gcm_dz(gcm_num_levels) ! thickness of layer k
+    real      (r8)                         , intent(in)    :: gcm_delta_z(gcm_num_levels) ! thickness of layer k
     real      (r8)                         , intent(in)    :: gcm_zw(gcm_num_levels) ! thickness of layer k
     real      (r8)                         , intent(in)    :: gcm_zt(gcm_num_levels) ! thickness of layer k
     character(marbl_nl_buffer_size), optional, intent(in)  :: gcm_nl_buffer(:)
@@ -365,7 +365,7 @@ contains
          num_PAR_subcols               = num_PAR_subcols,       &
          num_elements_surface_forcing  = num_surface_elements,  &
          num_elements_interior_forcing = num_interior_elements, &
-         dz                            = gcm_dz,                &
+         delta_z                       = gcm_delta_z,           &
          zw                            = gcm_zw,                &
          zt                            = gcm_zt)
 

--- a/src/marbl_interface_types.F90
+++ b/src/marbl_interface_types.F90
@@ -61,7 +61,6 @@ module marbl_interface_types
      real(r8), allocatable :: zt(:)                         ! (km) vert dist from sfc to midpoint of layer
      real(r8), allocatable :: zw(:)                         ! (km) vert dist from sfc to bottom of layer
      real(r8), allocatable :: delta_z(:)                    ! (km) delta z - different values for partial bottom cells
-     real(r8), allocatable :: dz(:)                         ! (km) delta z - same values for partial bottom cells
    contains
      procedure, public :: construct => marbl_domain_constructor
   end type marbl_domain_type
@@ -203,21 +202,19 @@ contains
   subroutine marbl_domain_constructor(this, &
        num_levels, num_PAR_subcols, &
        num_elements_surface_forcing, num_elements_interior_forcing, &
-       dz, zw, zt)
+       delta_z, zw, zt)
 
     class(marbl_domain_type), intent(inout) :: this
     integer (int_kind) , intent(in) :: num_levels
     integer (int_kind) , intent(in) :: num_PAR_subcols
     integer (int_kind) , intent(in) :: num_elements_surface_forcing
     integer (int_kind) , intent(in) :: num_elements_interior_forcing
-    real (r8)          , intent(in) :: dz(num_levels)
+    real (r8)          , intent(in) :: delta_z(num_levels)
     real (r8)          , intent(in) :: zw(num_levels)
     real (r8)          , intent(in) :: zt(num_levels)
 
     integer :: k
 
-    ! FIXME #24: remove dz from data type, use delta_z for all vertical depths
-    allocate(this%dz(num_levels))
     allocate(this%delta_z(num_levels))
     allocate(this%zw(num_levels))
     allocate(this%zt(num_levels))
@@ -228,8 +225,7 @@ contains
     this%num_elements_interior_forcing = num_elements_interior_forcing
 
     do k = 1, num_levels
-       this%delta_z(k) = dz(k)
-       this%dz(k)      = dz(k)
+       this%delta_z(k) = delta_z(k)
        this%zw(k)      = zw(k)
        this%zt(k)      = zt(k)
     end do

--- a/tests/driver_src/marbl_get_put_drv.F90
+++ b/tests/driver_src/marbl_get_put_drv.F90
@@ -26,15 +26,15 @@ Contains
     type(marbl_log_type),        intent(inout) :: marbl_status_log
 
     character(*), parameter      :: subname = 'marbl_get_put_drv:test'
-    real(kind=r8), dimension(km) :: dz, zw, zt
+    real(kind=r8), dimension(km) :: delta_z, zw, zt
     integer                      :: k
 
     ! Initialize levels
-    dz = c1
-    zw(1) = dz(1)
-    zt(1) = p5*dz(1)
+    delta_z = c1
+    zw(1) = delta_z(1)
+    zt(1) = p5*delta_z(1)
     do k=2,km
-      zw(k) = zw(k-1) + dz(k)
+      zw(k) = zw(k-1) + delta_z(k)
       zt(k) = p5*(zw(k-1)+zw(k))
     end do
 
@@ -72,7 +72,7 @@ Contains
                              gcm_num_PAR_subcols = 1,                         &
                              gcm_num_elements_interior_forcing = 1,           &
                              gcm_num_elements_surface_forcing = 1,            &
-                             gcm_dz = dz,                                     &
+                             gcm_delta_z = delta_z,                           &
                              gcm_zw = zw,                                     &
                              gcm_zt = zt)
     if (marbl_instance%StatusLog%labort_marbl) then

--- a/tests/driver_src/marbl_init_namelist_drv.F90
+++ b/tests/driver_src/marbl_init_namelist_drv.F90
@@ -21,15 +21,15 @@ Contains
     integer, intent(inout),  optional             :: nt
 
     character(*), parameter      :: subname = 'marbl_init_namelist_drv:test'
-    real(kind=r8), dimension(km) :: dz, zw, zt
+    real(kind=r8), dimension(km) :: delta_z, zw, zt
     integer                      :: k
 
     ! Initialize levels
-    dz = c1
-    zw(1) = dz(1)
-    zt(1) = p5*dz(1)
+    delta_z = c1
+    zw(1) = delta_z(1)
+    zt(1) = p5*delta_z(1)
     do k=2,km
-      zw(k) = zw(k-1) + dz(k)
+      zw(k) = zw(k-1) + delta_z(k)
       zt(k) = p5*(zw(k-1)+zw(k))
     end do
 
@@ -47,7 +47,7 @@ Contains
                              gcm_num_PAR_subcols = 1,                         &
                              gcm_num_elements_interior_forcing = 1,           &
                              gcm_num_elements_surface_forcing = 1,            &
-                             gcm_dz = dz,                                     &
+                             gcm_delta_z = delta_z,                           &
                              gcm_zw = zw,                                     &
                              gcm_zt = zt,                                     &
                              gcm_nl_buffer = gcm_namelist,                    &

--- a/tests/driver_src/marbl_init_no_namelist_drv.F90
+++ b/tests/driver_src/marbl_init_no_namelist_drv.F90
@@ -19,15 +19,15 @@ Contains
     type(marbl_interface_class), intent(inout) :: marbl_instance
 
     character(*), parameter      :: subname = 'marbl_init_no_namelist_drv:test'
-    real(kind=r8), dimension(km) :: dz, zw, zt
+    real(kind=r8), dimension(km) :: delta_z, zw, zt
     integer                      :: k
 
     ! Initialize levels
-    dz = c1
-    zw(1) = dz(1)
-    zt(1) = p5*dz(1)
+    delta_z = c1
+    zw(1) = delta_z(1)
+    zt(1) = p5*delta_z(1)
     do k=2,km
-      zw(k) = zw(k-1) + dz(k)
+      zw(k) = zw(k-1) + delta_z(k)
       zt(k) = p5*(zw(k-1)+zw(k))
     end do
 
@@ -50,7 +50,7 @@ Contains
                              gcm_num_PAR_subcols = 1,                         &
                              gcm_num_elements_interior_forcing = 1,           &
                              gcm_num_elements_surface_forcing = 1,            &
-                             gcm_dz = dz,                                     &
+                             gcm_delta_z = delta_z,                           &
                              gcm_zw = zw,                                     &
                              gcm_zt = zt)
     if (marbl_instance%StatusLog%labort_marbl) then


### PR DESCRIPTION
This addresses issue #24, that the domain type does not need both dz and
delta_z. For the fix, I changed all instances of dz on the interface to
delta_z -- this is in marbl_domain_type and also the calls to init().

Note that there will be a small in POP as well (the call to `marbl_instances(iblock)%init()` requires `gcm_delta_z` rather than `gcm_dz`); I need to add that change to marbl_dev_levy before accepting this pull request.