### PR TITLE
Remove locmip_k1_k2_bug_fix from config

### DIFF
--- a/src/marbl_co2calc_mod.F90
+++ b/src/marbl_co2calc_mod.F90
@@ -187,7 +187,7 @@ contains
 
     if (lcomp_co3_coeffs) then
        call marbl_comp_co3_coeffs(num_elements, mask, pressure_correct, &
-            temp, salt, press_bar, co3_coeffs, k1_k2_pH_tot=.true.)
+            temp, salt, press_bar, co3_coeffs)
     end if
 
     !---------------------------------------------------------------------------
@@ -357,7 +357,7 @@ contains
 
     if (lcomp_co3_coeffs) then
        call marbl_comp_co3_coeffs(num_elements, mask, pressure_correct, &
-            temp, salt, press_bar, co3_coeffs, k1_k2_pH_tot=.true.)
+            temp, salt, press_bar, co3_coeffs)
     end if
 
     !------------------------------------------------------------------------
@@ -414,7 +414,7 @@ contains
 
   subroutine marbl_comp_co3_coeffs(&
        num_elements, mask, pressure_correct, &
-       temp, salt, press_bar, co3_coeffs, k1_k2_pH_tot)
+       temp, salt, press_bar, co3_coeffs)
 
     !---------------------------------------------------------------------------
     ! FIXME #20: the computations for the individual constants need to
@@ -429,7 +429,6 @@ contains
     real(kind=r8)                         , intent(in)  :: temp(num_elements)      ! temperature (degrees c)
     real(kind=r8)                         , intent(in)  :: salt(num_elements)      ! salinity (psu)
     real(kind=r8)                         , intent(in)  :: press_bar(num_elements) ! pressure at level (bars)
-    logical(kind=log_kind)                , intent(in)  :: k1_k2_pH_tot
     type(thermodynamic_coefficients_type) , intent(out) :: co3_coeffs(num_elements)
 
     !---------------------------------------------------------------------------
@@ -534,7 +533,6 @@ contains
     !---------------------------------------------------------------------------
     !   k1 = [H][HCO3]/[H2CO3]
     !   k2 = [H][CO3]/[HCO3]
-    !   if k1_k2_pH_tot == .true., then use
     !      Lueker, Dickson, Keeling (2000) using Mehrbach et al. data on total scale
     !   otherwise, use
     !      Millero p.664 (1995) using Mehrbach et al. data on seawater scale
@@ -546,17 +544,10 @@ contains
     !      w/ typo corrections from CO2SYS
     !---------------------------------------------------------------------------
 
-    if (k1_k2_pH_tot) then
-       ! total pH scale
-       arg = 3633.86_r8 * invtk - 61.2172_r8 + &
-            9.67770_r8 * dlogtk - 0.011555_r8 * salt_lim + &
-            0.0001152_r8 * s2
-    else
-       ! seawater pH scale, see comment above
-       arg = 3670.7_r8 * invtk - 62.008_r8 + &
-            9.7944_r8 * dlogtk - 0.0118_r8 * salt_lim + &
-            0.000116_r8 * s2
-    end if
+    ! total pH scale
+    arg = 3633.86_r8 * invtk - 61.2172_r8 + &
+          9.67770_r8 * dlogtk - 0.011555_r8 * salt_lim + &
+          0.0001152_r8 * s2
     arg = -LOG(c10) * arg
     call vmath_exp(arg, k1, num_elements)
 
@@ -566,15 +557,9 @@ contains
          Kappa_coefs = (/-3.08_r8, 0.0877_r8, c0/),            &
          therm_coef = k1)
 
-    if (k1_k2_pH_tot) then
-       ! total pH scale
-       arg = 471.78_r8 * invtk + 25.9290_r8 - &
-            3.16967_r8 * dlogtk - 0.01781_r8 * salt_lim + 0.0001122_r8 * s2
-    else
-       ! seawater pH scale, see comment above
-       arg = 1394.7_r8 * invtk + 4.777_r8 - &
-            0.0184_r8 * salt_lim + 0.000118_r8 * s2
-    end if
+    ! total pH scale
+    arg = 471.78_r8 * invtk + 25.9290_r8 - &
+          3.16967_r8 * dlogtk - 0.01781_r8 * salt_lim + 0.0001122_r8 * s2
     arg = -LOG(c10) * arg
     call vmath_exp(arg, k2, num_elements)
 

--- a/src/marbl_config_mod.F90
+++ b/src/marbl_config_mod.F90
@@ -35,7 +35,6 @@ module marbl_config_mod
   logical(log_kind), target :: lflux_gas_o2                   ! controls which portion of code are executed usefull for debugging
   logical(log_kind), target :: lflux_gas_co2                  ! controls which portion of code are executed usefull for debugging
   logical(log_kind), target :: lapply_nhx_surface_emis        ! control if NHx emissions are applied to marbl NH4 tracer
-  logical(log_kind), target :: locmip_k1_k2_bug_fix
   type(autotroph_config_type), dimension(autotroph_cnt), target :: autotrophs_config
   type(zooplankton_config_type), dimension(zooplankton_cnt), target :: zooplankton_config
   type(grazing_config_type), dimension(grazer_prey_cnt, zooplankton_cnt), target :: grazing_config
@@ -135,7 +134,6 @@ contains
     lflux_gas_o2                  = .true.
     lflux_gas_co2                 = .true.
     lapply_nhx_surface_emis       = .false.
-    locmip_k1_k2_bug_fix          = .true.
     init_bury_coeff_opt           = 'nml'
     ladjust_bury_coeff            = .false.
 
@@ -223,7 +221,7 @@ contains
          ciso_on, lsource_sink, ciso_lsource_sink, lecovars_full_depth_tavg,  &
          ciso_lecovars_full_depth_tavg,                                       &
          lflux_gas_o2, lflux_gas_co2, lapply_nhx_surface_emis,                &
-         locmip_k1_k2_bug_fix, init_bury_coeff_opt, ladjust_bury_coeff,       &
+         init_bury_coeff_opt, ladjust_bury_coeff,                             &
          autotrophs_config, zooplankton_config, grazing_config
 
     !-----------------------------------------------------------------------
@@ -373,19 +371,6 @@ contains
     datatype  = 'logical'
     group     = 'marbl_config_nml'
     lptr      => lapply_nhx_surface_emis
-    call this%add_var(sname, lname, units, datatype, group,                 &
-                        marbl_status_log, lptr=lptr)
-    if (marbl_status_log%labort_marbl) then
-      call log_add_var_error(marbl_status_log, sname, subname)
-      return
-    end if
-
-    sname     = 'locmip_k1_k2_bug_fix'
-    lname     = 'Fix bug that was in code in OCMIP runs?'
-    units     = 'unitless'
-    datatype  = 'logical'
-    group     = 'marbl_config_nml'
-    lptr      => locmip_k1_k2_bug_fix
     call this%add_var(sname, lname, units, datatype, group,                 &
                         marbl_status_log, lptr=lptr)
     if (marbl_status_log%labort_marbl) then


### PR DESCRIPTION
MARBL should not be run with this variable set to `.false.` so I removed the
variable and changed the code to only follow the `.true.` path.

Note that this update also removes the `k1_k2_pH_tot` variable from
`marbl_comp_co3_coeffs()` as that variable is also always set to .true.

There is a required fix in POP as well (removing `locmip_k1_k2_bug_fix` from `&marbl_config_nml` in the `build-namelist` tool).

@klindsay28 -- did you already include a fix for this on your science branch? If so, this pull request can be disregarded.