### PR TITLE
Stand-alone MARBL supported on cheyenne

### DIFF
--- a/tests/python_for_tests/machines.py
+++ b/tests/python_for_tests/machines.py
@@ -4,6 +4,7 @@ from os import system as sh_command
 # Supported machines for running MARBL tests
 supported_machines = ['local-gnu', 
                       'yellowstone',
+                      'cheyenne',
                       'hobart',
                       'edison']
 
@@ -20,6 +21,13 @@ def load_module(mach, compiler):
     module('load', compiler)
     module('load', 'ncarcompilers')
     module('load', 'ncarbinlibs')
+
+  if mach == 'cheyenne':
+    sys.path.insert(0,'/glade/u/apps/ch/opt/lmod/7.2.1/lmod/lmod/init')
+    from env_modules_python import module
+    module('purge')
+    module('load', compiler)
+    module('load', 'ncarcompilers')
 
   if mach == 'hobart':
     sys.path.insert(0,'/usr/share/Modules/init')
@@ -50,6 +58,12 @@ def machine_specific(mach, supported_compilers):
     sys.exit(1)
 
   if mach == 'yellowstone':
+    # NCAR machine
+    supported_compilers.append('intel')
+    supported_compilers.append('gnu')
+    return
+
+  if mach == 'cheyenne':
     # NCAR machine
     supported_compilers.append('intel')
     supported_compilers.append('gnu')

--- a/tests/python_for_tests/marbl_testing_class.py
+++ b/tests/python_for_tests/marbl_testing_class.py
@@ -67,6 +67,8 @@ class MARBL_testcase(object):
       found = True
       if any(host in self._hostname for host in ['geyser', 'caldera', 'prong', 'yslogin']):
         self._machine = 'yellowstone'
+      elif 'cheyenne' in self._hostname:
+        self._machine = 'cheyenne'
       elif 'hobart' in self._hostname:
         self._machine = 'hobart'
       elif 'edison' in self._hostname:


### PR DESCRIPTION
New NCAR computer is up and running, and now we can run the MARBL stand-alone
tests on it.