### PR TITLE
Bugfix/better logging

### DIFF
--- a/src/marbl_co2calc_mod.F90
+++ b/src/marbl_co2calc_mod.F90
@@ -937,26 +937,32 @@ contains
 
        do c = 1,num_elements
           if (mask(c)) then
+             ! Log a warning message if bounding box end points have same sign
+             ! (no guarantee that there is a root on the interval)
              if (present(marbl_status_log)) then
                 ! FIXME #21: make marbl_status_log required - this is currently needed
                 !            since abio_dic_dic14_mod is calling this routine but has
                 !            not itself been MARBLized yet
-                WRITE(log_message,"(4A,I0,A,I0,A,I0)") '(', subname, ') ', &
-                     ', c = ', c, ', it = ', it
-                call marbl_status_log%log_noerror(log_message, subname, c, .true.)
-                WRITE(log_message,"(4A,2E15.7e3)") '(', subname, ') ', &
-                     '   x1,f = ', x1(c), flo(c)
-                call marbl_status_log%log_noerror(log_message, subname, c, .true.)
-                WRITE(log_message,"(4A,2E15.7e3)") '(', subname, ') ', &
-                     '   x2,f = ', x2(c), fhi(c)
-                call marbl_status_log%log_noerror(log_message, subname, c, .true.)
+                WRITE(log_message,"(3A,1X,A,I0,1X,I0)") '(', subname, ')', &
+                     'c, it = ', c, it
+                call marbl_status_log%log_noerror(log_message, subname, c, &
+                                lonly_master_writes=.false.)
+                WRITE(log_message,"(3A,1X,A,2E15.7e3)") '(', subname, ')', &
+                     'x1,f = ', x1(c), flo(c)
+                call marbl_status_log%log_noerror(log_message, subname,    &
+                                lonly_master_writes=.false.)
+                WRITE(log_message,"(3A,1X,A,2E15.7e3)") '(', subname, ')', &
+                     'x2,f = ', x2(c), fhi(c)
+                call marbl_status_log%log_noerror(log_message, subname,    &
+                                lonly_master_writes=.false.)
              end if
 
+             ! Error if iteration count exceeds max_bracket_grow_it
              if (it > max_bracket_grow_it) then
                 if (present(marbl_status_log)) then
                    ! FIXME #21 (see above)
                    log_message = "bounding bracket for pH solution not found"
-                   call marbl_status_log%log_error(log_message, subname, c)
+                   call marbl_status_log%log_error(log_message, subname)
                 end if
                 abort = .true.
              end if

--- a/src/marbl_co2calc_mod.F90
+++ b/src/marbl_co2calc_mod.F90
@@ -907,7 +907,7 @@ contains
     character(*), parameter :: subname = 'marbl_co2calc_mod:drtsafe'
     character(len=char_len) :: log_message
     logical(kind=log_kind)                          :: leave_bracket, dx_decrease
-    logical(kind=log_kind)                          :: abort = .false.
+    logical(kind=log_kind)                          :: abort
     logical(kind=log_kind), dimension(num_elements) :: mask
     integer(kind=int_kind)                          :: c, it
     real(kind=r8)                                   :: temp
@@ -919,6 +919,7 @@ contains
     !---------------------------------------------------------------------------
 
     mask = mask_in
+    abort = .false.
 
     it = 0
 
@@ -943,8 +944,7 @@ contains
                 ! FIXME #21: make marbl_status_log required - this is currently needed
                 !            since abio_dic_dic14_mod is calling this routine but has
                 !            not itself been MARBLized yet
-                WRITE(log_message,"(3A,1X,A,I0,1X,I0)") '(', subname, ')', &
-                     'c,it = ', c, it
+                WRITE(log_message,"(3A,1X,A,I0)") '(', subname, ')', 'it = ', it
                 call marbl_status_log%log_noerror(log_message, subname, c, &
                                 lonly_master_writes=.false.)
                 WRITE(log_message,"(3A,1X,A,2E15.7e3)") '(', subname, ')', &

--- a/src/marbl_co2calc_mod.F90
+++ b/src/marbl_co2calc_mod.F90
@@ -944,16 +944,16 @@ contains
                 !            since abio_dic_dic14_mod is calling this routine but has
                 !            not itself been MARBLized yet
                 WRITE(log_message,"(3A,1X,A,I0,1X,I0)") '(', subname, ')', &
-                     'c, it = ', c, it
+                     'c,it = ', c, it
                 call marbl_status_log%log_noerror(log_message, subname, c, &
                                 lonly_master_writes=.false.)
                 WRITE(log_message,"(3A,1X,A,2E15.7e3)") '(', subname, ')', &
                      'x1,f = ', x1(c), flo(c)
-                call marbl_status_log%log_noerror(log_message, subname,    &
+                call marbl_status_log%log_noerror(log_message, subname, c, &
                                 lonly_master_writes=.false.)
                 WRITE(log_message,"(3A,1X,A,2E15.7e3)") '(', subname, ')', &
                      'x2,f = ', x2(c), fhi(c)
-                call marbl_status_log%log_noerror(log_message, subname,    &
+                call marbl_status_log%log_noerror(log_message, subname, c, &
                                 lonly_master_writes=.false.)
              end if
 
@@ -962,7 +962,7 @@ contains
                 if (present(marbl_status_log)) then
                    ! FIXME #21 (see above)
                    log_message = "bounding bracket for pH solution not found"
-                   call marbl_status_log%log_error(log_message, subname)
+                   call marbl_status_log%log_error(log_message, subname, c)
                 end if
                 abort = .true.
              end if

--- a/src/marbl_logging.F90
+++ b/src/marbl_logging.F90
@@ -58,9 +58,9 @@ module marbl_logging
   !****************************************************************************
 
   type, public :: marbl_status_log_entry_type
-    integer :: ElementInd
-    logical :: lall_tasks  ! True => message should be written to stdout by
-                           !         all tasks; False => master task only
+    integer :: ElementInd = -1      ! ElementInd < 0 implies no location data
+    logical :: lonly_master_writes  ! True => message should be written to stdout
+                           !                  master task; False => all tasks
     character(len=marbl_log_len) :: LogMessage   ! Message text
     character(len=char_len)      :: CodeLocation ! Information on where log was written
 
@@ -194,12 +194,12 @@ contains
     if (present(ElemInd)) then
       new_entry%ElementInd = ElemInd
     else
-      new_entry%ElementInd = 1
+      new_entry%ElementInd = -1
     end if
     write(new_entry%LogMessage, "(4A)") "MARBL ERROR (", trim(CodeLoc), "): ", &
                                         trim(ErrorMsg)
     new_entry%CodeLocation = trim(CodeLoc)
-    new_entry%lall_tasks = .true.
+    new_entry%lonly_master_writes = .false.
 
     if (associated(this%FullLog)) then
       ! Append new entry to last entry in the log
@@ -214,7 +214,7 @@ contains
 
   !****************************************************************************
 
-  subroutine marbl_log_noerror(this, StatusMsg, CodeLoc, ElemInd, lall_tasks)
+  subroutine marbl_log_noerror(this, StatusMsg, CodeLoc, ElemInd, lonly_master_writes)
 
     class(marbl_log_type), intent(inout) :: this
     ! StatusMsg is the message to be printed in the log; it does not need to
@@ -222,10 +222,10 @@ contains
     ! CodeLoc is the name of the subroutine that is calling StatusLog%log_noerror
     character(len=*),      intent(in)    :: StatusMsg, CodeLoc
     integer, optional,     intent(in)    :: ElemInd
-    ! If lall_tasks is .true., then this is a message that should be printed out
-    ! regardless of which task produced it. By default, MARBL assumes that only
-    ! the master task needs to print a message
-    logical, optional,     intent(in)    :: lall_tasks
+    ! If lonly_master_writes is .false., then this is a message that should be
+    ! printed out regardless of which task produced it. By default, MARBL assumes
+    ! that only the master task needs to print a message
+    logical, optional,     intent(in)    :: lonly_master_writes
     type(marbl_status_log_entry_type), pointer :: new_entry
 
     ! Only allocate memory and add entry if we want to log full namelist!
@@ -238,14 +238,14 @@ contains
     if (present(ElemInd)) then
       new_entry%ElementInd = ElemInd
     else
-      new_entry%ElementInd = 1
+      new_entry%ElementInd = -1
     end if
     new_entry%LogMessage   = trim(StatusMsg)
     new_entry%CodeLocation = trim(CodeLoc)
-    if (present(lall_tasks)) then
-      new_entry%lall_tasks = lall_tasks
+    if (present(lonly_master_writes)) then
+      new_entry%lonly_master_writes = lonly_master_writes
     else
-      new_entry%lall_tasks = .false.
+      new_entry%lonly_master_writes = .true.
     end if
 
     if (associated(this%FullLog)) then

--- a/tests/driver_src/marbl.F90
+++ b/tests/driver_src/marbl.F90
@@ -229,7 +229,7 @@ Contains
 
     tmp => log_to_print%FullLog
     do while (associated(tmp))
-      if (mpi_on.and.(marbl_err.or.tmp%lall_tasks)) then
+      if (mpi_on .and. (marbl_err .or. (.not. tmp%lonly_master_writes))) then
         ! Output log from task(s) reporting errors, prefix task #
         write(*,101) my_task, trim(tmp%LogMessage)
       elseif (my_task.eq.0) then


### PR DESCRIPTION
A couple of improvements to message logging:

1. Clearer variable name (`lonly_master_writes = .true.` instead of `lall_tasks = .false.` if a message only needs to be written once)
1. Bugfix in logging location of error from `marbl_co2calc_mod::drtsafe` -- had previously been referencing `c` outside of the `do`-loop it indexed

Also tried to add a few comments to explain what was being added to the log in `drtsafe()`