### PR TITLE
Enhancement/remove non living tracer cnt

### DIFF
--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -559,7 +559,7 @@ contains
     call this%interior_forcing_ind%construct(this%tracer_metadata%short_name, &
                                    tracer_restore_vars, this%StatusLog)
     if (this%StatusLog%labort_marbl) then
-      call this%StatusLog%log_error_trace("itnerior_forcing_ind%construct",   &
+      call this%StatusLog%log_error_trace("interior_forcing_ind%construct",   &
                                           subname)
       return
     end if

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -2661,8 +2661,8 @@ contains
 
   !***********************************************************************
 
-  subroutine marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices,   &
-             n, short_name, long_name, marbl_tracer_metadata)
+  subroutine marbl_init_non_autotroph_tracer_metadata(short_name, long_name, &
+                                                      marbl_tracer_metadata)
 
     !-----------------------------------------------------------------------
     !  initialize non-autotroph tracer_d values and accumulate
@@ -2671,30 +2671,22 @@ contains
 
     implicit none
 
-    type(marbl_tracer_index_type),    intent(in)    :: marbl_tracer_indices
-    integer(int_kind),                intent(in)    :: n
     character(len=*),                 intent(in)    :: short_name
     character(len=*),                 intent(in)    :: long_name
     type(marbl_tracer_metadata_type), intent(inout) :: marbl_tracer_metadata
 
-    associate(&
-         alk_ind           => marbl_tracer_indices%alk_ind,         &
-         alk_alt_co2_ind   => marbl_tracer_indices%alk_alt_co2_ind  &
-             )
-
-      marbl_tracer_metadata%short_name = short_name
-      marbl_tracer_metadata%long_name  = long_name
-      if (n == alk_ind .or. n == alk_alt_co2_ind) then
-         marbl_tracer_metadata%units      = 'meq/m^3'
-         marbl_tracer_metadata%tend_units = 'meq/m^3/s'
-         marbl_tracer_metadata%flux_units = 'meq/m^3 cm/s'
-      else
-         marbl_tracer_metadata%units      = 'mmol/m^3'
-         marbl_tracer_metadata%tend_units = 'mmol/m^3/s'
-         marbl_tracer_metadata%flux_units = 'mmol/m^3 cm/s'
-      endif
-
-    end associate
+    marbl_tracer_metadata%short_name = short_name
+    marbl_tracer_metadata%long_name  = long_name
+    if ((trim(short_name) == "ALK") .or. &
+        (trim(short_name) == "ALK_ALT_CO2")) then
+       marbl_tracer_metadata%units      = 'meq/m^3'
+       marbl_tracer_metadata%tend_units = 'meq/m^3/s'
+       marbl_tracer_metadata%flux_units = 'meq/m^3 cm/s'
+    else
+       marbl_tracer_metadata%units      = 'mmol/m^3'
+       marbl_tracer_metadata%tend_units = 'mmol/m^3/s'
+       marbl_tracer_metadata%flux_units = 'mmol/m^3 cm/s'
+    endif
 
   end subroutine marbl_init_non_autotroph_tracer_metadata
 
@@ -2713,63 +2705,41 @@ contains
     type(marbl_tracer_metadata_type) , intent(inout) :: marbl_tracer_metadata(:)             ! descriptors for each tracer
     type(marbl_tracer_index_type)    , intent(in)    :: marbl_tracer_indices
 
-    associate(&
-         po4_ind           => marbl_tracer_indices%po4_ind,         &
-         no3_ind           => marbl_tracer_indices%no3_ind,         &
-         sio3_ind          => marbl_tracer_indices%sio3_ind,        &
-         nh4_ind           => marbl_tracer_indices%nh4_ind,         &
-         fe_ind            => marbl_tracer_indices%fe_ind,          &
-         lig_ind           => marbl_tracer_indices%lig_ind,         &
-         o2_ind            => marbl_tracer_indices%o2_ind,          &
-         dic_ind           => marbl_tracer_indices%dic_ind,         &
-         dic_alt_co2_ind   => marbl_tracer_indices%dic_alt_co2_ind, &
-         alk_ind           => marbl_tracer_indices%alk_ind,         &
-         alk_alt_co2_ind   => marbl_tracer_indices%alk_alt_co2_ind, &
-         doc_ind           => marbl_tracer_indices%doc_ind,         &
-         don_ind           => marbl_tracer_indices%don_ind,         &
-         dop_ind           => marbl_tracer_indices%dop_ind,         &
-         dopr_ind          => marbl_tracer_indices%dopr_ind,        &
-         donr_ind          => marbl_tracer_indices%donr_ind,        &
-         docr_ind          => marbl_tracer_indices%docr_ind         &
-             )
+    call marbl_init_non_autotroph_tracer_metadata('PO4', 'Dissolved Inorganic Phosphate', &
+               marbl_tracer_metadata(marbl_tracer_indices%po4_ind))
+    call marbl_init_non_autotroph_tracer_metadata('NO3', 'Dissolved Inorganic Nitrate',   &
+               marbl_tracer_metadata(marbl_tracer_indices%no3_ind))
+    call marbl_init_non_autotroph_tracer_metadata('SiO3', 'Dissolved Inorganic Silicate', &
+               marbl_tracer_metadata(marbl_tracer_indices%sio3_ind))
+    call marbl_init_non_autotroph_tracer_metadata('NH4', 'Dissolved Ammonia',             &
+               marbl_tracer_metadata(marbl_tracer_indices%nh4_ind))
+    call marbl_init_non_autotroph_tracer_metadata('Fe', 'Dissolved Inorganic Iron',       &
+               marbl_tracer_metadata(marbl_tracer_indices%fe_ind))
+    call marbl_init_non_autotroph_tracer_metadata('Lig', 'Iron Binding Ligand',           &
+               marbl_tracer_metadata(marbl_tracer_indices%lig_ind))
+    call marbl_init_non_autotroph_tracer_metadata('O2', 'Dissolved Oxygen',               &
+               marbl_tracer_metadata(marbl_tracer_indices%o2_ind))
+    call marbl_init_non_autotroph_tracer_metadata('DIC', 'Dissolved Inorganic Carbon',    &
+               marbl_tracer_metadata(marbl_tracer_indices%dic_ind))
+    call marbl_init_non_autotroph_tracer_metadata('ALK', 'Alkalinity',                    &
+               marbl_tracer_metadata(marbl_tracer_indices%alk_ind))
+    call marbl_init_non_autotroph_tracer_metadata('DOC', 'Dissolved Organic Carbon',      &
+               marbl_tracer_metadata(marbl_tracer_indices%doc_ind))
+    call marbl_init_non_autotroph_tracer_metadata('DON', 'Dissolved Organic Nitrogen',    &
+               marbl_tracer_metadata(marbl_tracer_indices%don_ind))
+    call marbl_init_non_autotroph_tracer_metadata('DOP', 'Dissolved Organic Phosphorus',  &
+               marbl_tracer_metadata(marbl_tracer_indices%dop_ind))
+    call marbl_init_non_autotroph_tracer_metadata('DOPr', 'Refractory DOP',               &
+               marbl_tracer_metadata(marbl_tracer_indices%dopr_ind))
+    call marbl_init_non_autotroph_tracer_metadata('DONr', 'Refractory DON',               &
+               marbl_tracer_metadata(marbl_tracer_indices%donr_ind))
+    call marbl_init_non_autotroph_tracer_metadata('DOCr', 'Refractory DOC',               &
+               marbl_tracer_metadata(marbl_tracer_indices%docr_ind))
 
-    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices, po4_ind, 'PO4',   &
-               'Dissolved Inorganic Phosphate', marbl_tracer_metadata(po4_ind))
-    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices, no3_ind, 'NO3',   &
-               'Dissolved Inorganic Nitrate', marbl_tracer_metadata(no3_ind))
-    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices, sio3_ind, 'SiO3', &
-               'Dissolved Inorganic Silicate', marbl_tracer_metadata(sio3_ind))
-    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices, nh4_ind, 'NH4',   &
-               'Dissolved Ammonia', marbl_tracer_metadata(nh4_ind))
-    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices, fe_ind, 'Fe',     &
-               'Dissolved Inorganic Iron', marbl_tracer_metadata(fe_ind))
-    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices, lig_ind, 'Lig',   &
-               'Iron Binding Ligand', marbl_tracer_metadata(lig_ind))
-    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices, o2_ind, 'O2',     &
-               'Dissolved Oxygen', marbl_tracer_metadata(o2_ind))
-    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices, dic_ind, 'DIC',   &
-               'Dissolved Inorganic Carbon', marbl_tracer_metadata(dic_ind))
-    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices, alk_ind, 'ALK',   &
-               'Alkalinity', marbl_tracer_metadata(alk_ind))
-    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices, doc_ind, 'DOC',   &
-               'Dissolved Organic Carbon', marbl_tracer_metadata(doc_ind))
-    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices, don_ind, 'DON',   &
-               'Dissolved Organic Nitrogen', marbl_tracer_metadata(don_ind))
-    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices, dop_ind, 'DOP',   &
-               'Dissolved Organic Phosphorus', marbl_tracer_metadata(dop_ind))
-    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices, dopr_ind, 'DOPr', &
-               'Refractory DOP', marbl_tracer_metadata(dopr_ind))
-    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices, donr_ind, 'DONr', &
-               'Refractory DON', marbl_tracer_metadata(donr_ind))
-    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices, docr_ind, 'DOCr', &
-               'Refractory DOC', marbl_tracer_metadata(docr_ind))
-
-    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices, dic_alt_co2_ind, 'DIC_ALT_CO2', &
-               'Dissolved Inorganic Carbon, Alternative CO2', marbl_tracer_metadata(dic_alt_co2_ind))
-    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices, alk_alt_co2_ind, 'ALK_ALT_CO2', &
-               'Alkalinity, Alternative CO2', marbl_tracer_metadata(alk_alt_co2_ind))
-
-    end associate
+    call marbl_init_non_autotroph_tracer_metadata('DIC_ALT_CO2', 'Dissolved Inorganic Carbon, Alternative CO2', &
+               marbl_tracer_metadata(marbl_tracer_indices%dic_alt_co2_ind))
+    call marbl_init_non_autotroph_tracer_metadata('ALK_ALT_CO2', 'Alkalinity, Alternative CO2', &
+               marbl_tracer_metadata(marbl_tracer_indices%alk_alt_co2_ind))
 
   end subroutine marbl_init_non_autotroph_tracers_metadata
 

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -215,6 +215,7 @@ module marbl_mod
   public  :: marbl_tracer_index_consistency_check
 
   private :: marbl_init_non_autotroph_tracer_metadata
+  private :: marbl_init_non_autotroph_tracers_metadata
   private :: marbl_init_particulate_terms
   private :: marbl_init_zooplankton_tracer_metadata
   private :: marbl_init_autotroph_tracer_metadata
@@ -623,7 +624,7 @@ contains
     marbl_tracer_metadata(:)%lfull_depth_tavg   = .true.
     marbl_tracer_metadata(:)%tracer_module_name = 'ecosys'
 
-    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_metadata,      &
+    call marbl_init_non_autotroph_tracers_metadata(marbl_tracer_metadata,     &
          marbl_tracer_indices)
 
     call marbl_init_zooplankton_tracer_metadata(marbl_tracer_metadata,        &
@@ -2660,7 +2661,46 @@ contains
 
   !***********************************************************************
 
-  subroutine marbl_init_non_autotroph_tracer_metadata(marbl_tracer_metadata, &
+  subroutine marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices,   &
+             n, short_name, long_name, marbl_tracer_metadata)
+
+    !-----------------------------------------------------------------------
+    !  initialize non-autotroph tracer_d values and accumulate
+    !  non_living_biomass_ecosys_tracer_cnt
+    !-----------------------------------------------------------------------
+
+    implicit none
+
+    type(marbl_tracer_index_type),    intent(in)    :: marbl_tracer_indices
+    integer(int_kind),                intent(in)    :: n
+    character(len=*),                 intent(in)    :: short_name
+    character(len=*),                 intent(in)    :: long_name
+    type(marbl_tracer_metadata_type), intent(inout) :: marbl_tracer_metadata
+
+    associate(&
+         alk_ind           => marbl_tracer_indices%alk_ind,         &
+         alk_alt_co2_ind   => marbl_tracer_indices%alk_alt_co2_ind  &
+             )
+
+      marbl_tracer_metadata%short_name = short_name
+      marbl_tracer_metadata%long_name  = long_name
+      if (n == alk_ind .or. n == alk_alt_co2_ind) then
+         marbl_tracer_metadata%units      = 'meq/m^3'
+         marbl_tracer_metadata%tend_units = 'meq/m^3/s'
+         marbl_tracer_metadata%flux_units = 'meq/m^3 cm/s'
+      else
+         marbl_tracer_metadata%units      = 'mmol/m^3'
+         marbl_tracer_metadata%tend_units = 'mmol/m^3/s'
+         marbl_tracer_metadata%flux_units = 'mmol/m^3 cm/s'
+      endif
+
+    end associate
+
+  end subroutine marbl_init_non_autotroph_tracer_metadata
+
+  !***********************************************************************
+
+  subroutine marbl_init_non_autotroph_tracers_metadata(marbl_tracer_metadata, &
              marbl_tracer_indices)
 
     !-----------------------------------------------------------------------
@@ -2672,9 +2712,6 @@ contains
 
     type(marbl_tracer_metadata_type) , intent(inout) :: marbl_tracer_metadata(:)             ! descriptors for each tracer
     type(marbl_tracer_index_type)    , intent(in)    :: marbl_tracer_indices
-
-    integer(int_kind) :: non_living_biomass_ecosys_tracer_cnt ! number of non-autotroph ecosystem tracers
-    integer(int_kind) :: n
 
     associate(&
          po4_ind           => marbl_tracer_indices%po4_ind,         &
@@ -2696,91 +2733,45 @@ contains
          docr_ind          => marbl_tracer_indices%docr_ind         &
              )
 
-    non_living_biomass_ecosys_tracer_cnt = 0
+    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices, po4_ind, 'PO4',   &
+               'Dissolved Inorganic Phosphate', marbl_tracer_metadata(po4_ind))
+    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices, no3_ind, 'NO3',   &
+               'Dissolved Inorganic Nitrate', marbl_tracer_metadata(no3_ind))
+    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices, sio3_ind, 'SiO3', &
+               'Dissolved Inorganic Silicate', marbl_tracer_metadata(sio3_ind))
+    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices, nh4_ind, 'NH4',   &
+               'Dissolved Ammonia', marbl_tracer_metadata(nh4_ind))
+    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices, fe_ind, 'Fe',     &
+               'Dissolved Inorganic Iron', marbl_tracer_metadata(fe_ind))
+    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices, lig_ind, 'Lig',   &
+               'Iron Binding Ligand', marbl_tracer_metadata(lig_ind))
+    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices, o2_ind, 'O2',     &
+               'Dissolved Oxygen', marbl_tracer_metadata(o2_ind))
+    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices, dic_ind, 'DIC',   &
+               'Dissolved Inorganic Carbon', marbl_tracer_metadata(dic_ind))
+    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices, alk_ind, 'ALK',   &
+               'Alkalinity', marbl_tracer_metadata(alk_ind))
+    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices, doc_ind, 'DOC',   &
+               'Dissolved Organic Carbon', marbl_tracer_metadata(doc_ind))
+    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices, don_ind, 'DON',   &
+               'Dissolved Organic Nitrogen', marbl_tracer_metadata(don_ind))
+    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices, dop_ind, 'DOP',   &
+               'Dissolved Organic Phosphorus', marbl_tracer_metadata(dop_ind))
+    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices, dopr_ind, 'DOPr', &
+               'Refractory DOP', marbl_tracer_metadata(dopr_ind))
+    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices, donr_ind, 'DONr', &
+               'Refractory DON', marbl_tracer_metadata(donr_ind))
+    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices, docr_ind, 'DOCr', &
+               'Refractory DOC', marbl_tracer_metadata(docr_ind))
 
-    marbl_tracer_metadata(po4_ind)%short_name='PO4'
-    marbl_tracer_metadata(po4_ind)%long_name='Dissolved Inorganic Phosphate'
-    non_living_biomass_ecosys_tracer_cnt = non_living_biomass_ecosys_tracer_cnt + 1
-
-    marbl_tracer_metadata(no3_ind)%short_name='NO3'
-    marbl_tracer_metadata(no3_ind)%long_name='Dissolved Inorganic Nitrate'
-    non_living_biomass_ecosys_tracer_cnt = non_living_biomass_ecosys_tracer_cnt + 1
-
-    marbl_tracer_metadata(sio3_ind)%short_name='SiO3'
-    marbl_tracer_metadata(sio3_ind)%long_name='Dissolved Inorganic Silicate'
-    non_living_biomass_ecosys_tracer_cnt = non_living_biomass_ecosys_tracer_cnt + 1
-
-    marbl_tracer_metadata(nh4_ind)%short_name='NH4'
-    marbl_tracer_metadata(nh4_ind)%long_name='Dissolved Ammonia'
-    non_living_biomass_ecosys_tracer_cnt = non_living_biomass_ecosys_tracer_cnt + 1
-
-    marbl_tracer_metadata(fe_ind)%short_name='Fe'
-    marbl_tracer_metadata(fe_ind)%long_name='Dissolved Inorganic Iron'
-    non_living_biomass_ecosys_tracer_cnt = non_living_biomass_ecosys_tracer_cnt + 1
-
-    marbl_tracer_metadata(lig_ind)%short_name='Lig'
-    marbl_tracer_metadata(lig_ind)%long_name='Iron Binding Ligand'
-    non_living_biomass_ecosys_tracer_cnt = non_living_biomass_ecosys_tracer_cnt + 1
-
-    marbl_tracer_metadata(o2_ind)%short_name='O2'
-    marbl_tracer_metadata(o2_ind)%long_name='Dissolved Oxygen'
-    non_living_biomass_ecosys_tracer_cnt = non_living_biomass_ecosys_tracer_cnt + 1
-
-    marbl_tracer_metadata(dic_ind)%short_name='DIC'
-    marbl_tracer_metadata(dic_ind)%long_name='Dissolved Inorganic Carbon'
-    non_living_biomass_ecosys_tracer_cnt = non_living_biomass_ecosys_tracer_cnt + 1
-
-    marbl_tracer_metadata(dic_alt_co2_ind)%short_name='DIC_ALT_CO2'
-    marbl_tracer_metadata(dic_alt_co2_ind)%long_name='Dissolved Inorganic Carbon, Alternative CO2'
-    non_living_biomass_ecosys_tracer_cnt = non_living_biomass_ecosys_tracer_cnt + 1
-
-    marbl_tracer_metadata(alk_ind)%short_name='ALK'
-    marbl_tracer_metadata(alk_ind)%long_name='Alkalinity'
-    non_living_biomass_ecosys_tracer_cnt = non_living_biomass_ecosys_tracer_cnt + 1
-
-    marbl_tracer_metadata(alk_alt_co2_ind)%short_name='ALK_ALT_CO2'
-    marbl_tracer_metadata(alk_alt_co2_ind)%long_name='Alkalinity, Alternative CO2'
-    non_living_biomass_ecosys_tracer_cnt = non_living_biomass_ecosys_tracer_cnt + 1
-
-    marbl_tracer_metadata(doc_ind)%short_name='DOC'
-    marbl_tracer_metadata(doc_ind)%long_name='Dissolved Organic Carbon'
-    non_living_biomass_ecosys_tracer_cnt = non_living_biomass_ecosys_tracer_cnt + 1
-
-    marbl_tracer_metadata(don_ind)%short_name='DON'
-    marbl_tracer_metadata(don_ind)%long_name='Dissolved Organic Nitrogen'
-    non_living_biomass_ecosys_tracer_cnt = non_living_biomass_ecosys_tracer_cnt + 1
-
-    marbl_tracer_metadata(dop_ind)%short_name='DOP'
-    marbl_tracer_metadata(dop_ind)%long_name='Dissolved Organic Phosphorus'
-    non_living_biomass_ecosys_tracer_cnt = non_living_biomass_ecosys_tracer_cnt + 1
-
-    marbl_tracer_metadata(dopr_ind)%short_name='DOPr'
-    marbl_tracer_metadata(dopr_ind)%long_name='Refractory DOP'
-    non_living_biomass_ecosys_tracer_cnt = non_living_biomass_ecosys_tracer_cnt + 1
-
-    marbl_tracer_metadata(donr_ind)%short_name='DONr'
-    marbl_tracer_metadata(donr_ind)%long_name='Refractory DON'
-    non_living_biomass_ecosys_tracer_cnt = non_living_biomass_ecosys_tracer_cnt + 1
-
-    marbl_tracer_metadata(docr_ind)%short_name='DOCr'
-    marbl_tracer_metadata(docr_ind)%long_name='Refractory DOC'
-    non_living_biomass_ecosys_tracer_cnt = non_living_biomass_ecosys_tracer_cnt + 1
-
-    do n = 1, non_living_biomass_ecosys_tracer_cnt
-       if (n == alk_ind .or. n == alk_alt_co2_ind) then
-          marbl_tracer_metadata(n)%units      = 'meq/m^3'
-          marbl_tracer_metadata(n)%tend_units = 'meq/m^3/s'
-          marbl_tracer_metadata(n)%flux_units = 'meq/m^3 cm/s'
-       else
-          marbl_tracer_metadata(n)%units      = 'mmol/m^3'
-          marbl_tracer_metadata(n)%tend_units = 'mmol/m^3/s'
-          marbl_tracer_metadata(n)%flux_units = 'mmol/m^3 cm/s'
-       endif
-    end do
+    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices, dic_alt_co2_ind, 'DIC_ALT_CO2', &
+               'Dissolved Inorganic Carbon, Alternative CO2', marbl_tracer_metadata(dic_alt_co2_ind))
+    call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_indices, alk_alt_co2_ind, 'ALK_ALT_CO2', &
+               'Alkalinity, Alternative CO2', marbl_tracer_metadata(alk_alt_co2_ind))
 
     end associate
 
-  end subroutine marbl_init_non_autotroph_tracer_metadata
+  end subroutine marbl_init_non_autotroph_tracers_metadata
 
   !***********************************************************************
 

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -612,7 +612,6 @@ contains
 
     character(*), parameter :: subname = 'marbl_mod:marbl_init_tracer_metadata'
 
-    integer (int_kind) :: non_living_biomass_ecosys_tracer_cnt ! number of non-autotroph ecosystem tracers
     integer (int_kind) :: n        ! index for looping over tracers
     integer (int_kind) :: zoo_ind  ! zooplankton functional group index
     integer (int_kind) :: auto_ind ! autotroph functional group index
@@ -625,7 +624,7 @@ contains
     marbl_tracer_metadata(:)%tracer_module_name = 'ecosys'
 
     call marbl_init_non_autotroph_tracer_metadata(marbl_tracer_metadata,      &
-         marbl_tracer_indices, non_living_biomass_ecosys_tracer_cnt)
+         marbl_tracer_indices)
 
     call marbl_init_zooplankton_tracer_metadata(marbl_tracer_metadata,        &
          marbl_tracer_indices)
@@ -2662,7 +2661,7 @@ contains
   !***********************************************************************
 
   subroutine marbl_init_non_autotroph_tracer_metadata(marbl_tracer_metadata, &
-             marbl_tracer_indices, non_living_biomass_ecosys_tracer_cnt)
+             marbl_tracer_indices)
 
     !-----------------------------------------------------------------------
     !  initialize non-autotroph tracer_d values and accumulate
@@ -2671,10 +2670,10 @@ contains
 
     implicit none
 
-    type (marbl_tracer_metadata_type) , intent(inout) :: marbl_tracer_metadata(:)             ! descriptors for each tracer
-    type (marbl_tracer_index_type)    , intent(in)    :: marbl_tracer_indices
-    integer (int_kind)                , intent(out)   :: non_living_biomass_ecosys_tracer_cnt ! number of non-autotroph ecosystem tracers
+    type(marbl_tracer_metadata_type) , intent(inout) :: marbl_tracer_metadata(:)             ! descriptors for each tracer
+    type(marbl_tracer_index_type)    , intent(in)    :: marbl_tracer_indices
 
+    integer(int_kind) :: non_living_biomass_ecosys_tracer_cnt ! number of non-autotroph ecosystem tracers
     integer(int_kind) :: n
 
     associate(&


### PR DESCRIPTION
Remove the `non_living_biomass_ecosys_tracer_cnt` variable (see issue #137).

Testing: verified that the tracer names and metadata did not change with this refactor by running a single POP CECO (+ciso) comparison test on both Cheyenne (intel 17) and Hobart (nag); this testing did catch some initial typos, and one of the errors flagged (I had accidentally changed the `ALK` tracer to `alk`) also caught a typo in a MARBL error traceback.