### PR TITLE
Omit comment from log if it makes string too long

### DIFF
--- a/src/marbl_config_mod.F90
+++ b/src/marbl_config_mod.F90
@@ -882,9 +882,16 @@ contains
           end select
 
           ! (4) Write log_message to the log
-          if (this%vars(n)%comment.ne.'') &
-            write(log_message, "(3A)") trim(log_message), ' ! ',                  &
-                                       trim(this%vars(n)%comment)
+          if (this%vars(n)%comment.ne.'') then
+            if (len_trim(log_message) + 3 + len_trim(this%vars(n)%comment) .le. len(log_message)) then
+              write(log_message, "(3A)") trim(log_message), ' ! ',                  &
+                                         trim(this%vars(n)%comment)
+            else
+              call marbl_status_log%log_noerror(&
+                   '! WARNING: omitting comment on line below because including it exceeds max length for log message', &
+                   subname)
+            end if
+          endif
           call marbl_status_log%log_noerror(log_message, subname)
         end if
       end do


### PR DESCRIPTION
There's an issue on PGI (that smells like a compiler bug) where the
actual contents of a string of length char_len are being ignored in
favor of char_len characters of gibberish; this string is being appended
to another string that has length char_len, causing an overflow. The fix
is to ensure that len_trim() of the two strings (plus the three
additional characters being included) don't exceed the length of the
string they are being written into. If the limit is exceeded, a warning
is printed out and the comment is omitted.