### PR TITLE
Introduce local-pgi machine

### DIFF
--- a/tests/python_for_tests/machines.py
+++ b/tests/python_for_tests/machines.py
@@ -3,6 +3,7 @@ from os import system as sh_command
 
 # Supported machines for running MARBL tests
 supported_machines = ['local-gnu', 
+                      'local-pgi',
                       'yellowstone',
                       'cheyenne',
                       'hobart',
@@ -92,6 +93,12 @@ def machine_specific(mach, supported_compilers):
     # Not a specific machine, but a flag to specify
     # "run with gnu without loading any modules"
     supported_compilers.append('gnu')
+    return
+
+  if mach == 'local-pgi':
+    # Not a specific machine, but a flag to specify
+    # "run with pgi without loading any modules"
+    supported_compilers.append('pgi')
     return
 
 # -----------------------------------------------

--- a/tests/python_for_tests/marbl_testing_class.py
+++ b/tests/python_for_tests/marbl_testing_class.py
@@ -44,7 +44,7 @@ class MARBL_testcase(object):
       parser.add_argument('--clean', action='store_true',
              help='remove object, module, and library files for MARBL driver')
 
-    parser.add_argument('-m', '--mach', action='store', dest='mach',
+    parser.add_argument('-m', '--mach', '--machine', action='store', dest='mach',
            help='machine to build on', choices=machs.supported_machines)
 
     parser.add_argument('--mpitasks', action='store', dest='mpitasks',
@@ -121,7 +121,7 @@ class MARBL_testcase(object):
 
     src_dir = '%s/src' % self._marbl_dir
 
-    if self._machine != 'local-gnu':
+    if self._machine not in ['local-gnu','local-pgi']:
       machs.load_module(self._machine, loc_compiler)
 
     makecmd = 'make %s' % loc_compiler
@@ -139,7 +139,7 @@ class MARBL_testcase(object):
 
     drv_dir = '%s/tests/driver_src' % self._marbl_dir
 
-    if self._machine != 'local-gnu':
+    if self._machine not in ['local-gnu','local-pgi']:
       machs.load_module(self._machine, loc_compiler)
 
     makecmd = 'make %s' % loc_compiler


### PR DESCRIPTION
PGI offers Community Edition of PGI 17.4, which can be installed locally and
then used to build / run the stand-alone MARBL tests. The default machine is
still 'local-gnu'; it might be time to consider adding a `~/.marbl/` directory
and letting users specify what compilers are available if the machine is not
recognized (so default machine would be 'local', and if `~/.marbl/` is not found
then only gnu would be supported; otherwise users could specify other compilers
that are installed)

** Compiler available at http://www.pgroup.com/products/community.htm

Verified that this does not change behavior on cheyenne or hobart