### PR TITLE
gcm_num_elements_interior_forcing not in interface

### DIFF
--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -254,7 +254,6 @@ contains
   subroutine init(this,                   &
        gcm_num_levels,                    &
        gcm_num_PAR_subcols,               &
-       gcm_num_elements_interior_forcing, &
        gcm_num_elements_surface_forcing,  &
        gcm_delta_z,                       &
        gcm_zw,                            &
@@ -283,7 +282,6 @@ contains
     integer   (int_kind)                   , intent(in)    :: gcm_num_levels
     integer   (int_kind)                   , intent(in)    :: gcm_num_PAR_subcols
     integer   (int_kind)                   , intent(in)    :: gcm_num_elements_surface_forcing
-    integer   (int_kind)                   , intent(in)    :: gcm_num_elements_interior_forcing
     real      (r8)                         , intent(in)    :: gcm_delta_z(gcm_num_levels) ! thickness of layer k
     real      (r8)                         , intent(in)    :: gcm_zw(gcm_num_levels) ! thickness of layer k
     real      (r8)                         , intent(in)    :: gcm_zt(gcm_num_levels) ! thickness of layer k
@@ -293,6 +291,7 @@ contains
     character(*), parameter :: subname = 'marbl_interface:init'
     character(len=char_len) :: log_message
     integer :: i
+    integer, parameter :: num_interior_elements = 1 ! FIXME #66: get this value from interface, let it vary
     !--------------------------------------------------------------------
 
     call this%timers%start(this%timer_ids%init_timer_id, this%StatusLog)
@@ -304,8 +303,7 @@ contains
     associate(&
          num_levels            => gcm_num_levels,                              &
          num_PAR_subcols       => gcm_num_PAR_subcols,                         &
-         num_surface_elements  => gcm_num_elements_surface_forcing,            &
-         num_interior_elements => gcm_num_elements_interior_forcing            &
+         num_surface_elements  => gcm_num_elements_surface_forcing             &
          )
 
     !-----------------------------------------------------------------------

--- a/tests/driver_src/marbl_get_put_drv.F90
+++ b/tests/driver_src/marbl_get_put_drv.F90
@@ -70,7 +70,6 @@ Contains
     ! Call marbl%init
     call marbl_instance%init(gcm_num_levels = km,                             &
                              gcm_num_PAR_subcols = 1,                         &
-                             gcm_num_elements_interior_forcing = 1,           &
                              gcm_num_elements_surface_forcing = 1,            &
                              gcm_delta_z = delta_z,                           &
                              gcm_zw = zw,                                     &

--- a/tests/driver_src/marbl_init_namelist_drv.F90
+++ b/tests/driver_src/marbl_init_namelist_drv.F90
@@ -45,7 +45,6 @@ Contains
     ! Call marbl%init
     call marbl_instance%init(gcm_num_levels = km,                             &
                              gcm_num_PAR_subcols = 1,                         &
-                             gcm_num_elements_interior_forcing = 1,           &
                              gcm_num_elements_surface_forcing = 1,            &
                              gcm_delta_z = delta_z,                           &
                              gcm_zw = zw,                                     &

--- a/tests/driver_src/marbl_init_no_namelist_drv.F90
+++ b/tests/driver_src/marbl_init_no_namelist_drv.F90
@@ -48,7 +48,6 @@ Contains
     ! Call marbl%init
     call marbl_instance%init(gcm_num_levels = km,                             &
                              gcm_num_PAR_subcols = 1,                         &
-                             gcm_num_elements_interior_forcing = 1,           &
                              gcm_num_elements_surface_forcing = 1,            &
                              gcm_delta_z = delta_z,                           &
                              gcm_zw = zw,                                     &


### PR DESCRIPTION
The implementation of gcm_num_elements_interior_forcing is not complete, and if
this variable is not set to 1 then MARBL will produce unexpected results or
errors. For now, I have removed this variable from the interface to ensure that
it is always set to 1 inside the library.