### PR TITLE
Had some bad whitespace in log

### DIFF
--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -425,7 +425,6 @@ contains
                                  trim(this%tracer_metadata(i)%short_name)
       call this%StatusLog%log_noerror(log_message, subname)
     end do
-    call this%StatusLog%log_noerror('', subname)
 
     call marbl_tracer_index_consistency_check(this%tracer_indices, this%StatusLog)
     if (this%StatusLog%labort_marbl) then
@@ -612,7 +611,6 @@ contains
       write(log_message, "(2A)") '* ', trim(this%interior_input_forcings(i)%metadata%varname)
       call this%StatusLog%log_noerror(log_message, subname)
     end do
-    call this%StatusLog%log_noerror('', subname)
 
     ! Set up running mean variables (dependent on parms namelist)
     call this%glo_vars_init()

--- a/src/marbl_parms.F90
+++ b/src/marbl_parms.F90
@@ -1412,10 +1412,7 @@ contains
     character(len=char_len) :: sname_in, sname_out
     integer :: m, n
 
-    call marbl_status_log%log_noerror('---------------------', subname)
-    call marbl_status_log%log_noerror('Setting derived parms', subname)
-    call marbl_status_log%log_noerror('---------------------', subname)
-    call marbl_status_log%log_noerror('', subname)
+    call marbl_status_log%log_header('Setting derived parms', subname)
 
     select case (caco3_bury_thres_opt)
     case ('fixed_depth')
@@ -1481,8 +1478,6 @@ contains
                grazing(m,n)%z_umax_0, subname, marbl_status_log)
        end do
     end do
-
-    call marbl_status_log%log_noerror('', subname)
 
   end subroutine set_derived_parms
 


### PR DESCRIPTION
3 unnecessary write statements were adding an extra empty line to the log, and
there was also one spot where I should have used the log_header() routine but
didn't.

(I was playing with MARBL on a machine I don't often use, and these issues stood out)