### PR TITLE
Split thermodynamic_coefficients_type

### DIFF
--- a/src/marbl_co2calc_mod.F90
+++ b/src/marbl_co2calc_mod.F90
@@ -23,6 +23,7 @@ module marbl_co2calc_mod
   public  :: marbl_comp_co3_sat_vals
 
   private :: comp_htotal
+  private :: comp_co2calc_coeffs
   private :: drtsafe
   private :: total_alkalinity
   private :: apply_pressure_correction
@@ -81,7 +82,7 @@ contains
 
   subroutine marbl_co2calc_surf( &
        num_elements,             &
-       lcomp_co3_coeffs,         &
+       lcomp_co2calc_coeffs,     &
        dic_in,                   &
        xco2_in,                  &
        ta_in,                    &
@@ -90,8 +91,8 @@ contains
        temp,                     &
        salt,                     &
        atmpres,                  &
-       co3_coeffs,               &
-       species_concentration,    &
+       co2calc_coeffs,           &
+       co2calc_state,            &
        co3,                      &
        co2star,                  &
        dco2star,                 &
@@ -110,7 +111,7 @@ contains
     implicit none
 
     integer(kind=int_kind)        , intent(in)    :: num_elements
-    logical(kind=log_kind)        , intent(in)    :: lcomp_co3_coeffs
+    logical(kind=log_kind)        , intent(in)    :: lcomp_co2calc_coeffs
     real(kind=r8)                 , intent(in)    :: dic_in(num_elements)   ! total inorganic carbon (nmol/cm^3)
     real(kind=r8)                 , intent(in)    :: xco2_in(num_elements)  ! atmospheric mole fraction CO2 in dry air (ppmv)
     real(kind=r8)                 , intent(in)    :: ta_in(num_elements)    ! total alkalinity (neq/cm^3)
@@ -123,8 +124,8 @@ contains
     real(kind=r8)                 , intent(inout) :: phhi(num_elements)     ! upper limit of ph range
     real(kind=r8)                 , intent(out)   :: ph(num_elements)       ! computed ph values, for initial guess on next time step
     real(kind=r8)                 , intent(out)   :: co3(num_elements)      ! Carbonate Ion Concentration
-    type(co2calc_coeffs_type)     , intent(inout) :: co3_coeffs(num_elements)
-    type(co2calc_state_type)      , intent(inout) :: species_concentration(num_elements)
+    type(co2calc_coeffs_type)     , intent(inout) :: co2calc_coeffs(num_elements)
+    type(co2calc_state_type)      , intent(inout) :: co2calc_state(num_elements)
     real(kind=r8)                 , intent(out)   :: co2star(num_elements)  ! CO2*water (nmol/cm^3)
     real(kind=r8)                 , intent(out)   :: dco2star(num_elements) ! delta CO2 (nmol/cm^3)
     real(kind=r8)                 , intent(out)   :: pco2surf(num_elements) ! oceanic pCO2 (ppmv)
@@ -148,11 +149,11 @@ contains
     logical(kind=log_kind)  :: pressure_correct(num_elements)
     !---------------------------------------------------------------------------
 
-    associate(                     &
-         k1  => co3_coeffs(:)%k1,  &
-         k2  => co3_coeffs(:)%k2,  &
-         ff  => co3_coeffs(:)%ff,  &
-         dic => species_concentration(:)%dic  &
+    associate(                        &
+         k1  => co2calc_coeffs(:)%k1, &
+         k2  => co2calc_coeffs(:)%k2, &
+         ff  => co2calc_coeffs(:)%ff, &
+         dic => co2calc_state(:)%dic  &
          )
 
     !---------------------------------------------------------------------------
@@ -171,18 +172,18 @@ contains
     !   compute thermodynamic CO3 coefficients
     !---------------------------------------------------------------------------
 
-    if (lcomp_co3_coeffs) then
-       call marbl_comp_co3_coeffs(num_elements, pressure_correct, &
-            temp, salt, press_bar, co3_coeffs, species_concentration)
+    if (lcomp_co2calc_coeffs) then
+       call comp_co2calc_coeffs(num_elements, pressure_correct, temp, salt,   &
+                 press_bar, co2calc_coeffs, co2calc_state)
     end if
 
     !---------------------------------------------------------------------------
     !   compute htotal
     !---------------------------------------------------------------------------
 
-    call comp_htotal(num_elements, num_elements, temp, dic_in, &
-                     ta_in, pt_in, sit_in, co3_coeffs, species_concentration, &
-                     phlo, phhi, htotal, marbl_status_log)
+    call comp_htotal(num_elements, num_elements, temp, dic_in, ta_in, pt_in,    &
+                     sit_in, co2calc_coeffs, co2calc_state, phlo, phhi, htotal, &
+                     marbl_status_log)
 
     if (present (marbl_status_log)) then
        if (marbl_status_log%labort_marbl) then
@@ -241,9 +242,9 @@ contains
   !***********************************************************************
 
   subroutine marbl_comp_CO3terms(&
-       num_elements, num_active_elements, pressure_correct, lcomp_co3_coeffs, co3_coeffs,  &
-       species_concentration, temp, salt, press_bar, dic_in, ta_in, pt_in, sit_in, phlo,   &
-       phhi, ph, H2CO3, HCO3, CO3, marbl_status_log)
+       num_elements, num_active_elements, pressure_correct, lcomp_co2calc_coeffs,   &
+       co2calc_coeffs,  co2calc_state, temp, salt, press_bar, dic_in, ta_in, pt_in, &
+       sit_in, phlo, phhi, ph, H2CO3, HCO3, CO3, marbl_status_log)
 
     !---------------------------------------------------------------------------
     ! Calculate H2CO3, HCO3, CO3 from total alkalinity, total CO2, temp, salinity (s), etc.
@@ -254,7 +255,7 @@ contains
     integer(kind=int_kind)    , intent(in)    :: num_elements
     integer(kind=int_kind)    , intent(in)    :: num_active_elements
     logical(kind=log_kind)    , intent(in)    :: pressure_correct(num_elements)
-    logical(kind=log_kind)    , intent(in)    :: lcomp_co3_coeffs
+    logical(kind=log_kind)    , intent(in)    :: lcomp_co2calc_coeffs
     real(kind=r8)             , intent(in)    :: temp(num_elements)      ! temperature (degrees C)
     real(kind=r8)             , intent(in)    :: salt(num_elements)      ! salinity (PSU)
     real(kind=r8)             , intent(in)    :: press_bar(num_elements) ! pressure at level (bars)
@@ -262,8 +263,8 @@ contains
     real(kind=r8)             , intent(in)    :: ta_in(num_elements)     ! total alkalinity (neq/cm^3)
     real(kind=r8)             , intent(in)    :: pt_in(num_elements)     ! inorganic phosphate (nmol/cm^3)
     real(kind=r8)             , intent(in)    :: sit_in(num_elements)    ! inorganic silicate (nmol/cm^3)
-    type(co2calc_coeffs_type) , intent(inout) :: co3_coeffs(num_elements)
-    type(co2calc_state_type)  , intent(inout) :: species_concentration(num_elements)
+    type(co2calc_coeffs_type) , intent(inout) :: co2calc_coeffs(num_elements)
+    type(co2calc_state_type)  , intent(inout) :: co2calc_state(num_elements)
     real(kind=r8)             , intent(inout) :: phlo(num_elements)      ! lower limit of pH range
     real(kind=r8)             , intent(inout) :: phhi(num_elements)      ! upper limit of pH range
     real(kind=r8)             , intent(out)   :: pH(num_elements)        ! computed ph values, for initial guess on next time step
@@ -284,25 +285,25 @@ contains
     real(kind=r8)          :: htotal(num_elements) ! free concentration of H ion
     !---------------------------------------------------------------------------
 
-    associate(                     &
-         k0  => co3_coeffs(:)%k0,  &
-         k1  => co3_coeffs(:)%k1,  &
-         k2  => co3_coeffs(:)%k2,  &
-         ff  => co3_coeffs(:)%ff,  &
-         kw  => co3_coeffs(:)%kw,  &
-         kb  => co3_coeffs(:)%kb,  &
-         ks  => co3_coeffs(:)%ks,  &
-         kf  => co3_coeffs(:)%kf,  &
-         k1p => co3_coeffs(:)%k1p, &
-         k2p => co3_coeffs(:)%k2p, &
-         ksi => co3_coeffs(:)%ksi, &
-         bt  => co3_coeffs(:)%bt,  &
-         st  => co3_coeffs(:)%st,  &
-         ft  => co3_coeffs(:)%ft,  &
-         dic => species_concentration(:)%dic, &
-         ta  => species_concentration(:)%ta,  &
-         pt  => species_concentration(:)%pt,  &
-         sit => species_concentration(:)%sit  &
+    associate(                         &
+         k0  => co2calc_coeffs(:)%k0,  &
+         k1  => co2calc_coeffs(:)%k1,  &
+         k2  => co2calc_coeffs(:)%k2,  &
+         ff  => co2calc_coeffs(:)%ff,  &
+         kw  => co2calc_coeffs(:)%kw,  &
+         kb  => co2calc_coeffs(:)%kb,  &
+         ks  => co2calc_coeffs(:)%ks,  &
+         kf  => co2calc_coeffs(:)%kf,  &
+         k1p => co2calc_coeffs(:)%k1p, &
+         k2p => co2calc_coeffs(:)%k2p, &
+         ksi => co2calc_coeffs(:)%ksi, &
+         bt  => co2calc_coeffs(:)%bt,  &
+         st  => co2calc_coeffs(:)%st,  &
+         ft  => co2calc_coeffs(:)%ft,  &
+         dic => co2calc_state(:)%dic,  &
+         ta  => co2calc_state(:)%ta,   &
+         pt  => co2calc_state(:)%pt,   &
+         sit => co2calc_state(:)%sit   &
          )
 
     !---------------------------------------------------------------------------
@@ -316,18 +317,18 @@ contains
     !   compute thermodynamic CO3 coefficients
     !------------------------------------------------------------------------
 
-    if (lcomp_co3_coeffs) then
-       call marbl_comp_co3_coeffs(num_elements, pressure_correct, &
-            temp, salt, press_bar, co3_coeffs, species_concentration)
+    if (lcomp_co2calc_coeffs) then
+       call comp_co2calc_coeffs(num_elements, pressure_correct, temp, salt,   &
+                 press_bar, co2calc_coeffs, co2calc_state)
     end if
 
     !------------------------------------------------------------------------
     !   compute htotal
     !------------------------------------------------------------------------
 
-    call comp_htotal(num_elements, num_active_elements, temp, dic_in, &
-         ta_in, pt_in, sit_in, co3_coeffs, species_concentration, &
-         phlo, phhi, htotal, marbl_status_log)
+    call comp_htotal(num_elements, num_active_elements, temp, dic_in, ta_in,    &
+              pt_in, sit_in, co2calc_coeffs, co2calc_state, phlo, phhi, htotal, &
+              marbl_status_log)
 
     if (marbl_status_log%labort_marbl) then
        call marbl_status_log%log_error_trace("comp_htotal()", subname)
@@ -367,8 +368,8 @@ contains
 
   !*****************************************************************************
 
-  subroutine marbl_comp_co3_coeffs(num_elements, pressure_correct, &
-       temp, salt, press_bar, co3_coeffs, species_concentration)
+  subroutine comp_co2calc_coeffs(num_elements, pressure_correct, temp, salt,  &
+                  press_bar, co2calc_coeffs, co2calc_state)
 
     !---------------------------------------------------------------------------
     ! FIXME #20: the computations for the individual constants need to
@@ -382,8 +383,8 @@ contains
     real(kind=r8)             , intent(in)  :: temp(num_elements)      ! temperature (degrees c)
     real(kind=r8)             , intent(in)  :: salt(num_elements)      ! salinity (psu)
     real(kind=r8)             , intent(in)  :: press_bar(num_elements) ! pressure at level (bars)
-    type(co2calc_coeffs_type) , intent(out) :: co3_coeffs(num_elements)
-    type(co2calc_state_type)  , intent(out) :: species_concentration(num_elements)
+    type(co2calc_coeffs_type) , intent(out) :: co2calc_coeffs(num_elements)
+    type(co2calc_state_type)  , intent(out) :: co2calc_state(num_elements)
 
     !---------------------------------------------------------------------------
     !   local variable declarations
@@ -413,26 +414,26 @@ contains
     real(kind=r8), dimension(num_elements) :: log_1_p_tot_sulfate_div_ks
     !---------------------------------------------------------------------------
 
-    associate(                     &
-         k0  => co3_coeffs(:)%k0,  &
-         k1  => co3_coeffs(:)%k1,  &
-         k2  => co3_coeffs(:)%k2,  &
-         ff  => co3_coeffs(:)%ff,  &
-         kw  => co3_coeffs(:)%kw,  &
-         kb  => co3_coeffs(:)%kb,  &
-         ks  => co3_coeffs(:)%ks,  &
-         kf  => co3_coeffs(:)%kf,  &
-         k1p => co3_coeffs(:)%k1p, &
-         k2p => co3_coeffs(:)%k2p, &
-         k3p => co3_coeffs(:)%k3p, &
-         ksi => co3_coeffs(:)%ksi, &
-         bt  => co3_coeffs(:)%bt,  &
-         st  => co3_coeffs(:)%st,  &
-         ft  => co3_coeffs(:)%ft,  &
-         dic => species_concentration(:)%dic, &
-         ta  => species_concentration(:)%ta,  &
-         pt  => species_concentration(:)%pt,  &
-         sit => species_concentration(:)%sit  &
+    associate(                         &
+         k0  => co2calc_coeffs(:)%k0,  &
+         k1  => co2calc_coeffs(:)%k1,  &
+         k2  => co2calc_coeffs(:)%k2,  &
+         ff  => co2calc_coeffs(:)%ff,  &
+         kw  => co2calc_coeffs(:)%kw,  &
+         kb  => co2calc_coeffs(:)%kb,  &
+         ks  => co2calc_coeffs(:)%ks,  &
+         kf  => co2calc_coeffs(:)%kf,  &
+         k1p => co2calc_coeffs(:)%k1p, &
+         k2p => co2calc_coeffs(:)%k2p, &
+         k3p => co2calc_coeffs(:)%k3p, &
+         ksi => co2calc_coeffs(:)%ksi, &
+         bt  => co2calc_coeffs(:)%bt,  &
+         st  => co2calc_coeffs(:)%st,  &
+         ft  => co2calc_coeffs(:)%ft,  &
+         dic => co2calc_state(:)%dic,  &
+         ta  => co2calc_state(:)%ta,   &
+         pt  => co2calc_state(:)%pt,   &
+         sit => co2calc_state(:)%sit   &
          )
 
     !---------------------------------------------------------------------------
@@ -691,12 +692,13 @@ contains
 
     end associate
 
-  end subroutine marbl_comp_co3_coeffs
+  end subroutine comp_co2calc_coeffs
 
   !*****************************************************************************
 
-  subroutine comp_htotal(num_elements, num_active_elements, temp, dic_in, ta_in, pt_in, sit_in, &
-                         co3_coeffs, species_concentration, phlo, phhi, htotal, marbl_status_log)
+  subroutine comp_htotal(num_elements, num_active_elements, temp, dic_in, ta_in,    &
+                  pt_in, sit_in, co2calc_coeffs, co2calc_state, phlo, phhi, htotal, &
+                  marbl_status_log)
 
     !---------------------------------------------------------------------------
     ! Calculate htotal (free concentration of H ion) from
@@ -710,8 +712,8 @@ contains
     real(kind=r8)                 , intent(in)    :: ta_in(num_elements)  ! total alkalinity (neq/cm^3)
     real(kind=r8)                 , intent(in)    :: pt_in(num_elements)  ! inorganic phosphate (nmol/cm^3)
     real(kind=r8)                 , intent(in)    :: sit_in(num_elements) ! inorganic silicate (nmol/cm^3)
-    type(co2calc_coeffs_type)     , intent(inout) :: co3_coeffs(num_elements)
-    type(co2calc_state_type)      , intent(inout) :: species_concentration(num_elements)
+    type(co2calc_coeffs_type)     , intent(inout) :: co2calc_coeffs(num_elements)
+    type(co2calc_state_type)      , intent(inout) :: co2calc_state(num_elements)
     real(kind=r8)                 , intent(inout) :: phlo(num_elements)   ! lower limit of pH range
     real(kind=r8)                 , intent(inout) :: phhi(num_elements)   ! upper limit of pH range
     real(kind=r8)                 , intent(out)   :: htotal(num_elements) ! free concentration of H ion
@@ -728,24 +730,24 @@ contains
     real(kind=r8)          :: x1(num_elements), x2(num_elements) ! bounds on htotal for solver
     !---------------------------------------------------------------------------
 
-    associate(                      &
-          k1  => co3_coeffs(:)%k1,  &
-          k2  => co3_coeffs(:)%k2,  &
-          kw  => co3_coeffs(:)%kw,  &
-          kb  => co3_coeffs(:)%kb,  &
-          ks  => co3_coeffs(:)%ks,  &
-          kf  => co3_coeffs(:)%kf,  &
-          k1p => co3_coeffs(:)%k1p, &
-          k2p => co3_coeffs(:)%k2p, &
-          k3p => co3_coeffs(:)%k3p, &
-          ksi => co3_coeffs(:)%ksi, &
-          bt  => co3_coeffs(:)%bt,  &
-          st  => co3_coeffs(:)%st,  &
-          ft  => co3_coeffs(:)%ft,  &
-          dic => species_concentration(:)%dic, &
-          ta  => species_concentration(:)%ta,  &
-          pt  => species_concentration(:)%pt,  &
-          sit => species_concentration(:)%sit  &
+    associate(                          &
+          k1  => co2calc_coeffs(:)%k1,  &
+          k2  => co2calc_coeffs(:)%k2,  &
+          kw  => co2calc_coeffs(:)%kw,  &
+          kb  => co2calc_coeffs(:)%kb,  &
+          ks  => co2calc_coeffs(:)%ks,  &
+          kf  => co2calc_coeffs(:)%kf,  &
+          k1p => co2calc_coeffs(:)%k1p, &
+          k2p => co2calc_coeffs(:)%k2p, &
+          k3p => co2calc_coeffs(:)%k3p, &
+          ksi => co2calc_coeffs(:)%ksi, &
+          bt  => co2calc_coeffs(:)%bt,  &
+          st  => co2calc_coeffs(:)%st,  &
+          ft  => co2calc_coeffs(:)%ft,  &
+          dic => co2calc_state(:)%dic,  &
+          ta  => co2calc_state(:)%ta,   &
+          pt  => co2calc_state(:)%pt,   &
+          sit => co2calc_state(:)%sit   &
           )
 
     !---------------------------------------------------------------------------
@@ -784,8 +786,8 @@ contains
     !   set x1 and x2 to the previous value of the pH +/- ~0.5.
     !---------------------------------------------------------------------------
 
-    call drtsafe(num_elements, num_active_elements, k1, k2, co3_coeffs, species_concentration, &
-                 x1, x2, xacc, htotal, marbl_status_log)
+    call drtsafe(num_elements, num_active_elements, k1, k2, co2calc_coeffs,   &
+                 co2calc_state, x1, x2, xacc, htotal, marbl_status_log)
 
     if (marbl_status_log%labort_marbl) then
        call marbl_status_log%log_error_trace("drtsafe", subname)
@@ -798,8 +800,8 @@ contains
 
   !*****************************************************************************
 
-  subroutine drtsafe(num_elements, num_active_elements, k1, k2, co3_coeffs, species_concentration, &
-                     x1, x2, xacc, soln, marbl_status_log)
+  subroutine drtsafe(num_elements, num_active_elements, k1, k2, co2calc_coeffs, &
+                     co2calc_state, x1, x2, xacc, soln, marbl_status_log)
 
     !---------------------------------------------------------------------------
     !   Vectorized version of drtsafe, which was a modified version of
@@ -818,8 +820,8 @@ contains
     integer(kind=int_kind)        , intent(in)    :: num_active_elements
     real(kind=r8)                 , intent(in)    :: k1(num_elements)
     real(kind=r8)                 , intent(in)    :: k2(num_elements)
-    type(co2calc_coeffs_type)     , intent(in)    :: co3_coeffs(num_elements)
-    type(co2calc_state_type)      , intent(in)    :: species_concentration(num_elements)
+    type(co2calc_coeffs_type)     , intent(in)    :: co2calc_coeffs(num_elements)
+    type(co2calc_state_type)      , intent(in)    :: co2calc_state(num_elements)
     real(kind=r8)                 , intent(in)    :: xacc
     real(kind=r8)                 , intent(inout) :: x1(num_elements)
     real(kind=r8)                 , intent(inout) :: x2(num_elements)
@@ -854,8 +856,8 @@ contains
     it = 0
 
     do
-       call total_alkalinity(num_elements, mask, k1, k2, x1, co3_coeffs, species_concentration, flo, df)
-       call total_alkalinity(num_elements, mask, k1, k2, x2, co3_coeffs, species_concentration, fhi, df)
+       call total_alkalinity(num_elements, mask, k1, k2, x1, co2calc_coeffs, co2calc_state, flo, df)
+       call total_alkalinity(num_elements, mask, k1, k2, x2, co2calc_coeffs, co2calc_state, fhi, df)
 
        where ( mask )
           mask = (flo > c0 .AND. fhi > c0) .OR. &
@@ -925,7 +927,7 @@ contains
        dx(c) = dxold(c)
     end do
 
-    call total_alkalinity(num_elements, mask, k1, k2, soln, co3_coeffs, species_concentration, f, df)
+    call total_alkalinity(num_elements, mask, k1, k2, soln, co2calc_coeffs, co2calc_state, f, df)
 
     !---------------------------------------------------------------------------
     !   perform iterations, zeroing mask when a location has converged
@@ -955,7 +957,7 @@ contains
 
        if (.not. ANY(mask)) return
 
-       call total_alkalinity(num_elements, mask, k1, k2, soln, co3_coeffs, species_concentration, f, df)
+       call total_alkalinity(num_elements, mask, k1, k2, soln, co2calc_coeffs, co2calc_state, f, df)
 
        do c = 1,num_elements
           if (mask(c)) then
@@ -979,8 +981,8 @@ contains
 
   !*****************************************************************************
 
-  subroutine total_alkalinity(num_elements, mask, k1, k2, x, co3_coeffs, &
-             species_concentration, fn, df)
+  subroutine total_alkalinity(num_elements, mask, k1, k2, x, co2calc_coeffs, &
+             co2calc_state, fn, df)
 
     !---------------------------------------------------------------------------
     !   This routine computes TA as a function of DIC, htotal and constants.
@@ -997,8 +999,8 @@ contains
     real(kind=r8)             , intent(in)  :: k1(num_elements)
     real(kind=r8)             , intent(in)  :: k2(num_elements)
     real(kind=r8)             , intent(in)  :: x(num_elements)
-    type(co2calc_coeffs_type) , intent(in)  :: co3_coeffs(num_elements)
-    type(co2calc_state_type)  , intent(in)  :: species_concentration(num_elements)
+    type(co2calc_coeffs_type) , intent(in)  :: co2calc_coeffs(num_elements)
+    type(co2calc_state_type)  , intent(in)  :: co2calc_state(num_elements)
     real(kind=r8)             , intent(out) :: fn(num_elements)
     real(kind=r8)             , intent(out) :: df(num_elements)
 
@@ -1011,22 +1013,22 @@ contains
     real(kind=r8) :: kb_p_x1_r, ksi_p_x1_r, c1_p_c_ks_x1_r_r, c1_p_kf_x1_r_r
     !---------------------------------------------------------------------------
 
-    associate(                     &
-         kw  => co3_coeffs(:)%kw,  &
-         kb  => co3_coeffs(:)%kb,  &
-         ks  => co3_coeffs(:)%ks,  &
-         kf  => co3_coeffs(:)%kf,  &
-         k1p => co3_coeffs(:)%k1p, &
-         k2p => co3_coeffs(:)%k2p, &
-         k3p => co3_coeffs(:)%k3p, &
-         ksi => co3_coeffs(:)%ksi, &
-         bt  => co3_coeffs(:)%bt,  &
-         st  => co3_coeffs(:)%st,  &
-         ft  => co3_coeffs(:)%ft,  &
-         dic => species_concentration(:)%dic, &
-         ta  => species_concentration(:)%ta,  &
-         pt  => species_concentration(:)%pt,  &
-         sit => species_concentration(:)%sit  &
+    associate(                         &
+         kw  => co2calc_coeffs(:)%kw,  &
+         kb  => co2calc_coeffs(:)%kb,  &
+         ks  => co2calc_coeffs(:)%ks,  &
+         kf  => co2calc_coeffs(:)%kf,  &
+         k1p => co2calc_coeffs(:)%k1p, &
+         k2p => co2calc_coeffs(:)%k2p, &
+         k3p => co2calc_coeffs(:)%k3p, &
+         ksi => co2calc_coeffs(:)%ksi, &
+         bt  => co2calc_coeffs(:)%bt,  &
+         st  => co2calc_coeffs(:)%st,  &
+         ft  => co2calc_coeffs(:)%ft,  &
+         dic => co2calc_state(:)%dic,  &
+         ta  => co2calc_state(:)%ta,   &
+         pt  => co2calc_state(:)%pt,   &
+         sit => co2calc_state(:)%sit   &
          )
 
     do c = 1,num_elements

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -2302,8 +2302,8 @@ contains
     real (r8)          :: o2sat_1atm(num_elements) ! o2 saturation @ 1 atm (mmol/m^3)
     real (r8)          :: totalChl_loc(num_elements)  ! local value of totalChl
     real (r8)          :: flux_o2_loc(num_elements)   ! local value of o2 flux
-    type(co2calc_coeffs_type), dimension(num_elements) :: co3_coeffs
-    type(co2calc_state_type),  dimension(num_elements) :: species_concentration
+    type(co2calc_coeffs_type), dimension(num_elements) :: co2calc_coeffs
+    type(co2calc_state_type),  dimension(num_elements) :: co2calc_state
     !-----------------------------------------------------------------------
 
     associate(                                                                                      &
@@ -2447,7 +2447,7 @@ contains
           ! pass in sections of surface_input_forcings instead of associated vars because of problems with intel/15.0.3
           call marbl_co2calc_surf(                                         &
                num_elements     = num_elements,                            &
-               lcomp_co3_coeffs = .true.,                                  &
+               lcomp_co2calc_coeffs = .true.,                              &
                dic_in     = surface_vals(:,dic_ind),                       &
                xco2_in    = surface_input_forcings(ind%xco2_id)%field_0d,  &
                ta_in      = surface_vals(:,alk_ind),                       &
@@ -2456,8 +2456,8 @@ contains
                temp       = surface_input_forcings(ind%sst_id)%field_0d,   &
                salt       = surface_input_forcings(ind%sss_id)%field_0d,   &
                atmpres    = surface_input_forcings(ind%atm_pressure_id)%field_0d, &
-               co3_coeffs = co3_coeffs,                                    &
-               species_concentration = species_concentration,              &
+               co2calc_coeffs = co2calc_coeffs,                            &
+               co2calc_state = co2calc_state,                              &
                co3        = co3,                                           &
                co2star    = co2star,                                       &
                dco2star   = dco2star,                                      &
@@ -2507,7 +2507,7 @@ contains
           ! pass in sections of surface_input_forcings instead of associated vars because of problems with intel/15.0.3
           call marbl_co2calc_surf(                                         &
                num_elements     = num_elements,                            &
-               lcomp_co3_coeffs = .false.,                                 &
+               lcomp_co2calc_coeffs = .false.,                             &
                dic_in     = surface_vals(:,dic_alt_co2_ind),               &
                xco2_in    = surface_input_forcings(ind%xco2_alt_co2_id)%field_0d, &
                ta_in      = surface_vals(:,alk_alt_co2_ind),               &
@@ -2516,8 +2516,8 @@ contains
                temp       = surface_input_forcings(ind%sst_id)%field_0d,   &
                salt       = surface_input_forcings(ind%sss_id)%field_0d,   &
                atmpres    = surface_input_forcings(ind%atm_pressure_id)%field_0d, &
-               co3_coeffs = co3_coeffs,                                    &
-               species_concentration = species_concentration,              &
+               co2calc_coeffs = co2calc_coeffs,                            &
+               co2calc_state = co2calc_state,                              &
                co3        = co3,                                           &
                co2star    = co2star_alt,                                   &
                dco2star   = dco2star_alt,                                  &
@@ -3322,8 +3322,8 @@ contains
     character(len=*), parameter :: subname = 'marbl_mod:marbl_compute_carbonate_chemistry'
 
     integer :: k
-    type(co2calc_coeffs_type), dimension(domain%km) :: co3_coeffs
-    type(co2calc_state_type) , dimension(domain%km) :: species_concentration
+    type(co2calc_coeffs_type), dimension(domain%km) :: co2calc_coeffs
+    type(co2calc_state_type) , dimension(domain%km) :: co2calc_state
     logical(log_kind)        , dimension(domain%km) :: pressure_correct
     real(r8)                 , dimension(domain%km) :: ph_lower_bound
     real(r8)                 , dimension(domain%km) :: ph_upper_bound
@@ -3375,8 +3375,8 @@ contains
     enddo
 
     call marbl_comp_CO3terms(&
-         dkm, column_kmt, pressure_correct, .true., co3_coeffs, species_concentration, &
-         temperature, salinity, press_bar, dic_loc, alk_loc, po4_loc, sio3_loc,        &
+         dkm, column_kmt, pressure_correct, .true., co2calc_coeffs, co2calc_state, &
+         temperature, salinity, press_bar, dic_loc, alk_loc, po4_loc, sio3_loc,    &
          ph_lower_bound, ph_upper_bound, ph, h2co3, hco3, co3, marbl_status_log)
 
     if (marbl_status_log%labort_marbl) then
@@ -3400,7 +3400,7 @@ contains
     enddo
 
     call marbl_comp_CO3terms(&
-         dkm, column_kmt, pressure_correct, .false., co3_coeffs, species_concentration, &
+         dkm, column_kmt, pressure_correct, .false., co2calc_coeffs, co2calc_state,     &
          temperature, salinity, press_bar, dic_alt_co2_loc, alk_alt_co2_loc, po4_loc,   &
          sio3_loc, ph_lower_bound, ph_upper_bound, ph_alt_co2, h2co3_alt_co2,           &
          hco3_alt_co2, co3_alt_co2, marbl_status_log)

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -2257,8 +2257,8 @@ contains
     use marbl_schmidt_number_mod , only : schmidt_co2_surf
     use marbl_oxygen             , only : schmidt_o2_surf
     use marbl_co2calc_mod        , only : marbl_co2calc_surf
-    use marbl_co2calc_mod        , only : thermodynamic_coefficients_type
-    use marbl_co2calc_mod        , only : thermodynamic_species_concentration_type
+    use marbl_co2calc_mod        , only : co2calc_coeffs_type
+    use marbl_co2calc_mod        , only : co2calc_state_type
     use marbl_oxygen             , only : o2sat_surf
     use marbl_constants_mod      , only : molw_Fe
     use marbl_nhx_surface_emis_mod, only : marbl_comp_nhx_surface_emis
@@ -2299,8 +2299,8 @@ contains
     real (r8)               :: o2sat_1atm(num_elements) ! o2 saturation @ 1 atm (mmol/m^3)
     real (r8)               :: totalChl_loc(num_elements)  ! local value of totalChl
     real (r8)               :: flux_o2_loc(num_elements)   ! local value of o2 flux
-    type(thermodynamic_coefficients_type), dimension(num_elements) :: co3_coeffs
-    type(thermodynamic_species_concentration_type), dimension(num_elements) :: species_concentration
+    type(co2calc_coeffs_type), dimension(num_elements) :: co3_coeffs
+    type(co2calc_state_type),  dimension(num_elements) :: species_concentration
     !-----------------------------------------------------------------------
 
     associate(                                                                                      &
@@ -3296,8 +3296,8 @@ contains
 
     use marbl_co2calc_mod, only : marbl_comp_co3terms
     use marbl_co2calc_mod, only : marbl_comp_co3_sat_vals
-    use marbl_co2calc_mod, only : thermodynamic_coefficients_type
-    use marbl_co2calc_mod        , only : thermodynamic_species_concentration_type
+    use marbl_co2calc_mod, only : co2calc_coeffs_type
+    use marbl_co2calc_mod, only : co2calc_state_type
 
     type(marbl_domain_type)                 , intent(in)    :: domain
     real (r8)                               , intent(in)    :: temperature(:)
@@ -3317,17 +3317,17 @@ contains
     !-----------------------------------------------------------------------
     character(*), parameter :: subname = 'marbl_mod:marbl_compute_carbonate_chemistry'
     integer :: k
-    type(thermodynamic_coefficients_type), dimension(domain%km) :: co3_coeffs
-    type(thermodynamic_species_concentration_type), dimension(domain%km) :: species_concentration
-    logical(log_kind) , dimension(domain%km) :: pressure_correct
-    real(r8)          , dimension(domain%km) :: ph_lower_bound
-    real(r8)          , dimension(domain%km) :: ph_upper_bound
-    real(r8)          , dimension(domain%km) :: dic_loc
-    real(r8)          , dimension(domain%km) :: dic_alt_co2_loc
-    real(r8)          , dimension(domain%km) :: alk_loc
-    real(r8)          , dimension(domain%km) :: alk_alt_co2_loc
-    real(r8)          , dimension(domain%km) :: po4_loc
-    real(r8)          , dimension(domain%km) :: sio3_loc
+    type(co2calc_coeffs_type), dimension(domain%km) :: co3_coeffs
+    type(co2calc_state_type) , dimension(domain%km) :: species_concentration
+    logical(log_kind)        , dimension(domain%km) :: pressure_correct
+    real(r8)                 , dimension(domain%km) :: ph_lower_bound
+    real(r8)                 , dimension(domain%km) :: ph_upper_bound
+    real(r8)                 , dimension(domain%km) :: dic_loc
+    real(r8)                 , dimension(domain%km) :: dic_alt_co2_loc
+    real(r8)                 , dimension(domain%km) :: alk_loc
+    real(r8)                 , dimension(domain%km) :: alk_alt_co2_loc
+    real(r8)                 , dimension(domain%km) :: po4_loc
+    real(r8)                 , dimension(domain%km) :: sio3_loc
     !-----------------------------------------------------------------------
 
     ! make local copies instead of using associate construct because of gnu fortran bug


### PR DESCRIPTION
Per #19, have put dic, ta, pt, and sit in their own data type.

I used the name `thermodynamic_species_concentration_type` based on the comment above the declaration (`declarations for function coefficients & species concentrations`) but am happy to change it to something more appropriate.

Verified this code builds on the usual machines / compilers, and that it does not change answers in my one-off ciso gx3v7 test on hobart (nag) or cheyenne (intel).