### PR TITLE
ciso_interior_forcing shouldn't set DIC_ & DOC_loc

### DIFF
--- a/src/marbl_ciso_mod.F90
+++ b/src/marbl_ciso_mod.F90
@@ -238,7 +238,7 @@ contains
     type(marbl_interior_share_type)         , intent(in)    :: marbl_interior_share(marbl_domain%km)
     type(marbl_zooplankton_share_type)      , intent(in)    :: marbl_zooplankton_share(zooplankton_cnt, marbl_domain%km)
     type(marbl_autotroph_share_type)        , intent(in)    :: marbl_autotroph_share(autotroph_cnt, marbl_domain%km)
-    type(marbl_particulate_share_type)      , intent(inout) :: marbl_particulate_share
+    type(marbl_particulate_share_type)      , intent(in)    :: marbl_particulate_share
     real (r8)                               , intent(in)    :: temperature(:)
     real (r8)                               , intent(in)    :: column_tracer(:,:)
     real (r8)                               , intent(inout) :: column_dtracer(:,:)  ! computed source/sink terms (inout because we don't touch non-ciso tracers)

--- a/src/marbl_ciso_mod.F90
+++ b/src/marbl_ciso_mod.F90
@@ -234,9 +234,8 @@ contains
 
     implicit none
 
-    type(marbl_domain_type)                 , intent(in)    :: marbl_domain                               
-    ! FIXME #17: intent is inout due to DIC_Loc
-    type(marbl_interior_share_type)         , intent(inout) :: marbl_interior_share(marbl_domain%km)
+    type(marbl_domain_type)                 , intent(in)    :: marbl_domain
+    type(marbl_interior_share_type)         , intent(in)    :: marbl_interior_share(marbl_domain%km)
     type(marbl_zooplankton_share_type)      , intent(in)    :: marbl_zooplankton_share(zooplankton_cnt, marbl_domain%km)
     type(marbl_autotroph_share_type)        , intent(in)    :: marbl_autotroph_share(autotroph_cnt, marbl_domain%km)
     type(marbl_particulate_share_type)      , intent(inout) :: marbl_particulate_share
@@ -461,11 +460,6 @@ contains
     !-----------------------------------------------------------------------
 
     do k = 1, column_km
-
-       if (k > column_kmt) then
-          DIC_loc(k) = c0
-          DOC_loc(k) = c0
-       end if
 
        !-----------------------------------------------------------------------
        !  set local 13C/12C ratios, assuming ecosystem carries 12C (C=C12+C13+C14)

--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -40,7 +40,6 @@ module marbl_interface
   use marbl_internal_types  , only : marbl_interior_forcing_indexing_type
   use marbl_internal_types  , only : marbl_interior_saved_state_indexing_type
   use marbl_internal_types  , only : marbl_PAR_type
-  use marbl_internal_types  , only : marbl_interior_share_type
   use marbl_internal_types  , only : marbl_autotroph_share_type
   use marbl_internal_types  , only : marbl_zooplankton_share_type
   use marbl_internal_types  , only : marbl_particulate_share_type
@@ -117,7 +116,6 @@ module marbl_interface
      ! private data
      type(marbl_PAR_type)                      , private              :: PAR
      type(marbl_particulate_share_type)        , private              :: particulate_share
-     type(marbl_interior_share_type)           , private, allocatable :: interior_share(:)
      type(marbl_zooplankton_share_type)        , private, allocatable :: zooplankton_share(:,:)
      type(marbl_autotroph_share_type)          , private, allocatable :: autotroph_share(:,:)
      type(marbl_surface_forcing_share_type)    , private              :: surface_forcing_share
@@ -349,8 +347,6 @@ contains
     call this%PAR%construct(num_levels, num_PAR_subcols)
 
     call this%particulate_share%construct(num_levels)
-
-    allocate (this%interior_share(num_levels))
 
     allocate (this%zooplankton_share(zooplankton_cnt, num_levels))
 
@@ -729,7 +725,6 @@ contains
          marbl_timers             = this%timers,                              &
          marbl_timer_indices      = this%timer_ids,                           &
          PAR                      = this%PAR,                                 &
-         marbl_interior_share     = this%interior_share,                      &
          marbl_zooplankton_share  = this%zooplankton_share,                   &
          marbl_autotroph_share    = this%autotroph_share,                     &
          marbl_particulate_share  = this%particulate_share,                   &

--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -40,10 +40,7 @@ module marbl_interface
   use marbl_internal_types  , only : marbl_interior_forcing_indexing_type
   use marbl_internal_types  , only : marbl_interior_saved_state_indexing_type
   use marbl_internal_types  , only : marbl_PAR_type
-  use marbl_internal_types  , only : marbl_autotroph_share_type
-  use marbl_internal_types  , only : marbl_zooplankton_share_type
   use marbl_internal_types  , only : marbl_particulate_share_type
-  use marbl_internal_types  , only : marbl_surface_forcing_share_type
   use marbl_internal_types  , only : marbl_surface_forcing_internal_type
   use marbl_internal_types  , only : marbl_tracer_index_type
   use marbl_internal_types  , only : marbl_internal_timers_type
@@ -116,9 +113,6 @@ module marbl_interface
      ! private data
      type(marbl_PAR_type)                      , private              :: PAR
      type(marbl_particulate_share_type)        , private              :: particulate_share
-     type(marbl_zooplankton_share_type)        , private, allocatable :: zooplankton_share(:,:)
-     type(marbl_autotroph_share_type)          , private, allocatable :: autotroph_share(:,:)
-     type(marbl_surface_forcing_share_type)    , private              :: surface_forcing_share
      type(marbl_surface_forcing_internal_type) , private              :: surface_forcing_internal
      logical                                   , private              :: lallow_glo_ops
      type(marbl_internal_timers_type)          , private              :: timers
@@ -348,10 +342,6 @@ contains
 
     call this%particulate_share%construct(num_levels)
 
-    allocate (this%zooplankton_share(zooplankton_cnt, num_levels))
-
-    allocate (this%autotroph_share(autotroph_cnt, num_levels))
-
     call this%domain%construct(                                 &
          num_levels                    = num_levels,            &
          num_PAR_subcols               = num_PAR_subcols,       &
@@ -558,7 +548,6 @@ contains
       return
     end if
 
-    call this%surface_forcing_share%construct(num_surface_elements)
     call this%surface_forcing_internal%construct(num_surface_elements)
 
     allocate(this%surface_input_forcings(num_surface_forcing_fields))
@@ -725,8 +714,6 @@ contains
          marbl_timers             = this%timers,                              &
          marbl_timer_indices      = this%timer_ids,                           &
          PAR                      = this%PAR,                                 &
-         marbl_zooplankton_share  = this%zooplankton_share,                   &
-         marbl_autotroph_share    = this%autotroph_share,                     &
          marbl_particulate_share  = this%particulate_share,                   &
          interior_forcing_diags   = this%interior_forcing_diags,              &
          glo_avg_fields_interior  = this%glo_avg_fields_interior,             &
@@ -774,7 +761,6 @@ contains
          saved_state_ind          = this%surf_state_ind,                      &
          surface_forcing_output   = this%surface_forcing_output,              &
          surface_forcing_internal = this%surface_forcing_internal,            &
-         surface_forcing_share    = this%surface_forcing_share,               &
          surface_forcing_diags    = this%surface_forcing_diags,               &
          glo_avg_fields_surface   = this%glo_avg_fields_surface,              &
          marbl_status_log         = this%StatusLog)

--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -41,6 +41,7 @@ module marbl_interface
   use marbl_internal_types  , only : marbl_interior_saved_state_indexing_type
   use marbl_internal_types  , only : marbl_PAR_type
   use marbl_internal_types  , only : marbl_particulate_share_type
+  use marbl_internal_types  , only : marbl_surface_forcing_share_type
   use marbl_internal_types  , only : marbl_surface_forcing_internal_type
   use marbl_internal_types  , only : marbl_tracer_index_type
   use marbl_internal_types  , only : marbl_internal_timers_type
@@ -113,6 +114,7 @@ module marbl_interface
      ! private data
      type(marbl_PAR_type)                      , private              :: PAR
      type(marbl_particulate_share_type)        , private              :: particulate_share
+     type(marbl_surface_forcing_share_type)    , private              :: surface_forcing_share
      type(marbl_surface_forcing_internal_type) , private              :: surface_forcing_internal
      logical                                   , private              :: lallow_glo_ops
      type(marbl_internal_timers_type)          , private              :: timers
@@ -548,6 +550,7 @@ contains
       return
     end if
 
+    call this%surface_forcing_share%construct(num_surface_elements)
     call this%surface_forcing_internal%construct(num_surface_elements)
 
     allocate(this%surface_input_forcings(num_surface_forcing_fields))
@@ -761,6 +764,7 @@ contains
          saved_state_ind          = this%surf_state_ind,                      &
          surface_forcing_output   = this%surface_forcing_output,              &
          surface_forcing_internal = this%surface_forcing_internal,            &
+         surface_forcing_share    = this%surface_forcing_share,               &
          surface_forcing_diags    = this%surface_forcing_diags,               &
          glo_avg_fields_surface   = this%glo_avg_fields_surface,              &
          marbl_status_log         = this%StatusLog)

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -2242,6 +2242,7 @@ contains
        saved_state_ind,                 &
        surface_forcing_output,          &
        surface_forcing_internal,        &
+       surface_forcing_share,           &
        surface_forcing_diags,           &
        glo_avg_fields_surface,          &
        marbl_status_log)
@@ -2276,6 +2277,7 @@ contains
     type(marbl_surface_saved_state_indexing_type), intent(in) :: saved_state_ind
     type(marbl_surface_forcing_internal_type) , intent(inout) :: surface_forcing_internal
     type(marbl_surface_forcing_output_type)   , intent(inout) :: surface_forcing_output
+    type(marbl_surface_forcing_share_type)    , intent(inout) :: surface_forcing_share
     type(marbl_diagnostics_type)              , intent(inout) :: surface_forcing_diags
     real (r8)                                 , intent(out)   :: glo_avg_fields_surface(:,:)
     type(marbl_log_type)                      , intent(inout) :: marbl_status_log
@@ -2294,7 +2296,6 @@ contains
     real (r8)               :: totalChl_loc(num_elements)  ! local value of totalChl
     real (r8)               :: flux_o2_loc(num_elements)   ! local value of o2 flux
     type(thermodynamic_coefficients_type), dimension(num_elements) :: co3_coeffs
-    type(marbl_surface_forcing_share_type) :: surface_forcing_share
     !-----------------------------------------------------------------------
 
     associate(                                                                                      &

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -916,7 +916,6 @@ contains
        marbl_timers,                     &
        marbl_timer_indices,              &
        PAR,                              &
-       marbl_interior_share,             &
        marbl_zooplankton_share,          &
        marbl_autotroph_share,            &
        marbl_particulate_share,          &
@@ -945,7 +944,6 @@ contains
     type    (marbl_tracer_index_type)           , intent(in)    :: marbl_tracer_indices
     type    (marbl_internal_timers_type)        , intent(inout) :: marbl_timers
     type    (marbl_timer_indexing_type)         , intent(in)    :: marbl_timer_indices
-    type    (marbl_interior_share_type)         , intent(inout) :: marbl_interior_share(domain%km)
     type    (marbl_zooplankton_share_type)      , intent(inout) :: marbl_zooplankton_share(zooplankton_cnt, domain%km)
     type    (marbl_autotroph_share_type)        , intent(inout) :: marbl_autotroph_share(autotroph_cnt, domain%km)
     type    (marbl_particulate_share_type)      , intent(inout) :: marbl_particulate_share
@@ -958,6 +956,8 @@ contains
     !-----------------------------------------------------------------------
     character(*), parameter :: subname = 'marbl_mod:marbl_set_interior_forcing'
     real(r8), dimension(marbl_total_tracer_cnt, domain%km) :: interior_restore
+
+    type    (marbl_interior_share_type) :: marbl_interior_share(domain%km)
 
     integer (int_kind) :: n         ! tracer index
     integer (int_kind) :: k         ! vertical level index
@@ -5191,24 +5191,19 @@ contains
     real(r8)                            , intent(in)    :: QA_dust_def
     type(marbl_interior_share_type)     , intent(inout) :: marbl_interior_share
 
-    associate( &
-         share => marbl_interior_share &
-         )
-
-    share%QA_dust_def    = QA_dust_def
-    share%DIC_loc_fields = tracer_local(marbl_tracer_indices%DIC_ind)
-    share%DOC_loc_fields = tracer_local(marbl_tracer_indices%DOC_ind)
-    share%O2_loc_fields  = tracer_local(marbl_tracer_indices%O2_ind)
-    share%NO3_loc_fields = tracer_local(marbl_tracer_indices%NO3_ind)
+    marbl_interior_share%QA_dust_def    = QA_dust_def
+    marbl_interior_share%DIC_loc_fields = tracer_local(marbl_tracer_indices%DIC_ind)
+    marbl_interior_share%DOC_loc_fields = tracer_local(marbl_tracer_indices%DOC_ind)
+    marbl_interior_share%O2_loc_fields  = tracer_local(marbl_tracer_indices%O2_ind)
+    marbl_interior_share%NO3_loc_fields = tracer_local(marbl_tracer_indices%NO3_ind)
 
 
-    share%CO3_fields   = carbonate%CO3
-    share%HCO3_fields  = carbonate%HCO3
-    share%H2CO3_fields = carbonate%H2CO3
+    marbl_interior_share%CO3_fields   = carbonate%CO3
+    marbl_interior_share%HCO3_fields  = carbonate%HCO3
+    marbl_interior_share%H2CO3_fields = carbonate%H2CO3
 
-    share%DOC_remin_fields = dissolved_organic_matter%DOC_remin
+    marbl_interior_share%DOC_remin_fields = dissolved_organic_matter%DOC_remin
 
-    end associate
   end subroutine marbl_export_interior_shared_variables
 
   !-----------------------------------------------------------------------

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -945,7 +945,6 @@ contains
     type    (marbl_tracer_index_type)           , intent(in)    :: marbl_tracer_indices
     type    (marbl_internal_timers_type)        , intent(inout) :: marbl_timers
     type    (marbl_timer_indexing_type)         , intent(in)    :: marbl_timer_indices
-    ! FIXME #17: intent is inout due to DIC_Loc
     type    (marbl_interior_share_type)         , intent(inout) :: marbl_interior_share(domain%km)
     type    (marbl_zooplankton_share_type)      , intent(inout) :: marbl_zooplankton_share(zooplankton_cnt, domain%km)
     type    (marbl_autotroph_share_type)        , intent(inout) :: marbl_autotroph_share(autotroph_cnt, domain%km)

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -916,8 +916,6 @@ contains
        marbl_timers,                     &
        marbl_timer_indices,              &
        PAR,                              &
-       marbl_zooplankton_share,          &
-       marbl_autotroph_share,            &
        marbl_particulate_share,          &
        interior_forcing_diags,           &
        glo_avg_fields_interior,          &
@@ -944,8 +942,6 @@ contains
     type    (marbl_tracer_index_type)           , intent(in)    :: marbl_tracer_indices
     type    (marbl_internal_timers_type)        , intent(inout) :: marbl_timers
     type    (marbl_timer_indexing_type)         , intent(in)    :: marbl_timer_indices
-    type    (marbl_zooplankton_share_type)      , intent(inout) :: marbl_zooplankton_share(zooplankton_cnt, domain%km)
-    type    (marbl_autotroph_share_type)        , intent(inout) :: marbl_autotroph_share(autotroph_cnt, domain%km)
     type    (marbl_particulate_share_type)      , intent(inout) :: marbl_particulate_share
     type    (marbl_diagnostics_type)            , intent(inout) :: interior_forcing_diags
     real    (r8)                                , intent(out)   :: glo_avg_fields_interior(:)
@@ -957,7 +953,9 @@ contains
     character(*), parameter :: subname = 'marbl_mod:marbl_set_interior_forcing'
     real(r8), dimension(marbl_total_tracer_cnt, domain%km) :: interior_restore
 
-    type    (marbl_interior_share_type) :: marbl_interior_share(domain%km)
+    type(marbl_interior_share_type)    :: marbl_interior_share(domain%km)
+    type(marbl_autotroph_share_type)   :: marbl_autotroph_share(autotroph_cnt, domain%km)
+    type(marbl_zooplankton_share_type) :: marbl_zooplankton_share(zooplankton_cnt, domain%km)
 
     integer (int_kind) :: n         ! tracer index
     integer (int_kind) :: k         ! vertical level index
@@ -2244,7 +2242,6 @@ contains
        saved_state_ind,                 &
        surface_forcing_output,          &
        surface_forcing_internal,        &
-       surface_forcing_share,           &
        surface_forcing_diags,           &
        glo_avg_fields_surface,          &
        marbl_status_log)
@@ -2279,7 +2276,6 @@ contains
     type(marbl_surface_saved_state_indexing_type), intent(in) :: saved_state_ind
     type(marbl_surface_forcing_internal_type) , intent(inout) :: surface_forcing_internal
     type(marbl_surface_forcing_output_type)   , intent(inout) :: surface_forcing_output
-    type(marbl_surface_forcing_share_type)    , intent(inout) :: surface_forcing_share
     type(marbl_diagnostics_type)              , intent(inout) :: surface_forcing_diags
     real (r8)                                 , intent(out)   :: glo_avg_fields_surface(:,:)
     type(marbl_log_type)                      , intent(inout) :: marbl_status_log
@@ -2298,6 +2294,7 @@ contains
     real (r8)               :: totalChl_loc(num_elements)  ! local value of totalChl
     real (r8)               :: flux_o2_loc(num_elements)   ! local value of o2 flux
     type(thermodynamic_coefficients_type), dimension(num_elements) :: co3_coeffs
+    type(marbl_surface_forcing_share_type) :: surface_forcing_share
     !-----------------------------------------------------------------------
 
     associate(                                                                                      &


### PR DESCRIPTION
The DIC_loc_fields and DOC_loc_fields components of
marbl_interior_share_type are initialized to c0 below level kmt in
marbl_setup_local_tracers() [since all values in tracer_local = c0 for
k>kmt]. By not setting these two components to c0 in marbl_ciso_mod, we
can change the intent of the interior_share argument from intent(inout)
to intent(in).