### PR TITLE
marbl_status_log no longer optional in drtsafe

### DIFF
--- a/src/marbl_co2calc_mod.F90
+++ b/src/marbl_co2calc_mod.F90
@@ -814,7 +814,7 @@ contains
     real(kind=r8)                         , intent(inout) :: x1(num_elements)
     real(kind=r8)                         , intent(inout) :: x2(num_elements)
     real(kind=r8)                         , intent(out)   :: soln(num_elements)
-    type(marbl_log_type), optional        , intent(inout) :: marbl_status_log
+    type(marbl_log_type)                  , intent(inout) :: marbl_status_log
 
     !---------------------------------------------------------------------------
     !   local variable declarations
@@ -859,30 +859,22 @@ contains
           if (mask(c)) then
              ! Log a warning message if bounding box end points have same sign
              ! (no guarantee that there is a root on the interval)
-             if (present(marbl_status_log)) then
-                ! FIXME #21: make marbl_status_log required - this is currently needed
-                !            since abio_dic_dic14_mod is calling this routine but has
-                !            not itself been MARBLized yet
-                WRITE(log_message,"(3A,1X,A,I0)") '(', subname, ')', 'it = ', it
-                call marbl_status_log%log_noerror(log_message, subname, c, &
-                                lonly_master_writes=.false.)
-                WRITE(log_message,"(3A,1X,A,2E15.7e3)") '(', subname, ')', &
-                     'x1,f = ', x1(c), flo(c)
-                call marbl_status_log%log_noerror(log_message, subname, c, &
-                                lonly_master_writes=.false.)
-                WRITE(log_message,"(3A,1X,A,2E15.7e3)") '(', subname, ')', &
-                     'x2,f = ', x2(c), fhi(c)
-                call marbl_status_log%log_noerror(log_message, subname, c, &
-                                lonly_master_writes=.false.)
-             end if
+             WRITE(log_message,"(3A,1X,A,I0)") '(', subname, ')', 'it = ', it
+             call marbl_status_log%log_noerror(log_message, subname, c,       &
+                             lonly_master_writes=.false.)
+             WRITE(log_message,"(3A,1X,A,2E15.7e3)") '(', subname, ')',       &
+                  'x1,f = ', x1(c), flo(c)
+             call marbl_status_log%log_noerror(log_message, subname, c,       &
+                             lonly_master_writes=.false.)
+             WRITE(log_message,"(3A,1X,A,2E15.7e3)") '(', subname, ')',       &
+                  'x2,f = ', x2(c), fhi(c)
+             call marbl_status_log%log_noerror(log_message, subname, c,       &
+                             lonly_master_writes=.false.)
 
              ! Error if iteration count exceeds max_bracket_grow_it
              if (it > max_bracket_grow_it) then
-                if (present(marbl_status_log)) then
-                   ! FIXME #21 (see above)
-                   log_message = "bounding bracket for pH solution not found"
-                   call marbl_status_log%log_error(log_message, subname, c)
-                end if
+                log_message = "bounding bracket for pH solution not found"
+                call marbl_status_log%log_error(log_message, subname, c)
                 abort = .true.
              end if
           end if
@@ -942,7 +934,7 @@ contains
           end if
        end do
 
-       if (.not. ANY(mask)) return 
+       if (.not. ANY(mask)) return
 
        call total_alkalinity(num_elements, mask, k1, k2, soln, co3_coeffs, f, df)
 
@@ -951,7 +943,7 @@ contains
              if (f(c) .LT. c0) then
                 xlo(c) = soln(c)
                 flo(c) = f(c)
-             else   
+             else
                 xhi(c) = soln(c)
                 fhi(c) = f(c)
              end if


### PR DESCRIPTION
There was a period of time where POP's abio tracer module was using MARBL's
solver, which meant we needed to be able to call drtsafe without a
marbl_status_log. Since that is no longer the case, and since omitting the
status log would mean that MARBL would error out silently, it makes more sense
to require this argument to the subroutine.

Note that all calls to drtsafe from inside MARBL already pass this optional
argument, so these changes were contained to drtsafe() itself.