### PR TITLE
CaCO3_form instead of CaCO3_prod

### DIFF
--- a/src/marbl_ciso_mod.F90
+++ b/src/marbl_ciso_mod.F90
@@ -296,12 +296,12 @@ contains
          mui_to_co2star_loc     ! local carbon autotroph instanteous growth rate over [CO2*] (m^3 /mol C /s)
 
     real (r8), dimension(marbl_domain%km) :: &
-         R13C_CaCO3_PROD,   & ! 13C/12C in CaCO3 production of small phyto
+         R13C_CaCO3_form,   & ! 13C/12C in CaCO3 production of small phyto
          R13C_CO2STAR,      & ! 13C/12C in CO2* water
          R13C_DIC,          & ! 13C/12C in total DIC
          R13C_DOC,          & ! 13C/12C in total DOC
          R13C_zooC,         & ! 13C/12C in total zooplankton
-         R14C_CaCO3_PROD,   & ! 14C/12C in CaCO3 production of small phyto
+         R14C_CaCO3_form,   & ! 14C/12C in CaCO3 production of small phyto
          R14C_CO2STAR,      & ! 14C/12C in CO2* water
          R14C_DIC,          & ! 14C/12C in total DIC
          R14C_DOC,          & ! 14C/12C in total DOC
@@ -379,7 +379,7 @@ contains
          auto_loss_dic      => marbl_autotroph_share%auto_loss_dic_fields      , & ! INPUT auto_loss routed to dic (mmol C/m^3/sec)                                      
          auto_agg           => marbl_autotroph_share%auto_agg_fields           , & ! INPUT autotroph aggregation (mmol C/m^3/sec)                                        
          photoC             => marbl_autotroph_share%photoC_fields             , & ! INPUT C-fixation (mmol C/m^3/sec)                                                   
-         CaCO3_PROD         => marbl_autotroph_share%CaCO3_PROD_fields         , & ! INPUT prod. of CaCO3 by small phyto (mmol CaCO3/m^3/sec)                            
+         CaCO3_form         => marbl_autotroph_share%CaCO3_form_fields         , & ! INPUT prod. of CaCO3 by small phyto (mmol CaCO3/m^3/sec)                            
          PCphoto            => marbl_autotroph_share%PCphoto_fields            , & ! INPUT C-specific rate of photosynth. (1/sec)                                        
 
          zooC_loc           => marbl_zooplankton_share%zooC_loc_fields         , & ! INPUT local copy of model zooC                                                      
@@ -670,26 +670,24 @@ contains
           ! Use R13/14C_photoC to determine small phytoplankton, Diatom, and
           ! Diaztroph 13C and 14C fixation
           !-----------------------------------------------------------------------
-          
+
           photo13C(auto_ind,k) = photoC(auto_ind,k) * R13C_photoC(auto_ind,k)
           photo14C(auto_ind,k) = photoC(auto_ind,k) * R14C_photoC(auto_ind,k)
-          
+
           !-----------------------------------------------------------------------
           ! C13 & C14 CaCO3 production
           !-----------------------------------------------------------------------
 
           if (autotrophs_config(auto_ind)%imp_calcifier) then
-             
-             R13C_CaCO3_PROD(k) = R13C_DIC(k) + R13C_std * eps_carb / c1000 
-             
-             R14C_CaCO3_PROD(k) = R14C_DIC(k) + R14C_std * eps_carb * 2.0_r8 / c1000
-             
-             Ca13CO3_PROD(auto_ind,k) = CaCO3_PROD(auto_ind,k) * R13C_CaCO3_PROD(k)
-             
-             Ca14CO3_PROD(auto_ind,k) = CaCO3_PROD(auto_ind,k) * R14C_CaCO3_PROD(k)
+
+             R13C_CaCO3_form(k) = R13C_DIC(k) + R13C_std * eps_carb / c1000
+             R14C_CaCO3_form(k) = R14C_DIC(k) + R14C_std * eps_carb * 2.0_r8 / c1000
+
+             Ca13CO3_PROD(auto_ind,k) = CaCO3_form(auto_ind,k) * R13C_CaCO3_form(k)
+             Ca14CO3_PROD(auto_ind,k) = CaCO3_form(auto_ind,k) * R14C_CaCO3_form(k)
 
           end if
-             
+
        end do ! end loop over auto_ind
 
        !-----------------------------------------------------------------------

--- a/src/marbl_diagnostics_mod.F90
+++ b/src/marbl_diagnostics_mod.F90
@@ -3650,7 +3650,7 @@ contains
        endif
 
        if (ind%CaCO3_form(n).ne.-1) then
-          diags(ind%CaCO3_form(n))%field_3d(:, 1)  = autotroph_secondary_species(n,:)%CaCO3_PROD
+          diags(ind%CaCO3_form(n))%field_3d(:, 1)  = autotroph_secondary_species(n,:)%CaCO3_form
           diags(ind%tot_CaCO3_form)%field_3d(:, 1) = diags(ind%tot_CaCO3_form)%field_3d(:, 1) + &
                diags(ind%CaCO3_form(n))%field_3d(:, 1)
        end if
@@ -3679,7 +3679,7 @@ contains
 
        ! vertical integrals
        if (ind%CaCO3_form_zint(n).ne.-1) then
-          call compute_vertical_integrals(autotroph_secondary_species(n,:)%CaCO3_PROD, &
+          call compute_vertical_integrals(autotroph_secondary_species(n,:)%CaCO3_form, &
                delta_z, kmt, full_depth_integral=diags(ind%CaCO3_form_zint(n))%field_2d(1))
 
           diags(ind%tot_CaCO3_form_zint)%field_2d(1) = diags(ind%tot_CaCO3_form_zint)%field_2d(1) + &

--- a/src/marbl_internal_types.F90
+++ b/src/marbl_internal_types.F90
@@ -204,7 +204,7 @@ module marbl_internal_types
      real(r8) :: auto_loss_dic_fields      ! auto_loss routed to dic (mmol C/m^3/sec)
      real(r8) :: auto_agg_fields           ! autotroph aggregation (mmol C/m^3/sec)
      real(r8) :: photoC_fields             ! C-fixation (mmol C/m^3/sec)
-     real(r8) :: CaCO3_PROD_fields         ! prod. of CaCO3 by small phyto (mmol CaCO3/m^3/sec)
+     real(r8) :: CaCO3_form_fields         ! calcification of CaCO3 by small phyto (mmol CaCO3/m^3/sec)
      real(r8) :: PCphoto_fields            ! C-specific rate of photosynth. (1/sec)
   end type marbl_autotroph_share_type
 
@@ -296,7 +296,7 @@ module marbl_internal_types
      real (r8) :: auto_graze_doc  ! auto_graze routed to doc (mmol C/m^3/sec)
      real (r8) :: auto_graze_dic  ! auto_graze routed to dic (mmol C/m^3/sec)
      real (r8) :: Pprime          ! used to limit autotroph mort at low biomass (mmol C/m^3)
-     real (r8) :: CaCO3_PROD      ! prod. of CaCO3 by small phyto (mmol CaCO3/m^3/sec)
+     real (r8) :: CaCO3_form      ! calcification of CaCO3 by small phyto (mmol CaCO3/m^3/sec)
      real (r8) :: Nfix            ! total Nitrogen fixation (mmol N/m^3/sec)
      real (r8) :: Nexcrete        ! fixed N excretion
      real (r8) :: remaining_P_dop ! remaining_P from grazing routed to DOP pool

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -3820,21 +3820,21 @@ contains
     associate(                                                       &
          f_nut      => autotroph_secondary_species(:)%f_nut,     & ! input
          photoC     => autotroph_secondary_species(:)%photoC,    & ! input
-         CaCO3_PROD => autotroph_secondary_species(:)%CaCO3_PROD & ! output
+         CaCO3_form => autotroph_secondary_species(:)%CaCO3_form & ! output
          )
 
     do auto_ind = 1, auto_cnt
        if (auto_config(auto_ind)%imp_calcifier) then
-          CaCO3_PROD(auto_ind) = parm_f_prod_sp_CaCO3 * photoC(auto_ind)
-          CaCO3_PROD(auto_ind) = CaCO3_PROD(auto_ind) * f_nut(auto_ind) * f_nut(auto_ind)
+          CaCO3_form(auto_ind) = parm_f_prod_sp_CaCO3 * photoC(auto_ind)
+          CaCO3_form(auto_ind) = CaCO3_form(auto_ind) * f_nut(auto_ind) * f_nut(auto_ind)
 
           if (temperature < CaCO3_temp_thres1)  then
-             CaCO3_PROD(auto_ind) = CaCO3_PROD(auto_ind) * max((temperature - CaCO3_temp_thres2), c0) / &
+             CaCO3_form(auto_ind) = CaCO3_form(auto_ind) * max((temperature - CaCO3_temp_thres2), c0) / &
                   (CaCO3_temp_thres1-CaCO3_temp_thres2)
           end if
 
           if (autotroph_loc(auto_ind)%C > CaCO3_sp_thres) then
-             CaCO3_PROD(auto_ind) = min((CaCO3_PROD(auto_ind) * autotroph_loc(auto_ind)%C / CaCO3_sp_thres), &
+             CaCO3_form(auto_ind) = min((CaCO3_form(auto_ind) * autotroph_loc(auto_ind)%C / CaCO3_sp_thres), &
                   (f_photosp_CaCO3 * photoC(auto_ind)))
           end if
        end if
@@ -4942,7 +4942,7 @@ contains
          auto_graze_zoo  => autotroph_secondary_species(:)%auto_graze_zoo  , & ! auto_graze routed to zoo (mmol C/m^3/sec)
          auto_graze_dic  => autotroph_secondary_species(:)%auto_graze_dic  , & ! auto_graze routed to dic (mmol C/m^3/sec)
          auto_graze_doc  => autotroph_secondary_species(:)%auto_graze_doc  , & ! auto_graze routed to doc (mmol C/m^3/sec)
-         CaCO3_PROD      => autotroph_secondary_species(:)%CaCO3_PROD      , & ! prod. of CaCO3 by small phyto (mmol CaCO3/m^3/sec)
+         CaCO3_form      => autotroph_secondary_species(:)%CaCO3_form      , & ! prod. of CaCO3 by small phyto (mmol CaCO3/m^3/sec)
          Nfix            => autotroph_secondary_species(:)%Nfix            , & ! total Nitrogen fixation (mmol N/m^3/sec)
          Nexcrete        => autotroph_secondary_species(:)%Nexcrete        , & ! fixed N excretion
          remaining_P_dip => autotroph_secondary_species(:)%remaining_P_dip , & ! remaining_P from mort routed to remin
@@ -5086,7 +5086,7 @@ contains
 
        n = marbl_tracer_indices%auto_inds(auto_ind)%CaCO3_ind
        if (n > 0) then
-          dtracers(n) = CaCO3_PROD(auto_ind) - QCaCO3(auto_ind) * auto_sum
+          dtracers(n) = CaCO3_form(auto_ind) - QCaCO3(auto_ind) * auto_sum
        endif
     end do
 
@@ -5120,7 +5120,7 @@ contains
     do auto_ind = 1, auto_cnt
        if (marbl_tracer_indices%auto_inds(auto_ind)%CaCO3_ind > 0) then
           dtracers(dic_ind) = dtracers(dic_ind) &
-               + f_graze_CaCO3_REMIN * auto_graze(auto_ind) * QCaCO3(auto_ind) - CaCO3_PROD(auto_ind)
+               + f_graze_CaCO3_REMIN * auto_graze(auto_ind) * QCaCO3(auto_ind) - CaCO3_form(auto_ind)
        end if
     end do
 
@@ -5135,7 +5135,7 @@ contains
     do auto_ind = 1, auto_cnt
        if (marbl_tracer_indices%auto_inds(auto_ind)%CaCO3_ind > 0) then
           dtracers(alk_ind) = dtracers(alk_ind) &
-               + c2 * (f_graze_CaCO3_REMIN * auto_graze(auto_ind) * QCaCO3(auto_ind) - CaCO3_PROD(auto_ind))
+               + c2 * (f_graze_CaCO3_REMIN * auto_graze(auto_ind) * QCaCO3(auto_ind) - CaCO3_form(auto_ind))
        end if
     end do
 
@@ -5293,7 +5293,7 @@ contains
        share(n)%auto_loss_dic_fields  = autotroph_secondary_species(n)%auto_loss_dic
        share(n)%auto_agg_fields       = autotroph_secondary_species(n)%auto_agg
        share(n)%photoC_fields         = autotroph_secondary_species(n)%photoC
-       share(n)%CaCO3_PROD_fields     = autotroph_secondary_species(n)%CaCO3_PROD
+       share(n)%CaCO3_form_fields     = autotroph_secondary_species(n)%CaCO3_form
        share(n)%PCphoto_fields        = autotroph_secondary_species(n)%PCphoto
     end do
     end associate


### PR DESCRIPTION
This name change applies to the components of `marbl_autotroph_share_type` and
`autotroph_secondary_species_type`, and was done to ensure consistency between
internal variable names and the variable names provided in diagnostic output.