### PR TITLE
Error checking when adding new config var

### DIFF
--- a/src/marbl_config_mod.F90
+++ b/src/marbl_config_mod.F90
@@ -654,6 +654,40 @@ contains
 
     ! 3) copy this%vars into first N-1 elements of new_vars
     do n=1, old_size
+      ! Also do some error checking
+      ! (a) Ensure sname does not match a previous variable short_name
+      if (trim(sname) .eq. trim(this%vars(n)%short_name)) then
+        write(log_message, "(A,1X,A)") trim(sname), "has been added twice"
+        call marbl_status_log%log_error(log_message, subname)
+      end if
+
+      ! (b) Ensure pointers do not point to same target as other variables
+      if (present(rptr)) then
+        if (associated(rptr, this%vars(n)%rptr)) then
+          write(log_message, "(4A)") trim(sname), " and ", trim(this%vars(n)%short_name), &
+                                     " both point to same variable in memory."
+        end if
+      end if
+      if (present(iptr)) then
+        if (associated(iptr, this%vars(n)%iptr)) then
+          write(log_message, "(4A)") trim(sname), " and ", trim(this%vars(n)%short_name), &
+                                     " both point to same variable in memory."
+        end if
+      end if
+      if (present(lptr)) then
+        if (associated(lptr, this%vars(n)%lptr)) then
+          write(log_message, "(4A)") trim(sname), " and ", trim(this%vars(n)%short_name), &
+                                     " both point to same variable in memory."
+        end if
+      end if
+      if (present(sptr)) then
+        if (associated(sptr, this%vars(n)%sptr)) then
+          write(log_message, "(4A)") trim(sname), " and ", trim(this%vars(n)%short_name), &
+                                     " both point to same variable in memory."
+        end if
+      end if
+      if (marbl_status_log%labort_marbl) return
+
       new_vars(n)%long_name     = this%vars(n)%long_name
       new_vars(n)%short_name    = this%vars(n)%short_name
       new_vars(n)%units         = this%vars(n)%units

--- a/src/marbl_config_mod.F90
+++ b/src/marbl_config_mod.F90
@@ -699,6 +699,8 @@ contains
       new_vars(n)%group         = this%vars(n)%group
       new_vars(n)%category_ind  = this%vars(n)%category_ind
       new_vars(n)%comment       = this%vars(n)%comment
+      ! All pointer components of new_vars are nullified in the type definition
+      ! via => NULL() statements
       if (associated(this%vars(n)%lptr)) &
         new_vars(n)%lptr => this%vars(n)%lptr
       if (associated(this%vars(n)%iptr)) &
@@ -709,7 +711,9 @@ contains
         new_vars(n)%sptr => this%vars(n)%sptr
     end do
 
-    ! 3) add newest parm variable
+    ! 4) add newest parm variable
+    !    All pointer components of new_vars are nullified in the type definition
+    !    via => NULL() statements
     select case (trim(datatype))
       case ('real')
         if (present(rptr)) then
@@ -764,7 +768,7 @@ contains
       new_vars(id)%comment = ''
     end if
 
-    ! 4) deallocate this%vars / point to new_vars (and update cnt)
+    ! 5) deallocate this%vars / point to new_vars (and update cnt)
     deallocate(this%vars)
     this%vars => new_vars
     this%cnt = id

--- a/src/marbl_config_mod.F90
+++ b/src/marbl_config_mod.F90
@@ -666,24 +666,28 @@ contains
         if (associated(rptr, this%vars(n)%rptr)) then
           write(log_message, "(4A)") trim(sname), " and ", trim(this%vars(n)%short_name), &
                                      " both point to same variable in memory."
+          call marbl_status_log%log_error(log_message, subname)
         end if
       end if
       if (present(iptr)) then
         if (associated(iptr, this%vars(n)%iptr)) then
           write(log_message, "(4A)") trim(sname), " and ", trim(this%vars(n)%short_name), &
                                      " both point to same variable in memory."
+          call marbl_status_log%log_error(log_message, subname)
         end if
       end if
       if (present(lptr)) then
         if (associated(lptr, this%vars(n)%lptr)) then
           write(log_message, "(4A)") trim(sname), " and ", trim(this%vars(n)%short_name), &
                                      " both point to same variable in memory."
+          call marbl_status_log%log_error(log_message, subname)
         end if
       end if
       if (present(sptr)) then
         if (associated(sptr, this%vars(n)%sptr)) then
           write(log_message, "(4A)") trim(sname), " and ", trim(this%vars(n)%short_name), &
                                      " both point to same variable in memory."
+          call marbl_status_log%log_error(log_message, subname)
         end if
       end if
       if (marbl_status_log%labort_marbl) return


### PR DESCRIPTION
When adding a new configuration variable or parameter, abort if the short name
(used for the put and get statements) is not unique or if the pointer provided
points to memory already registered with a different config var or parameter.