### PR TITLE
Consistent use of molw_Fe constant

### DIFF
--- a/src/marbl_constants_mod.F90
+++ b/src/marbl_constants_mod.F90
@@ -59,7 +59,7 @@ module marbl_constants_mod
       rho_sw    =   1.026_r8,          & ! density of salt water (g/cm^3)
       epsC      =   1.00e-8,           & ! small C concentration (mmol C/m^3)
       epsTinv   =   3.17e-8,           & ! small inverse time scale (1/year) (1/sec)
-      molw_Fe   =  55.845_r8,          & ! molecular weight of iron
+      molw_Fe   =  55.845_r8,          & ! molecular weight of iron (gFe / mol Fe)
       R13C_std  =   1.0_r8,            & ! actual 13C/12C PDB standard ratio (Craig, 1957) = 1123.72e-5_r8
       R14C_std =    1.0_r8               ! actual 14C/12C NOSAMS standard ratio = 11.76e-13_r8
 

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -1857,11 +1857,8 @@ contains
        endif
 
        !-----------------------------------------------------------------------
-       !  Compute iron release from dust remin/dissolution
-       !
-       !  dust remin gDust = 0.035 / 55.847 * 1.0e9 = 626712.0 nmolFe
-       !                      gFe     molFe     nmolFe
-       !  Also add in Fe source from sediments if applicable to this cell.
+       !  Compute iron release from dust remin/dissolution and add in Fe source
+       !  from sediments
        !-----------------------------------------------------------------------
 
 

--- a/src/marbl_parms.F90
+++ b/src/marbl_parms.F90
@@ -26,6 +26,7 @@ module marbl_parms
   use marbl_constants_mod, only : c2
   use marbl_constants_mod, only : c1000
   use marbl_constants_mod, only : dps
+  use marbl_constants_mod, only : molw_Fe
 
   use marbl_internal_types, only : autotroph_parms_type
   use marbl_internal_types, only : zooplankton_parms_type
@@ -122,14 +123,11 @@ module marbl_parms
   real(kind=r8), parameter :: &
        dust_Fe_scavenge_scale  = 1.0e9         !dust scavenging scale factor
 
-  ! Compute iron remineralization and flux out.
-  ! dust remin gDust = 0.035 gFe      mol Fe     1e9 nmolFe
-  !                    --------- *  ---------- * ----------
-  !                      gDust      55.847 gFe     molFe
-  !
-  ! dust_to_Fe          conversion - dust to iron (nmol Fe/g Dust)
-  real(kind=r8), parameter :: &
-       dust_to_Fe=0.035_r8/55.847_r8*1.0e9_r8
+  ! dust_to_Fe: conversion of dust to iron (nmol Fe/g Dust)
+  ! dust remin gDust = 0.035 gFe       mol Fe     1e9 nmolFe
+  !                    --------- *  ----------- * ----------
+  !                      gDust      molw_Fe gFe      molFe
+  real(kind=r8), parameter :: dust_to_Fe = 0.035_r8 / molw_Fe * 1.0e9_r8
 
   ! parameters related to Iron binding ligands
   integer (int_kind), parameter :: Lig_cnt = 1 ! valid values are 1 or 2


### PR DESCRIPTION
marbl_constants_mod has a parameter for the molecular weight of iron, but
marbl_parms was not using the parameter in a computation involving the
constant. Also, many comments regarding the constant were missing information
or contained un-necessary details.