### PR TITLE
Enhancement/nl buffer update

### DIFF
--- a/src/marbl_ciso_mod.F90
+++ b/src/marbl_ciso_mod.F90
@@ -102,8 +102,8 @@ contains
     !-----------------------------------------------------------------------
     !  local variables
     !-----------------------------------------------------------------------
-    character(*), parameter :: subname = 'marbl_ciso_mod:marbl_ciso_init_tracer_metadata'
-    character(len=char_len) :: log_message
+    character(len=*), parameter :: subname = 'marbl_ciso_mod:marbl_ciso_init_tracer_metadata'
+    character(len=char_len)     :: log_message
 
     integer (int_kind) :: n                             ! tracer index
     integer (int_kind) :: auto_ind                      ! autotroph functional group index
@@ -250,7 +250,7 @@ contains
     !-----------------------------------------------------------------------
     !  local variables
     !-----------------------------------------------------------------------
-    character(*), parameter :: subname = 'marbl_ciso_mod:marbl_ciso_set_interior forcing'
+    character(len=*), parameter :: subname = 'marbl_ciso_mod:marbl_ciso_set_interior forcing'
 
     logical (log_kind) :: zero_mask
 
@@ -922,10 +922,11 @@ contains
     type(marbl_tracer_index_type), intent(in)    :: tracer_indices
     type(marbl_log_type),          intent(inout) :: marbl_status_log
 
-    character(*), parameter :: subname = 'marbl_ciso_mod:' // &
+    character(len=*), parameter :: subname = 'marbl_ciso_mod:' // &
                   'marbl_ciso_tracer_index_consistency_check'
-    character(len=char_len) :: log_message
-    integer                 :: tracer_cnt
+    character(len=char_len)     :: log_message
+
+    integer :: tracer_cnt
 
     tracer_cnt = tracer_indices%ciso_ind_end - (tracer_indices%ciso_ind_beg-1)
     if (tracer_cnt.ne.ciso_tracer_cnt) then
@@ -948,23 +949,23 @@ contains
 
     implicit none
 
-    character(char_len) , intent(in)  :: ciso_fract_factors                  ! option for which biological fractionation calculation to use
-    real (r8)           , intent(out) :: cell_active_C_uptake(autotroph_cnt) ! ratio of active carbon uptake to carbon fixation
-    real (r8)           , intent(out) :: cell_active_C(autotroph_cnt)        ! ratio of active carbon uptake to carbon fixation
-    real (r8)           , intent(out) :: cell_surf(autotroph_cnt)            ! surface areas of cells ( m2 )
-    real (r8)           , intent(out) :: cell_carb_cont(autotroph_cnt)       ! cell carbon content ( mol C cell-1 )
-    real (r8)           , intent(out) :: cell_radius(autotroph_cnt)          ! cell radius ( um )
-    real (r8)           , intent(out) :: cell_permea(autotroph_cnt)          ! cell wall permeability to CO2(aq) (m/s)
-    real (r8)           , intent(out) :: cell_eps_fix(autotroph_cnt)         ! fractionation effect of carbon fixation
-    type(marbl_log_type), intent(inout) :: marbl_status_log
+    character(len=char_len), intent(in)  :: ciso_fract_factors                  ! option for which biological fractionation calculation to use
+    real (r8),               intent(out) :: cell_active_C_uptake(autotroph_cnt) ! ratio of active carbon uptake to carbon fixation
+    real (r8),               intent(out) :: cell_active_C(autotroph_cnt)        ! ratio of active carbon uptake to carbon fixation
+    real (r8),               intent(out) :: cell_surf(autotroph_cnt)            ! surface areas of cells ( m2 )
+    real (r8),               intent(out) :: cell_carb_cont(autotroph_cnt)       ! cell carbon content ( mol C cell-1 )
+    real (r8),               intent(out) :: cell_radius(autotroph_cnt)          ! cell radius ( um )
+    real (r8),               intent(out) :: cell_permea(autotroph_cnt)          ! cell wall permeability to CO2(aq) (m/s)
+    real (r8),               intent(out) :: cell_eps_fix(autotroph_cnt)         ! fractionation effect of carbon fixation
+    type(marbl_log_type),    intent(inout) :: marbl_status_log
 
     !-----------------------------------------------------------------------
     !  local variables
     !-----------------------------------------------------------------------
-    character(*), parameter :: subname = 'marbl_ciso_mod:setup_cell_attributes'
-    character(len=char_len) :: log_message
-    integer (int_kind) :: &
-         auto_ind           ! autotroph functional group index
+    character(len=*), parameter :: subname = 'marbl_ciso_mod:setup_cell_attributes'
+    character(len=char_len)     :: log_message
+
+    integer(int_kind) :: auto_ind           ! autotroph functional group index
     !-----------------------------------------------------------------------
 
     select case (ciso_fract_factors)
@@ -1405,8 +1406,8 @@ contains
     !-----------------------------------------------------------------------
     !  local variables
     !-----------------------------------------------------------------------
-    character(*), parameter :: subname = 'marbl_ciso_mod:compute_particulate_terms'
-    character(len=char_len) :: log_message
+    character(len=*), parameter :: subname = 'marbl_ciso_mod:compute_particulate_terms'
+    character(len=char_len)     :: log_message
 
     real (r8) ::              &
          dz_loc,              & ! dz at a particular i,j location
@@ -1752,8 +1753,8 @@ contains
     !-----------------------------------------------------------------------
     !  local variables
     !-----------------------------------------------------------------------
-    character(*), parameter :: subname = 'marbl_ciso_mod:marbl_ciso_set_surface_forcing'
-    character(len=char_len) :: log_message
+    character(len=*), parameter :: subname = 'marbl_ciso_mod:marbl_ciso_set_surface_forcing'
+    character(len=char_len)     :: log_message
 
     logical (log_kind), save :: &
          first = .true.  ! Logical for first iteration test

--- a/src/marbl_co2calc_mod.F90
+++ b/src/marbl_co2calc_mod.F90
@@ -130,7 +130,8 @@ contains
     !---------------------------------------------------------------------------
     !   local variable declarations
     !---------------------------------------------------------------------------
-    character(*), parameter :: subname = 'marbl_co2calc_mod:marbl_co2calc_surf'
+    character(len=*), parameter :: subname = 'marbl_co2calc_mod:marbl_co2calc_surf'
+
     integer(kind=int_kind)  :: n
     integer(kind=int_kind)  :: k
     real(kind=r8)           :: mass_to_vol          ! (mol/kg) -> (mmol/m^3)
@@ -269,12 +270,13 @@ contains
     !---------------------------------------------------------------------------
     !   local variable declarations
     !---------------------------------------------------------------------------
-    character(*), parameter :: subname = 'marbl_co2calc_mod:marbl_comp_CO3terms'
+    character(len=*), parameter :: subname = 'marbl_co2calc_mod:marbl_comp_CO3terms'
+
     integer(kind=int_kind) :: c
-    real(kind=r8) :: mass_to_vol          ! (mol/kg) -> (mmol/m^3)
-    real(kind=r8) :: vol_to_mass          ! (mmol/m^3) -> (mol/kg)
-    real(kind=r8) :: htotal2, denom
-    real(kind=r8) :: htotal(num_elements) ! free concentration of H ion
+    real(kind=r8)          :: mass_to_vol          ! (mol/kg) -> (mmol/m^3)
+    real(kind=r8)          :: vol_to_mass          ! (mmol/m^3) -> (mol/kg)
+    real(kind=r8)          :: htotal2, denom
+    real(kind=r8)          :: htotal(num_elements) ! free concentration of H ion
     !---------------------------------------------------------------------------
 
     associate(                     &
@@ -712,11 +714,12 @@ contains
     !---------------------------------------------------------------------------
     !   local variable declarations
     !---------------------------------------------------------------------------
-    character(*), parameter :: subname = 'marbl_co2calc_mod:marbl_comp_htotal'
+    character(len=*), parameter :: subname = 'marbl_co2calc_mod:marbl_comp_htotal'
+
     integer(kind=int_kind) :: c
-    real(kind=r8) :: mass_to_vol                        ! (mol/kg) -> (mmol/m^3)
-    real(kind=r8) :: vol_to_mass                        ! (mmol/m^3) -> (mol/kg)
-    real(kind=r8) :: x1(num_elements), x2(num_elements) ! bounds on htotal for solver
+    real(kind=r8)          :: mass_to_vol                        ! (mol/kg) -> (mmol/m^3)
+    real(kind=r8)          :: vol_to_mass                        ! (mmol/m^3) -> (mol/kg)
+    real(kind=r8)          :: x1(num_elements), x2(num_elements) ! bounds on htotal for solver
     !---------------------------------------------------------------------------
 
     associate(                      &
@@ -819,8 +822,9 @@ contains
     !---------------------------------------------------------------------------
     !   local variable declarations
     !---------------------------------------------------------------------------
-    character(*), parameter :: subname = 'marbl_co2calc_mod:drtsafe'
-    character(len=char_len) :: log_message
+    character(len=*), parameter :: subname = 'marbl_co2calc_mod:drtsafe'
+    character(len=char_len)     :: log_message
+
     logical(kind=log_kind)                          :: leave_bracket, dx_decrease
     logical(kind=log_kind)                          :: abort
     logical(kind=log_kind), dimension(num_elements) :: mask

--- a/src/marbl_config_mod.F90
+++ b/src/marbl_config_mod.F90
@@ -47,8 +47,8 @@ module marbl_config_mod
   !  to preserve C, P, Si inventories on timescales exceeding bury_coeff_rmean_timescale_years
   !  this is done primarily in spinup runs
   !-----------------------------------------------------------------------
-  character(char_len), target :: init_bury_coeff_opt
-  logical (log_kind),  target :: ladjust_bury_coeff
+  character(len=char_len), target :: init_bury_coeff_opt
+  logical(log_kind),       target :: ladjust_bury_coeff
 
 
   !---------------------------------------------------------------------
@@ -213,8 +213,8 @@ contains
     !---------------------------------------------------------------------------
     !   local variables
     !---------------------------------------------------------------------------
-    character(*), parameter :: subname = 'marbl_config:marbl_config_read_namelist'
-    character(len=char_len) :: log_message
+    character(len=*), parameter :: subname = 'marbl_config:marbl_config_read_namelist'
+    character(len=char_len)     :: log_message
 
     character(len=len(nl_buffer)) :: tmp_nl_buffer
     integer (int_kind)            :: nml_error                   ! namelist i/o error flag
@@ -253,9 +253,10 @@ contains
     class(marbl_config_and_parms_type), intent(inout) :: this
     type(marbl_log_type),    intent(inout) :: marbl_status_log
 
-    character(*), parameter :: subname = 'marbl_config_mod:marbl_define_config_vars'
-    character(len=char_len) :: log_message
-    character(len=char_len) :: sname, lname, units, datatype, group, category
+    character(len=*), parameter :: subname = 'marbl_config_mod:marbl_define_config_vars'
+    character(len=char_len)     :: log_message
+
+    character(len=char_len)          :: sname, lname, units, datatype, group, category
     real(r8),                pointer :: rptr => NULL()
     integer(int_kind),       pointer :: iptr => NULL()
     logical(log_kind),       pointer :: lptr => NULL()
@@ -619,7 +620,8 @@ contains
     character(len=char_len), optional, pointer, intent(in) :: sptr
     character(len=char_len), optional,          intent(in) :: comment
 
-    character(*), parameter :: subname = 'marbl_config_mod:marbl_var_add'
+    character(len=*), parameter :: subname = 'marbl_config_mod:marbl_var_add'
+
     type(marbl_single_config_or_parm_type), dimension(:), pointer :: new_vars
     character(len=char_len),                dimension(:), pointer :: new_categories
     integer :: old_size, id, cat_ind, n
@@ -746,10 +748,11 @@ contains
     real(kind=r8), dimension(:), target, intent(in)    :: r8array
     type(marbl_log_type),                intent(inout) :: marbl_status_log
 
-    character(*), parameter :: subname = 'marbl_config_mod:marbl_var_add_1d_r8'
+    character(len=*), parameter :: subname = 'marbl_config_mod:marbl_var_add_1d_r8'
+
     character(len=char_len) :: sname_loc
-    real(r8), pointer :: rptr => NULL()
-    integer :: n
+    real(r8), pointer       :: rptr => NULL()
+    integer                 :: n
 
     do n=1,size(r8array)
       write(sname_loc, "(2A,I0,A)") trim(sname), '(', n, ')'
@@ -778,10 +781,11 @@ contains
     integer, dimension(:), target,       intent(in)    :: intarray
     type(marbl_log_type),                intent(inout) :: marbl_status_log
 
-    character(*), parameter :: subname = 'marbl_config_mod:marbl_var_add_1d_int'
+    character(len=*), parameter :: subname = 'marbl_config_mod:marbl_var_add_1d_int'
+
     character(len=char_len) :: sname_loc
-    integer, pointer :: iptr => NULL()
-    integer :: n
+    integer, pointer        :: iptr => NULL()
+    integer                 :: n
 
     do n=1,size(intarray)
       write(sname_loc, "(2A,I0,A)") trim(sname), '(', n, ')'
@@ -810,10 +814,11 @@ contains
     character(len=char_len),     target, intent(in)    :: strarray(:)
     type(marbl_log_type),                intent(inout) :: marbl_status_log
 
-    character(*), parameter :: subname = 'marbl_config_mod:marbl_var_add_1d_str'
-    character(len=char_len) :: sname_loc
+    character(len=*), parameter :: subname = 'marbl_config_mod:marbl_var_add_1d_str'
+
+    character(len=char_len)          :: sname_loc
     character(len=char_len), pointer :: sptr => NULL()
-    integer :: n
+    integer                          :: n
 
     do n=1,size(strarray)
       write(sname_loc, "(2A,I0,A)") trim(sname), '(', n, ')'
@@ -835,11 +840,12 @@ contains
     class(marbl_config_and_parms_type), intent(inout) :: this
     type(marbl_log_type),    intent(inout) :: marbl_status_log
 
-    character(*), parameter :: subname = 'marbl_config_mod:marbl_vars_finalize'
-    character(len=char_len) :: log_message
+    character(len=*), parameter :: subname = 'marbl_config_mod:marbl_vars_finalize'
+    character(len=char_len)     :: log_message
+
     character(len=char_len) :: group
     character(len=7)        :: logic
-    integer :: i,n, cat_ind
+    integer                 :: i,n, cat_ind
 
     ! (1) Lock data type (put calls will now cause MARBL to abort)
     this%locked = .true.
@@ -939,8 +945,9 @@ contains
     character(len=*), optional,         intent(in)    :: sval
     type(marbl_log_type),               intent(inout) :: marbl_status_log
 
-    character(*), parameter :: subname = 'marbl_config_mod%marbl_var_put_all_types'
-    character(len=char_len) :: log_message
+    character(len=*), parameter :: subname = 'marbl_config_mod%marbl_var_put_all_types'
+    character(len=char_len)     :: log_message
+
     integer :: varid
 
     if (this%locked) then
@@ -1003,8 +1010,9 @@ contains
     character(len=*), optional,         intent(out)   :: sval
     type(marbl_log_type),               intent(inout) :: marbl_status_log
 
-    character(*), parameter :: subname = 'marbl_config_mod%marbl_var_get_all_types'
-    character(len=char_len) :: log_message
+    character(len=*), parameter :: subname = 'marbl_config_mod%marbl_var_get_all_types'
+    character(len=char_len)     :: log_message
+
     integer :: varid, cnt
 
     cnt = 0
@@ -1185,8 +1193,9 @@ contains
     type(marbl_log_type),               intent(inout) :: marbl_status_log
     integer                                           :: id
 
-    character(*), parameter :: subname = 'marbl_config_mod:marbl_var_inquire_id'
-    character(len=char_len) :: log_message
+    character(len=*), parameter :: subname = 'marbl_config_mod:marbl_var_inquire_id'
+    character(len=char_len)     :: log_message
+
     integer :: n
 
     id = 0
@@ -1212,8 +1221,8 @@ contains
     character(len=*), optional,         intent(out)   :: lname, sname, units
     character(len=*), optional,         intent(out)   :: group, datatype
 
-    character(*), parameter :: subname = 'marbl_config_mod:marbl_var_inquire_metadata'
-    character(len=char_len) :: log_message
+    character(len=*), parameter :: subname = 'marbl_config_mod:marbl_var_inquire_metadata'
+    character(len=char_len)     :: log_message
 
     if ((ind .lt. 1).or.(ind .gt. this%cnt)) then
       write(log_message,'(I0,2A,I0)') ind, ' is not a valid index: must be ', &

--- a/src/marbl_config_mod.F90
+++ b/src/marbl_config_mod.F90
@@ -205,20 +205,19 @@ contains
 
   subroutine marbl_config_read_namelist(nl_buffer, marbl_status_log)
 
-    use marbl_namelist_mod, only : marbl_nl_cnt
-    use marbl_namelist_mod, only : marbl_nl_buffer_size
     use marbl_namelist_mod, only : marbl_namelist
 
-    character(marbl_nl_buffer_size), intent(in)    :: nl_buffer(:)
-    type(marbl_log_type),            intent(inout) :: marbl_status_log
+    character(len=*),     intent(in)    :: nl_buffer(:)
+    type(marbl_log_type), intent(inout) :: marbl_status_log
 
     !---------------------------------------------------------------------------
     !   local variables
     !---------------------------------------------------------------------------
     character(*), parameter :: subname = 'marbl_config:marbl_config_read_namelist'
     character(len=char_len) :: log_message
-    character(len=marbl_nl_buffer_size) :: tmp_nl_buffer
-    integer (int_kind)           :: nml_error                   ! namelist i/o error flag
+
+    character(len=len(nl_buffer)) :: tmp_nl_buffer
+    integer (int_kind)            :: nml_error                   ! namelist i/o error flag
 
     namelist /marbl_config_nml/                                               &
          ciso_on, lsource_sink, ciso_lsource_sink, lecovars_full_depth_tavg,  &

--- a/src/marbl_diagnostics_mod.F90
+++ b/src/marbl_diagnostics_mod.F90
@@ -360,7 +360,7 @@ contains
     logical :: truncate
     character(len=char_len) :: lname, sname, units, vgrid
 
-    character(*), parameter :: subname = 'marbl_diagnostics_mod:marbl_diagnostics_init'
+    character(len=*), parameter :: subname = 'marbl_diagnostics_mod:marbl_diagnostics_init'
     !-----------------------------------------------------------------------
 
     !-----------------------------------------------------------------
@@ -3180,7 +3180,7 @@ contains
     type (marbl_diagnostics_type)             , intent(inout) :: marbl_interior_forcing_diags
     type (marbl_log_type)                     , intent(inout) :: marbl_status_log
 
-    character(*), parameter :: subname = 'marbl_diagnostics_mod:marbl_diagnostics_set_interior_forcing'
+    character(len=*), parameter :: subname = 'marbl_diagnostics_mod:marbl_diagnostics_set_interior_forcing'
 
     !-----------------------------------------------------------------
 
@@ -3300,7 +3300,7 @@ contains
     !-----------------------------------------------------------------------
     !  local variables
     !-----------------------------------------------------------------------
-    character(*), parameter :: subname = 'marbl_diagnostics_mod:marbl_diagnostics_set_surface_forcing'
+    character(len=*), parameter :: subname = 'marbl_diagnostics_mod:marbl_diagnostics_set_surface_forcing'
     !-----------------------------------------------------------------------
 
     !-----------------------------------------------------------------------
@@ -3451,7 +3451,8 @@ contains
     !-----------------------------------------------------------------------
     !  local variables
     !-----------------------------------------------------------------------
-    character(*), parameter :: subname = 'marbl_diagnostics_mod:store_diagnostics_carbonate'
+    character(len=*), parameter :: subname = 'marbl_diagnostics_mod:store_diagnostics_carbonate'
+
     integer(int_kind) :: k
     !-----------------------------------------------------------------------
     
@@ -3513,7 +3514,8 @@ contains
     !-----------------------------------------------------------------------
     !  local variables
     !-----------------------------------------------------------------------
-    character(*), parameter :: subname = 'marbl_diagnostics_mod:compute_saturation_depth'
+    character(len=*), parameter :: subname = 'marbl_diagnostics_mod:compute_saturation_depth'
+
     real(r8) :: anomaly(marbl_domain%km) ! CO3 concentration above saturation at level
     integer  :: k
     !-----------------------------------------------------------------------
@@ -3559,7 +3561,8 @@ contains
     type(marbl_log_type),        intent(inout) :: marbl_status_log
     real(kind=r8) :: linear_root
 
-    character(*), parameter :: subname = 'marbl_diagnostics_mod:linear_root'
+    character(len=*), parameter :: subname = 'marbl_diagnostics_mod:linear_root'
+
     real(kind=r8) :: m_inv
 
     if ((y(1).gt.c0).and.(y(2).gt.c0)) then
@@ -4603,7 +4606,7 @@ contains
     !-----------------------------------------------------------------------
     !  local variables
     !-----------------------------------------------------------------------
-    character(*), parameter :: subname = 'marbl_diagnostics_mod:store_diagnostics_ciso_surface_forcing'
+    character(len=*), parameter :: subname = 'marbl_diagnostics_mod:store_diagnostics_ciso_surface_forcing'
     !-----------------------------------------------------------------------
 
     associate(                                          &

--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -170,8 +170,8 @@ contains
     character(len=*), optional,   intent(in)    :: gcm_nl_buffer(:)
     logical,          optional,   intent(in)    :: lgcm_has_global_ops
 
-    character(*), parameter :: subname = 'marbl_interface:config'
-    character(len=char_len) :: log_message
+    character(len=*), parameter :: subname = 'marbl_interface:config'
+    character(len=char_len)     :: log_message
 
     !--------------------------------------------------------------------
     ! initialize status log
@@ -284,8 +284,9 @@ contains
     character(len=*),  optional,  intent(in)    :: gcm_nl_buffer(:)
     integer(int_kind), optional,  intent(out)   :: marbl_tracer_cnt
 
-    character(*), parameter :: subname = 'marbl_interface:init'
-    character(len=char_len) :: log_message
+    character(len=*), parameter :: subname = 'marbl_interface:init'
+    character(len=char_len)     :: log_message
+
     integer :: i
     integer, parameter :: num_interior_elements = 1 ! FIXME #66: get this value from interface, let it vary
     !--------------------------------------------------------------------
@@ -501,8 +502,9 @@ contains
 
     class(marbl_interface_class), intent(inout) :: this
 
-    character(*), parameter :: subname = 'marbl_interface:complete_config_and_init'
-    character(len=char_len) :: log_message
+    character(len=*), parameter :: subname = 'marbl_interface:complete_config_and_init'
+    character(len=char_len)     :: log_message
+
     integer :: i
 
     call this%timers%start(this%timer_ids%init_timer_id, this%StatusLog)
@@ -626,7 +628,7 @@ contains
 
     class (marbl_interface_class), intent(inout) :: this
 
-    character(*), parameter :: subname = 'marbl_interface:reset_timers'
+    character(len=*), parameter :: subname = 'marbl_interface:reset_timers'
 
     call this%timers%reset(this%StatusLog)
     if (this%StatusLog%labort_marbl) then
@@ -642,7 +644,7 @@ contains
 
     class (marbl_interface_class), intent(inout) :: this
 
-    character(*), parameter :: subname = 'marbl_interface:extract_timing'
+    character(len=*), parameter :: subname = 'marbl_interface:extract_timing'
 
     call this%timers%extract(this%timer_summary, this%StatusLog)
     if (this%StatusLog%labort_marbl) then
@@ -704,7 +706,8 @@ contains
     use marbl_mod, only : marbl_set_interior_forcing
 
     class(marbl_interface_class), intent(inout) :: this
-    character(*), parameter :: subname = 'marbl_interface:set_interior_forcing'
+
+    character(len=*), parameter :: subname = 'marbl_interface:set_interior_forcing'
 
     call this%timers%start(this%timer_ids%interior_forcing_id, this%StatusLog)
     if (this%StatusLog%labort_marbl) then
@@ -756,7 +759,7 @@ contains
 
     class(marbl_interface_class), intent(inout) :: this
 
-    character(*), parameter :: subname = 'marbl_interface:set_surface_forcing'
+    character(len=*), parameter :: subname = 'marbl_interface:set_surface_forcing'
 
     call this%timers%start(this%timer_ids%surface_forcing_id, this%StatusLog)
     if (this%StatusLog%labort_marbl) then
@@ -802,7 +805,7 @@ contains
     implicit none
 
     class(marbl_interface_class), intent(inout) :: this
-    character (*)               , intent(in)    :: field_source ! 'interior' or 'surface'
+    character(len=*),             intent(in)    :: field_source ! 'interior' or 'surface'
 
     if (field_source == 'interior') then
        call marbl_set_global_scalars_interior(                          &
@@ -824,7 +827,7 @@ contains
 
     class(marbl_interface_class), intent(inout) :: this
 
-    character(*), parameter :: subname = 'marbl_interface:shutdown'
+    character(len=*), parameter :: subname = 'marbl_interface:shutdown'
 
     ! free dynamically allocated memory, etc
 
@@ -841,7 +844,7 @@ contains
   function get_tracer_index(this, tracer_name)
 
     class(marbl_interface_class), intent(inout) :: this
-    character(*),                 intent(in)    :: tracer_name
+    character(len=*),             intent(in)    :: tracer_name
     integer :: get_tracer_index
 
     integer :: n

--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -162,15 +162,13 @@ contains
        lgcm_has_global_ops,               &
        gcm_nl_buffer)
 
-    use marbl_namelist_mod, only : marbl_nl_cnt
-    use marbl_namelist_mod, only : marbl_nl_buffer_size
     use marbl_config_mod  , only : marbl_config_set_defaults
     use marbl_config_mod  , only : marbl_config_read_namelist
     use marbl_config_mod  , only : marbl_define_config_vars
 
-    class(marbl_interface_class)   , intent(inout)        :: this
-    character(marbl_nl_buffer_size), optional, intent(in) :: gcm_nl_buffer(:)
-    logical,                         optional, intent(in) :: lgcm_has_global_ops
+    class(marbl_interface_class), intent(inout) :: this
+    character(len=*), optional,   intent(in)    :: gcm_nl_buffer(:)
+    logical,          optional,   intent(in)    :: lgcm_has_global_ops
 
     character(*), parameter :: subname = 'marbl_interface:config'
     character(len=char_len) :: log_message
@@ -261,8 +259,6 @@ contains
        gcm_nl_buffer,                     &
        marbl_tracer_cnt)
 
-    use marbl_namelist_mod    , only : marbl_nl_cnt
-    use marbl_namelist_mod    , only : marbl_nl_buffer_size
     use marbl_ciso_mod        , only : marbl_ciso_init_tracer_metadata
     use marbl_mod             , only : marbl_init_tracer_metadata
     use marbl_mod             , only : marbl_tracer_index_consistency_check
@@ -278,15 +274,15 @@ contains
 
     implicit none
 
-    class     (marbl_interface_class)      , intent(inout) :: this
-    integer   (int_kind)                   , intent(in)    :: gcm_num_levels
-    integer   (int_kind)                   , intent(in)    :: gcm_num_PAR_subcols
-    integer   (int_kind)                   , intent(in)    :: gcm_num_elements_surface_forcing
-    real      (r8)                         , intent(in)    :: gcm_delta_z(gcm_num_levels) ! thickness of layer k
-    real      (r8)                         , intent(in)    :: gcm_zw(gcm_num_levels) ! thickness of layer k
-    real      (r8)                         , intent(in)    :: gcm_zt(gcm_num_levels) ! thickness of layer k
-    character(marbl_nl_buffer_size), optional, intent(in)  :: gcm_nl_buffer(:)
-    integer   (int_kind), optional         , intent(out)   :: marbl_tracer_cnt
+    class(marbl_interface_class), intent(inout) :: this
+    integer(int_kind),            intent(in)    :: gcm_num_levels
+    integer(int_kind),            intent(in)    :: gcm_num_PAR_subcols
+    integer(int_kind),            intent(in)    :: gcm_num_elements_surface_forcing
+    real(r8),                     intent(in)    :: gcm_delta_z(gcm_num_levels) ! thickness of layer k
+    real(r8),                     intent(in)    :: gcm_zw(gcm_num_levels) ! thickness of layer k
+    real(r8),                     intent(in)    :: gcm_zt(gcm_num_levels) ! thickness of layer k
+    character(len=*),  optional,  intent(in)    :: gcm_nl_buffer(:)
+    integer(int_kind), optional,  intent(out)   :: marbl_tracer_cnt
 
     character(*), parameter :: subname = 'marbl_interface:init'
     character(len=char_len) :: log_message

--- a/src/marbl_interface_types.F90
+++ b/src/marbl_interface_types.F90
@@ -68,13 +68,13 @@ module marbl_interface_types
   !*****************************************************************************
 
   type, public :: marbl_tracer_metadata_type
-     character(char_len) :: short_name
-     character(char_len) :: long_name
-     character(char_len) :: units
-     character(char_len) :: tend_units
-     character(char_len) :: flux_units
-     logical             :: lfull_depth_tavg
-     character(char_len) :: tracer_module_name
+     character(len=char_len) :: short_name
+     character(len=char_len) :: long_name
+     character(len=char_len) :: units
+     character(len=char_len) :: tend_units
+     character(len=char_len) :: flux_units
+     logical                 :: lfull_depth_tavg
+     character(len=char_len) :: tracer_module_name
   end type marbl_tracer_metadata_type
 
   !*****************************************************************************
@@ -147,10 +147,10 @@ module marbl_interface_types
      ! Contains variable names and units for required forcing fields as well as
      ! dimensional information; actual forcing data is in array of
      ! marbl_forcing_fields_type
-     character(char_len)   :: varname
-     character(char_len)   :: field_units
-     integer               :: rank            ! 0d or 1d
-     integer,  allocatable :: extent(:)       ! length = rank
+     character(len=char_len) :: varname
+     character(len=char_len) :: field_units
+     integer                 :: rank            ! 0d or 1d
+     integer,  allocatable   :: extent(:)       ! length = rank
   end type marbl_forcing_fields_metadata_type
 
   !*****************************************************************************
@@ -170,9 +170,9 @@ module marbl_interface_types
 
   type, public :: marbl_timers_type
     integer :: num_timers
-    character(char_len), allocatable :: names(:)
-    real(r8),            allocatable :: cumulative_runtimes(:)
-    logical,             allocatable :: is_threaded(:)
+    character(len=char_len), allocatable :: names(:)
+    real(r8),                allocatable :: cumulative_runtimes(:)
+    logical,                 allocatable :: is_threaded(:)
   contains
     procedure, public :: construct => marbl_timers_constructor
     procedure, public :: deconstruct => marbl_timers_deconstructor
@@ -183,13 +183,13 @@ module marbl_interface_types
   ! FIXME : move to marbl_internal_types.F90 when running means are moved to MARBL
 
   type, public :: marbl_running_mean_0d_type
-     character(char_len) :: sname
-     real(kind=r8)       :: timescale
-     real(kind=r8)       :: rmean
+     character(len=char_len) :: sname
+     real(kind=r8)           :: timescale
+     real(kind=r8)           :: rmean
 
      ! FIXME : perhaps the following get removed from the type when running means are moved to MARBL
-     logical(log_kind)   :: linit_by_val
-     real(kind=r8)       :: init_val
+     logical(log_kind)       :: linit_by_val
+     real(kind=r8)           :: init_val
   end type marbl_running_mean_0d_type
 
   !*****************************************************************************
@@ -239,17 +239,17 @@ contains
     class(marbl_single_saved_state_type), intent(inout) :: this
     type(marbl_log_type),                 intent(inout) :: marbl_status_log
 
-    character(*), intent(in) :: lname
-    character(*), intent(in) :: sname
-    character(*), intent(in) :: units
-    character(*), intent(in) :: vgrid
-    integer,      intent(in) :: rank
-    integer,      intent(in) :: num_elements
-    integer,      intent(in) :: num_levels
+    character(len=*), intent(in) :: lname
+    character(len=*), intent(in) :: sname
+    character(len=*), intent(in) :: units
+    character(len=*), intent(in) :: vgrid
+    integer,          intent(in) :: rank
+    integer,          intent(in) :: num_elements
+    integer,          intent(in) :: num_levels
 
-    character(*), parameter :: subname =                                      &
+    character(len=*), parameter :: subname =                                  &
                   'marbl_interface_types:marbl_single_saved_state_construct'
-    character(char_len)     :: log_message
+    character(len=char_len)     :: log_message
 
     select case (rank)
       case (3)
@@ -309,15 +309,16 @@ contains
     class(marbl_saved_state_type), intent(inout) :: this
     type(marbl_log_type),          intent(inout) :: marbl_status_log
 
-    character(*),      intent(in)  :: lname
-    character(*),      intent(in)  :: sname
-    character(*),      intent(in)  :: units
-    character(*),      intent(in)  :: vgrid
+    character(len=*),  intent(in)  :: lname
+    character(len=*),  intent(in)  :: sname
+    character(len=*),  intent(in)  :: units
+    character(len=*),  intent(in)  :: vgrid
     integer(int_kind), intent(in)  :: rank
     integer(int_kind), intent(out) :: id
 
-    character(*), parameter :: subname = 'marbl_interface_types:marbl_saved_state_add'
-    character(len=char_len) :: log_message
+    character(len=*), parameter :: subname = 'marbl_interface_types:marbl_saved_state_add'
+    character(len=char_len)     :: log_message
+
     type(marbl_single_saved_state_type), dimension(:), pointer :: new_state
     integer :: old_size,n, nlev
 
@@ -382,8 +383,8 @@ contains
     integer                 , intent(in)    :: num_levels
     type(marbl_log_type)    , intent(inout) :: marbl_status_log
 
-    character(*), parameter :: subname = 'marbl_interface_types:marbl_single_diag_init'
-    character(len=char_len) :: log_message
+    character(len=*), parameter :: subname = 'marbl_interface_types:marbl_single_diag_init'
+    character(len=char_len)     :: log_message
 
     ! Allocate column memory for 3D vars or num_elements memory for 2D vars
     select case (trim(vgrid))
@@ -419,8 +420,8 @@ contains
     integer(int_kind),            intent(in)    :: id
     type(marbl_log_type),         intent(inout) :: marbl_status_log
 
-    character(*), parameter :: subname = 'marbl_interface_types:marbl_single_sfo_constructor'
-    character(len=char_len) :: log_message
+    character(len=*), parameter :: subname = 'marbl_interface_types:marbl_single_sfo_constructor'
+    character(len=char_len)     :: log_message
 
     select case (trim(field_name))
       case("flux_o2")
@@ -482,9 +483,10 @@ contains
     type(marbl_log_type), intent(inout) :: marbl_status_log
     integer(int_kind),    intent(out)   :: sfo_id
 
+    character(len=*), parameter :: subname = 'marbl_interface_types:marbl_sfo_add'
+
     type(marbl_single_sfo_type), dimension(:), pointer :: new_sfo
     integer :: n, old_size
-    character(*), parameter :: subname = 'marbl_interface_types:marbl_sfo_add'
 
     if (associated(this%sfo)) then
       old_size = size(this%sfo)
@@ -546,9 +548,10 @@ contains
     class(marbl_diagnostics_type), intent(inout) :: this
     type(marbl_log_type),          intent(inout) :: marbl_status_log
 
+    character(len=*), parameter :: subname = 'marbl_interface_types:marbl_diagnostics_set_to_zero'
+    character(len=char_len)     :: log_message
+
     integer (int_kind) :: n
-    character(*), parameter :: subname = 'marbl_interface_types:marbl_diagnostics_set_to_zero'
-    character(len=char_len) :: log_message
 
     do n=1,size(this%diags)
       if (allocated(this%diags(n)%field_2d)) then
@@ -579,8 +582,9 @@ contains
     integer (int_kind)            , intent(out)   :: id
     type(marbl_log_type)          , intent(inout) :: marbl_status_log
 
-    character(*), parameter :: subname = 'marbl_interface_types:marbl_diagnostics_add'
-    character(len=char_len) :: log_message
+    character(len=*), parameter :: subname = 'marbl_interface_types:marbl_diagnostics_add'
+    character(len=char_len)     :: log_message
+
     type(marbl_single_diagnostic_type), dimension(:), pointer :: new_diags
     integer :: n, old_size
 
@@ -665,8 +669,8 @@ contains
     type(marbl_log_type),             intent(inout) :: marbl_status_log
     integer, optional,                intent(in)    :: dim1
 
-    character(*), parameter :: subname = 'marbl_interface_types:marbl_forcing_fields_set_rank'
-    character(len=char_len) :: log_message
+    character(len=*), parameter :: subname = 'marbl_interface_types:marbl_forcing_fields_set_rank'
+    character(len=char_len)     :: log_message
 
     this%metadata%rank = rank
     select case (rank)

--- a/src/marbl_internal_types.F90
+++ b/src/marbl_internal_types.F90
@@ -24,8 +24,8 @@ module marbl_internal_types
   ! derived types for zooplankton
 
   type, public :: zooplankton_config_type
-     character(char_len)     :: sname
-     character(char_len)     :: lname
+     character(len=char_len)     :: sname
+     character(len=char_len)     :: lname
   end type zooplankton_config_type
 
   type, public :: zooplankton_parms_type
@@ -40,12 +40,12 @@ module marbl_internal_types
   ! derived types for autotrophs
 
   type, public :: autotroph_config_type
-     character(char_len)     :: sname
-     character(char_len)     :: lname
-     logical (KIND=log_kind) :: Nfixer                             ! flag set to true if this autotroph fixes N2
-     logical (KIND=log_kind) :: imp_calcifier                      ! flag set to true if this autotroph implicitly handles calcification
-     logical (KIND=log_kind) :: exp_calcifier                      ! flag set to true if this autotroph explicitly handles calcification
-     logical (KIND=log_kind) :: silicifier                         ! flag set to true if this autotroph is a silicifier
+     character(len=char_len)     :: sname
+     character(len=char_len)     :: lname
+     logical (KIND=log_kind)     :: Nfixer                             ! flag set to true if this autotroph fixes N2
+     logical (KIND=log_kind)     :: imp_calcifier                      ! flag set to true if this autotroph implicitly handles calcification
+     logical (KIND=log_kind)     :: exp_calcifier                      ! flag set to true if this autotroph explicitly handles calcification
+     logical (KIND=log_kind)     :: silicifier                         ! flag set to true if this autotroph is a silicifier
   end type autotroph_config_type
 
   type, public :: autotroph_parms_type
@@ -71,8 +71,8 @@ module marbl_internal_types
   ! derived types for grazing
 
   type, public :: grazing_config_type
-    character(char_len)     :: sname
-    character(char_len)     :: lname
+    character(len=char_len) :: sname
+    character(len=char_len) :: lname
     integer (KIND=int_kind) :: auto_ind_cnt     ! number of autotrophs in prey-clase auto_ind
     integer (KIND=int_kind) :: zoo_ind_cnt      ! number of zooplankton in prey-clase zoo_ind
   end type grazing_config_type
@@ -933,9 +933,9 @@ contains
     character(len=char_len), dimension(:),       intent(in)    :: tracer_restore_vars
     type(marbl_log_type),                        intent(inout) :: marbl_status_log
 
-    character(*), parameter :: subname =                                      &
-                    'marbl_internal_types:interior_forcing_index_constructor'
-    character(len=char_len) :: log_message
+    character(len=*), parameter :: subname = 'marbl_internal_types:interior_forcing_index_constructor'
+    character(len=char_len)     :: log_message
+
     integer :: m, n
 
     associate(forcing_cnt => num_interior_forcing_fields)
@@ -1052,8 +1052,8 @@ contains
     type(grazing_config_type), intent(in)    :: grazing_conf
     type(marbl_log_type),      intent(inout) :: marbl_status_log
 
-    character(*), parameter :: subname = 'marbl_internal_types:grazing_config_constructor'
-    character(len=char_len) :: log_message
+    character(len=*), parameter :: subname = 'marbl_internal_types:grazing_config_constructor'
+    character(len=char_len)     :: log_message
 
     if (allocated(this%auto_ind)) then
       log_message = 'grazing%auto_inds is already allocated!'

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -295,10 +295,11 @@ contains
     !-----------------------------------------------------------------------
     !  local variables
     !-----------------------------------------------------------------------
-    character(*), parameter :: subname = 'marbl_mod:marbl_init_surface_forcing_fields'
-    character(len=char_len) :: log_message
-    integer                 :: id
-    logical                 :: found
+    character(len=*), parameter :: subname = 'marbl_mod:marbl_init_surface_forcing_fields'
+    character(len=char_len)     :: log_message
+
+    integer :: id
+    logical :: found
     !-----------------------------------------------------------------------
 
     associate(ind => surface_forcing_indices)
@@ -469,8 +470,9 @@ contains
     !-----------------------------------------------------------------------
     !  local variables
     !-----------------------------------------------------------------------
-    character(*), parameter :: subname = 'marbl_mod:marbl_init_interior_forcing_fields'
-    character(len=char_len) :: log_message
+    character(len=*), parameter :: subname = 'marbl_mod:marbl_init_interior_forcing_fields'
+    character(len=char_len)     :: log_message
+
     ! NAG didn't like associating to tracer_metadata(:)%*
     character(len=char_len) :: tracer_name
     character(len=char_len) :: tracer_units
@@ -611,7 +613,7 @@ contains
     !  local variables
     !-----------------------------------------------------------------------
 
-    character(*), parameter :: subname = 'marbl_mod:marbl_init_tracer_metadata'
+    character(len=*), parameter :: subname = 'marbl_mod:marbl_init_tracer_metadata'
 
     integer (int_kind) :: n        ! index for looping over tracers
     integer (int_kind) :: zoo_ind  ! zooplankton functional group index
@@ -957,7 +959,8 @@ contains
     !-----------------------------------------------------------------------
     !  local variables
     !-----------------------------------------------------------------------
-    character(*), parameter :: subname = 'marbl_mod:marbl_set_interior_forcing'
+    character(len=*), parameter :: subname = 'marbl_mod:marbl_set_interior_forcing'
+
     real(r8), dimension(marbl_total_tracer_cnt, domain%km) :: interior_restore
 
     integer (int_kind) :: n         ! tracer index
@@ -1560,9 +1563,8 @@ contains
          caco3_diss, &
          dust_diss
 
-    character(*), parameter :: &
-         subname = 'marbl_mod:marbl_compute_particulate_terms'
-    character(len=char_len) :: log_message
+    character(len=*), parameter :: subname = 'marbl_mod:marbl_compute_particulate_terms'
+    character(len=char_len)     :: log_message
 
 !   real (r8) :: TfuncS  ! temperature scaling from soft POM remin, not currently being applied
 
@@ -2288,16 +2290,17 @@ contains
     !-----------------------------------------------------------------------
     !  local variables
     !-----------------------------------------------------------------------
-    character(*), parameter :: subname = 'marbl_mod:marbl_set_surface_forcing'
-    integer (int_kind)      :: n                        ! loop indices
-    integer (int_kind)      :: auto_ind                 ! autotroph functional group index
-    real (r8)               :: phlo(num_elements)       ! lower bound for ph in solver
-    real (r8)               :: phhi(num_elements)       ! upper bound for ph in solver
-    real (r8)               :: ph_new(num_elements)     ! computed ph from solver
-    real (r8)               :: xkw_ice(num_elements)    ! common portion of piston vel., (1-fice)*xkw (cm/s)
-    real (r8)               :: o2sat_1atm(num_elements) ! o2 saturation @ 1 atm (mmol/m^3)
-    real (r8)               :: totalChl_loc(num_elements)  ! local value of totalChl
-    real (r8)               :: flux_o2_loc(num_elements)   ! local value of o2 flux
+    character(len=*), parameter :: subname = 'marbl_mod:marbl_set_surface_forcing'
+
+    integer (int_kind) :: n                        ! loop indices
+    integer (int_kind) :: auto_ind                 ! autotroph functional group index
+    real (r8)          :: phlo(num_elements)       ! lower bound for ph in solver
+    real (r8)          :: phhi(num_elements)       ! upper bound for ph in solver
+    real (r8)          :: ph_new(num_elements)     ! computed ph from solver
+    real (r8)          :: xkw_ice(num_elements)    ! common portion of piston vel., (1-fice)*xkw (cm/s)
+    real (r8)          :: o2sat_1atm(num_elements) ! o2 saturation @ 1 atm (mmol/m^3)
+    real (r8)          :: totalChl_loc(num_elements)  ! local value of totalChl
+    real (r8)          :: flux_o2_loc(num_elements)   ! local value of o2 flux
     type(thermodynamic_coefficients_type), dimension(num_elements) :: co3_coeffs
     !-----------------------------------------------------------------------
 
@@ -2944,9 +2947,10 @@ contains
     type(marbl_tracer_index_type), intent(in)    :: tracer_indices
     type(marbl_log_type),          intent(inout) :: marbl_status_log
 
-    character(*), parameter :: subname = 'marbl_mod:marbl_tracer_index_consistency_check'
-    character(len=char_len) :: log_message
-    integer                 :: tracer_cnt
+    character(len=*), parameter :: subname = 'marbl_mod:marbl_tracer_index_consistency_check'
+    character(len=char_len)     :: log_message
+
+    integer :: tracer_cnt
 
     tracer_cnt = tracer_indices%ecosys_base_ind_end -                         &
                  (tracer_indices%ecosys_base_ind_beg-1)
@@ -3310,7 +3314,8 @@ contains
     !-----------------------------------------------------------------------
     !  local variables
     !-----------------------------------------------------------------------
-    character(*), parameter :: subname = 'marbl_mod:marbl_compute_carbonate_chemistry'
+    character(len=*), parameter :: subname = 'marbl_mod:marbl_compute_carbonate_chemistry'
+
     integer :: k
     type(thermodynamic_coefficients_type), dimension(domain%km) :: co3_coeffs
     logical(log_kind) , dimension(domain%km) :: pressure_correct
@@ -4417,8 +4422,8 @@ contains
     !  local variables
     !-----------------------------------------------------------------------
 
-    character(*), parameter :: subname = 'marbl_mod:marbl_compute_scavenging'
-    character(len=char_len) :: log_message
+    character(len=*), parameter :: subname = 'marbl_mod:marbl_compute_scavenging'
+    character(len=char_len)     :: log_message
 
     ! ligand binding strengths, original values are L/mol, model units are L/umol
     real(kind=r8), parameter :: KFeLig1 = 10.0e13_r8 * 1.0e-6_r8

--- a/src/marbl_namelist_mod.F90
+++ b/src/marbl_namelist_mod.F90
@@ -16,11 +16,10 @@ module marbl_namelist_mod
   !            but runtime configurable?! Just not sure what the
   !            best approach is at the moment....
 
-  ! NOTES: nl_in_size is the number of characters in the entire namelist file
+  ! NOTES:
   !        nl_cnt is the number of distinct namelists in the file
   !        nl_buffer_size is the number of characters in the largest _nml
 
-  integer, public, parameter :: marbl_nl_in_size     = 262144
   integer, public, parameter :: marbl_nl_cnt = 256
   integer, public, parameter :: marbl_nl_buffer_size = 32768
 
@@ -51,7 +50,7 @@ contains
     ! FIXME #74: Strip comments out of str_in (without accidentally removing
     !            strings that happen to contain exclamation points)
 
-    character(len=marbl_nl_in_size), intent(in) :: str_in
+    character(len=*), intent(in) :: str_in
     ! array_out is intent(inout) because we initialized to '' previously
     ! (and also to save memory)
     character(len=marbl_nl_buffer_size), dimension(marbl_nl_cnt), intent(inout) :: &

--- a/src/marbl_namelist_mod.F90
+++ b/src/marbl_namelist_mod.F90
@@ -12,17 +12,6 @@ module marbl_namelist_mod
   implicit none
   private
 
-  ! FIXME #33: nl_buffer_size shouldn't be a hard coded constant
-  !            but runtime configurable?! Just not sure what the
-  !            best approach is at the moment....
-
-  ! NOTES:
-  !        nl_cnt is the number of distinct namelists in the file
-  !        nl_buffer_size is the number of characters in the largest _nml
-
-  integer, public, parameter :: marbl_nl_cnt = 256
-  integer, public, parameter :: marbl_nl_buffer_size = 32768
-
   ! Need to know what carriage return is on the system; use #define if we
   ! come across a machine that doesn't use achar(10)
 
@@ -53,10 +42,10 @@ contains
     character(len=*), intent(in) :: str_in
     ! array_out is intent(inout) because we initialized to '' previously
     ! (and also to save memory)
-    character(len=marbl_nl_buffer_size), dimension(marbl_nl_cnt), intent(inout) :: &
+    character(len=*), dimension(:), intent(inout) :: &
              array_out
 
-    character(len=marbl_nl_buffer_size) :: str_tmp
+    character(len=len(str_in)) :: str_tmp
     integer :: old_pos, nl_cnt, i, j
 
     ! each namelist needs to be stored in different element of array_out
@@ -94,14 +83,14 @@ contains
     use marbl_logging,   only : marbl_log_type
     use marbl_kinds_mod, only : char_len
 
-    character(len=marbl_nl_buffer_size), intent(in) :: nl_buffer(:)
+    character(len=*), intent(in) :: nl_buffer(:)
     character(len=*), intent(in) :: nl_name
     type(marbl_log_type), intent(inout) :: marbl_status_log
-    character(len=marbl_nl_buffer_size) :: marbl_namelist
+    character(len=len(nl_buffer)) :: marbl_namelist
 
     character(*), parameter :: subname = 'marbl_namelist_mod:marbl_namelist'
     character(len=char_len) :: log_message
-    character(len=marbl_nl_buffer_size) :: single_namelist
+    character(len=len(nl_buffer)) :: single_namelist
     integer :: j, n
 
     ! Will return empty string if namelist not found

--- a/src/marbl_namelist_mod.F90
+++ b/src/marbl_namelist_mod.F90
@@ -42,8 +42,7 @@ contains
     character(len=*), intent(in) :: str_in
     ! array_out is intent(inout) because we initialized to '' previously
     ! (and also to save memory)
-    character(len=*), dimension(:), intent(inout) :: &
-             array_out
+    character(len=*), dimension(:), intent(inout) :: array_out
 
     character(len=len(str_in)) :: str_tmp
     integer :: old_pos, nl_cnt, i, j
@@ -88,8 +87,9 @@ contains
     type(marbl_log_type), intent(inout) :: marbl_status_log
     character(len=len(nl_buffer)) :: marbl_namelist
 
-    character(*), parameter :: subname = 'marbl_namelist_mod:marbl_namelist'
-    character(len=char_len) :: log_message
+    character(len=*), parameter :: subname = 'marbl_namelist_mod:marbl_namelist'
+    character(len=char_len)     :: log_message
+
     character(len=len(nl_buffer)) :: single_namelist
     integer :: j, n
 

--- a/src/marbl_parms.F90
+++ b/src/marbl_parms.F90
@@ -462,19 +462,18 @@ contains
 
   subroutine marbl_parms_read_namelist(nl_buffer, marbl_status_log)
 
-    use marbl_namelist_mod, only : marbl_nl_cnt
-    use marbl_namelist_mod, only : marbl_nl_buffer_size
     use marbl_namelist_mod, only : marbl_namelist
 
-    character(marbl_nl_buffer_size), intent(in)    :: nl_buffer(:)
-    type(marbl_log_type),            intent(inout) :: marbl_status_log
+    character(len=*),     intent(in)    :: nl_buffer(:)
+    type(marbl_log_type), intent(inout) :: marbl_status_log
 
     !---------------------------------------------------------------------------
     !   local variables
     !---------------------------------------------------------------------------
     character(*), parameter :: subname = 'marbl_parms:marbl_parms_read_namelist'
     character(len=char_len) :: log_message
-    character(len=marbl_nl_buffer_size) :: tmp_nl_buffer
+
+    character(len=len(nl_buffer)) :: tmp_nl_buffer
 
     integer (int_kind)           :: n                           ! index for looping over tracers
     integer (int_kind)           :: nml_error                   ! namelist i/o error flag

--- a/src/marbl_parms.F90
+++ b/src/marbl_parms.F90
@@ -82,17 +82,17 @@ module marbl_parms
   type(autotroph_parms_type),   target :: autotrophs(autotroph_cnt)
   type(grazing_parms_type),     target :: grazing(grazer_prey_cnt, zooplankton_cnt)
 
-  real(r8),            target :: iron_frac_in_dust            ! fraction by weight of iron in dust
-  real(r8),            target :: iron_frac_in_bc              ! fraction by weight of iron in black carbon
-  character(char_len), target :: caco3_bury_thres_opt         ! option of threshold of caco3 burial ['fixed_depth', 'omega_calc']
-  real(r8),            target :: caco3_bury_thres_depth       ! threshold depth for caco3_bury_thres_opt='fixed_depth'
+  real(r8),                target :: iron_frac_in_dust            ! fraction by weight of iron in dust
+  real(r8),                target :: iron_frac_in_bc              ! fraction by weight of iron in black carbon
+  character(len=char_len), target :: caco3_bury_thres_opt         ! option of threshold of caco3 burial ['fixed_depth', 'omega_calc']
+  real(r8),                target :: caco3_bury_thres_depth       ! threshold depth for caco3_bury_thres_opt='fixed_depth'
   ! -----------
   ! PON_sed_loss = PON_bury_coeff * Q * POC_sed_loss
   ! factor is used to avoid overburying PON like POC
   ! is when total C burial is matched to C riverine input
   ! -----------
-  real(r8),            target :: PON_bury_coeff
-  character(char_len), target :: ciso_fract_factors             ! option for which biological fractionation calculation to use
+  real(r8),                target :: PON_bury_coeff
+  character(len=char_len), target :: ciso_fract_factors           ! option for which biological fractionation calculation to use
 
   character(len=char_len), allocatable, target, dimension(:) :: tracer_restore_vars
 
@@ -470,8 +470,8 @@ contains
     !---------------------------------------------------------------------------
     !   local variables
     !---------------------------------------------------------------------------
-    character(*), parameter :: subname = 'marbl_parms:marbl_parms_read_namelist'
-    character(len=char_len) :: log_message
+    character(len=*), parameter :: subname = 'marbl_parms:marbl_parms_read_namelist'
+    character(len=char_len)     :: log_message
 
     character(len=len(nl_buffer)) :: tmp_nl_buffer
 
@@ -544,8 +544,9 @@ contains
     class(marbl_config_and_parms_type), intent(inout) :: this
     type(marbl_log_type),    intent(inout) :: marbl_status_log
 
-    character(*), parameter :: subname = 'marbl_parms:marbl_define_parameters'
-    character(len=char_len) :: log_message
+    character(len=*), parameter :: subname = 'marbl_parms:marbl_define_parameters'
+    character(len=char_len)     :: log_message
+
     character(len=char_len) :: sname, lname, units, datatype, group, category
     real(r8),                pointer :: rptr => NULL()
     integer(int_kind),       pointer :: iptr => NULL()

--- a/src/marbl_saved_state_mod.F90
+++ b/src/marbl_saved_state_mod.F90
@@ -28,7 +28,8 @@ Contains
     integer,                      intent(in)    :: num_interior_forcing
     type(marbl_log_type),         intent(inout) :: marbl_status_log
 
-    character(*), parameter :: subname = 'marbl_saved_state_mod:marbl_saved_state_init'
+    character(len=*), parameter :: subname = 'marbl_saved_state_mod:marbl_saved_state_init'
+
     character(len=char_len) :: lname, sname, units, vgrid
     integer :: rank
 

--- a/src/marbl_timing_mod.F90
+++ b/src/marbl_timing_mod.F90
@@ -53,11 +53,11 @@ module marbl_timing_mod
   ! Internal timer types
 
   type :: marbl_single_timer_type
-    character(char_len) :: name
-    logical             :: is_running
-    logical             :: is_threaded
-    real(r8)            :: cur_start
-    real(r8)            :: cumulative_runtime
+    character(len=char_len) :: name
+    logical                 :: is_running
+    logical                 :: is_threaded
+    real(r8)                :: cur_start
+    real(r8)                :: cumulative_runtime
   contains
     procedure :: init => init_single_timer
   end type marbl_single_timer_type
@@ -100,8 +100,9 @@ Contains
     integer,                           intent(out)   :: id
     type(marbl_log_type),              intent(inout) :: marbl_status_log
 
-    character(*), parameter :: subname = 'marbl_timing_mod:marbl_timing_add'
-    character(len=char_len) :: log_message
+    character(len=*), parameter :: subname = 'marbl_timing_mod:marbl_timing_add'
+    character(len=char_len)     :: log_message
+
     type(marbl_single_timer_type), allocatable :: tmp(:)
     integer :: n
 
@@ -141,8 +142,8 @@ Contains
     integer,                           intent(in)    :: id
     type(marbl_log_type),              intent(inout) :: marbl_status_log
 
-    character(*), parameter :: subname = 'marbl_timing_mod:marbl_timing_start'
-    character(len=char_len) :: log_message
+    character(len=*), parameter :: subname = 'marbl_timing_mod:marbl_timing_start'
+    character(len=char_len)     :: log_message
 
 #ifdef _OPENMP
     integer, external :: omp_get_num_threads
@@ -182,8 +183,9 @@ Contains
     integer,                           intent(in)    :: id
     type(marbl_log_type),              intent(inout) :: marbl_status_log
 
-    character(*), parameter :: subname = 'marbl_timing_mod:marbl_timing_stop'
-    character(len=char_len) :: log_message
+    character(len=*), parameter :: subname = 'marbl_timing_mod:marbl_timing_stop'
+    character(len=char_len)     :: log_message
+
     real(r8) :: runtime
 
     ! Error checking
@@ -222,8 +224,9 @@ Contains
     type(marbl_timers_type),           intent(inout) :: interface_timers
     type(marbl_log_type),              intent(inout) :: marbl_status_log
 
-    character(*), parameter :: subname = 'marbl_timing_mod:extract_timer_data'
-    character(len=char_len) :: log_message
+    character(len=*), parameter :: subname = 'marbl_timing_mod:extract_timer_data'
+    character(len=char_len)     :: log_message
+
     integer :: n, num_timers
 
     if (allocated(self%individual_timers)) then
@@ -258,7 +261,7 @@ Contains
     type(marbl_timer_indexing_type),   intent(inout) :: timer_ids
     type(marbl_log_type),              intent(inout) :: marbl_status_log
 
-    character(*), parameter :: subname = 'marbl_timing_mod:setup_timers'
+    character(len=*), parameter :: subname = 'marbl_timing_mod:setup_timers'
 
     !-----------------------------------------------------------------------
     !  Set up timers for inside time loops
@@ -302,8 +305,9 @@ Contains
     class(marbl_internal_timers_type), intent(inout) :: self
     type(marbl_log_type),              intent(inout) :: marbl_status_log
 
-    character(*), parameter :: subname = 'marbl_timing_mod:reset_timers'
-    character(len=char_len) :: log_message
+    character(len=*), parameter :: subname = 'marbl_timing_mod:reset_timers'
+    character(len=char_len)     :: log_message
+
     integer :: n
 
     do n = 1,size(self%individual_timers)
@@ -331,7 +335,7 @@ Contains
     type(marbl_timers_type),           intent(inout) :: interface_timers
     type(marbl_log_type),              intent(inout) :: marbl_status_log
 
-    character(*), parameter :: subname = 'marbl_timing_mod:shutdown_timers'
+    character(len=*), parameter :: subname = 'marbl_timing_mod:shutdown_timers'
 
     call timer_ids%set_to_zero()
 

--- a/tests/driver_src/marbl.F90
+++ b/tests/driver_src/marbl.F90
@@ -31,9 +31,6 @@ Program marbl
   ! Use from libmarbl.a
   use marbl_interface,    only : marbl_interface_class
   use marbl_logging,      only : marbl_log_type
-  use marbl_namelist_mod, only : marbl_nl_in_size
-  use marbl_namelist_mod, only : marbl_nl_cnt
-  use marbl_namelist_mod, only : marbl_nl_buffer_size
   use marbl_namelist_mod, only : marbl_nl_split_string
   use marbl_namelist_mod, only : marbl_namelist
 
@@ -55,15 +52,19 @@ Program marbl
   Implicit None
 
   character(len=256), parameter :: subname = 'Program Marbl'
-  type(marbl_interface_class) :: marbl_instance
-  type(marbl_log_type)        :: driver_status_log
-  character(len=marbl_nl_buffer_size) :: nl_buffer(marbl_nl_cnt)
-  character(len=marbl_nl_buffer_size) :: tmp_nl_buffer
-  character(len=marbl_nl_in_size)     :: nl_str, tmp_str
-  integer                             :: ioerr=0
-  integer                             :: m, n, nt, cnt
-  character(len=256)                  :: testname, varname, log_message
-  logical                             :: lprint_marbl_log
+  integer,            parameter :: nl_buffer_size = 256
+  integer,            parameter :: nl_cnt = 4
+  integer,            parameter :: nl_in_size = 1024
+
+  type(marbl_interface_class)   :: marbl_instance
+  type(marbl_log_type)          :: driver_status_log
+  character(len=nl_buffer_size) :: nl_buffer(nl_cnt)
+  character(len=nl_buffer_size) :: tmp_nl_buffer
+  character(len=nl_in_size)     :: nl_str, tmp_str
+  integer                       :: ioerr=0
+  integer                       :: m, n, nt, cnt
+  character(len=256)            :: testname, varname, log_message
+  logical                       :: lprint_marbl_log
 
   namelist /marbl_driver_nml/testname
 


### PR DESCRIPTION
MARBL doesn't need to provide the GCM with `marbl_nl_in_size`, `marbl_nl_cnt`, or `marbl_nl_buffer_size` -- the GCM should determine these sizes and then MARBL can figure them out from `size()` and `len()`of various `intent(in)` strings.

Since the GCM no longer gets these values from MARBL, there is [an associated POP tag](https://svn-ccsm-models.cgd.ucar.edu/pop2/branch_tags/marbl_dev_levy_tags/marbl_dev_levy_n97_marbl_dev_n48_cesm_pop_2_1_20170601).
