### PR TITLE
Enhancement/improve drtsafe error

### DIFF
--- a/src/marbl_co2calc_mod.F90
+++ b/src/marbl_co2calc_mod.F90
@@ -301,10 +301,17 @@ contains
     real(kind=r8)            :: htotal(num_elements) ! free concentration of H ion
     !---------------------------------------------------------------------------
 
+    ! temp and salt are not used out of co2calc_state at this time but are
+    ! set here to avoid having co2calc_state%temp and %salt uninitialized
+    co2calc_state(:)%temp = temp
+    co2calc_state(:)%salt = salt
+
     co2calc_state_in(:)%dic = dic_in
     co2calc_state_in(:)%ta  = ta_in
     co2calc_state_in(:)%pt  = pt_in
     co2calc_state_in(:)%sit = sit_in
+    co2calc_state_in(:)%temp = temp
+    co2calc_state_in(:)%salt = salt
 
     associate(                         &
          k0  => co2calc_coeffs(:)%k0,  &

--- a/src/marbl_co2calc_mod.F90
+++ b/src/marbl_co2calc_mod.F90
@@ -916,15 +916,22 @@ contains
                 ! DIC
                 WRITE(log_message,"(3A,1X,A,E15.7e3)") '(', subname, ')',     &
                       'dic = ', co2calc_state_in(c)%dic
+                call marbl_status_log%log_error(log_message, subname, c)
+
                 ! TA
                 WRITE(log_message,"(3A,1X,A,E15.7e3)") '(', subname, ')',     &
                       'ta = ', co2calc_state_in(c)%ta
+                call marbl_status_log%log_error(log_message, subname, c)
+
                 ! PT
                 WRITE(log_message,"(3A,1X,A,E15.7e3)") '(', subname, ')',     &
                       'pt = ', co2calc_state_in(c)%pt
+                call marbl_status_log%log_error(log_message, subname, c)
+
                 ! SIT
                 WRITE(log_message,"(3A,1X,A,E15.7e3)") '(', subname, ')',     &
                       'sit = ', co2calc_state_in(c)%sit
+                call marbl_status_log%log_error(log_message, subname, c)
 
                 abort = .true.
              end if


### PR DESCRIPTION
Add DIC, PT, TA, and SIT to error message when `drtsafe()` does not converge. I did this by creating a new local variable of type `co2calc_state_type` in `marbl_co2calc_surf()` and `marbl_comp_CO3terms()` (copies of `dic_in`, `pt_in`, `ta_in`, and `sit_in`) to ensure that the log contains the values passed by the GCM rather than the value after MARBL limits the range by applying a minimum value check.

I don't really like how this leads to passing both `marbl_co2calc_state_in` and `marbl_co2calc_state` as `intent(in)`, so maybe better variable names are called for?

If I force an error by setting the `del_ph` to a very small number then the error reads:

```
Message from (lon, lat) ( 323.300, -77.981), which is global (i,j) (1, 2)
(marbl_co2calc_mod:drtsafe) it = 4
(marbl_co2calc_mod:drtsafe) x1,f =  0.7588892E-008 0.3275306E-006
(marbl_co2calc_mod:drtsafe) x2,f =  0.7588948E-008 0.3262787E-006
MARBL ERROR (marbl_co2calc_mod:drtsafe): bounding bracket for pH solution not found
MARBL ERROR (marbl_co2calc_mod:drtsafe): (marbl_co2calc_mod:drtsafe) dic =  0.2230582E+004
MARBL ERROR (marbl_co2calc_mod:drtsafe): (marbl_co2calc_mod:drtsafe) ta =  0.2373427E+004
MARBL ERROR (marbl_co2calc_mod:drtsafe): (marbl_co2calc_mod:drtsafe) pt =  0.1780354E+001
MARBL ERROR (marbl_co2calc_mod:drtsafe): (marbl_co2calc_mod:drtsafe) sit =  0.5790140E+002
```

Addresses #151 