### PR TITLE
Add get_tracer_cnt routine to interface and tests

### DIFF
--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -121,6 +121,7 @@ module marbl_interface
      procedure, public  :: extract_timing
      procedure, private :: glo_vars_init
      procedure, public  :: get_tracer_index
+     procedure, public  :: get_tracer_cnt
      procedure, public  :: set_interior_forcing
      procedure, public  :: set_surface_forcing
      procedure, public  :: set_global_scalars
@@ -1044,6 +1045,41 @@ contains
     end do
 
   end function get_tracer_index
+
+  !***********************************************************************
+
+  function get_tracer_cnt(this, module_name)
+
+    class(marbl_interface_class), intent(inout) :: this
+    character(len=*), optional,   intent(in)    :: module_name
+    integer :: get_tracer_cnt
+
+    character(len=*), parameter :: subname = 'marbl_interface:get_tracer_cnt'
+    character(len=char_len) :: log_message
+    character(len=char_len) :: module_name_loc
+
+    ! If module_name is not present, return total tracer count
+    if (present(module_name)) then
+      module_name_loc = module_name
+    else
+      module_name_loc = 'ALL TRACERS'
+    end if
+
+    get_tracer_cnt = 0
+    select case (trim(module_name_loc))
+      case ('ecosys_base')
+        get_tracer_cnt = this%tracer_indices%ecosys_base%cnt
+      case ('ciso')
+        get_tracer_cnt = this%tracer_indices%ciso%cnt
+      case ('ALL TRACERS')
+        get_tracer_cnt = this%tracer_indices%total_cnt
+      case DEFAULT
+        write(log_message,"(3A)") "Unrecognized tracer module: ", trim(module_name_loc), &
+                                  "; returning tracer count of 0"
+        call this%StatusLog%log_error(log_message, subname)
+    end select
+
+  end function get_tracer_cnt
 
   !*****************************************************************************
 

--- a/tests/driver_src/marbl.F90
+++ b/tests/driver_src/marbl.F90
@@ -54,7 +54,8 @@ Program marbl
 
   type(marbl_interface_class)   :: marbl_instance
   type(marbl_log_type)          :: driver_status_log
-  integer                       :: m, n, nt, cnt
+  integer                       :: m, n, cnt
+  integer                       :: base_nt, ciso_nt, nt
   character(len=256)            :: input_line, testname, varname, log_message, log_out_file
   logical                       :: lprint_marbl_log, lhas_inputfile
   logical                       :: ldriver_log_to_file, lsummarize_timers
@@ -209,6 +210,21 @@ Program marbl
         call driver_status_log%log_noerror('No tracers to restore!', subname)
       end if
       call marbl_instance%shutdown()
+
+    ! -- tracer_cnt test -- !
+  case ('tracer_cnt')
+    lprint_marbl_log = .false.
+    lsummarize_timers = .false.
+    call marbl_init_test(marbl_instance, lshutdown = .false.)
+    if (.not. marbl_instance%StatusLog%labort_marbl) then
+      call marbl_instance%StatusLog%erase()
+      base_nt = marbl_instance%get_tracer_cnt('ecosys_base')
+      ciso_nt = marbl_instance%get_tracer_cnt('ciso')
+      nt      = marbl_instance%get_tracer_cnt()
+      write(log_message,'(I0,1X,I0,1X,I0)')  base_nt, ciso_nt, nt
+      call driver_status_log%log_noerror(log_message, subname)
+      call marbl_instance%shutdown()
+    end if
 
     !    UNIT TESTS
     ! -- get_put test -- !

--- a/tests/regression_tests/tracer_cnt/marbl.input
+++ b/tests/regression_tests/tracer_cnt/marbl.input
@@ -1,0 +1,1 @@
+ciso_on = .true.

--- a/tests/regression_tests/tracer_cnt/test.nml
+++ b/tests/regression_tests/tracer_cnt/test.nml
@@ -1,0 +1,3 @@
+&marbl_driver_nml
+testname="tracer_cnt"
+/

--- a/tests/regression_tests/tracer_cnt/tracer_cnt.py
+++ b/tests/regression_tests/tracer_cnt/tracer_cnt.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+from sys import path
+
+path.insert(0,'../../python_for_tests')
+from marbl_testing_class import MARBL_testcase
+
+mt = MARBL_testcase()
+
+mt.parse_args(desc='Run MARBL init and return tracer counts for ecosys_base, ciso, and marbl')
+
+mt.build_exe()
+
+mt.run_exe()


### PR DESCRIPTION
The get_tracer_cnt test returns the number of tracers in the ecosys_base
module, the number of tracers in the ciso module, and the total MARBL tracer
cnt all in one line, separated by spaces. So with ciso_on = .true. and all
other parameters kept to default settings, the output of the test is

Beginning tracer_cnt test...
32 14 46

One use for this test will be for POP to determine ECOSYS_BASE_NT, CISO_NT, and
MARBL_NT directly from the MARBL code rather than relying on users to update it
correctly.