### PR TITLE
Enhancement/better python

### DIFF
--- a/src/makedep.py
+++ b/src/makedep.py
@@ -43,9 +43,9 @@ for src_file in files_in_src_dir:
   file_name, file_ext = os.path.splitext(src_file)
   if file_ext == '.F90':
     try:
-      fin = open(src_dir+'/'+src_file,"r")
+      fin = open(os.path.join(src_dir, src_file),"r")
     except:
-      fin = open(src_dir2+'/'+src_file,"r")
+      fin = open(os.path.join(src_dir2, src_file),"r")
 
     # (1) dependency list from current file should be empty
     depends = ['']

--- a/tests/bld_tests/bld_exe.py
+++ b/tests/bld_tests/bld_exe.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 from sys import path
+import os
 
-path.insert(0, '../python_for_tests')
+path.insert(0, os.path.join('..', 'python_for_tests'))
 from marbl_testing_class import MARBL_testcase
 from general import pause
 

--- a/tests/bld_tests/bld_lib.py
+++ b/tests/bld_tests/bld_lib.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 from sys import path
+import os
 
-path.insert(0, '../python_for_tests')
+path.insert(0, os.path.join('..', 'python_for_tests'))
 from marbl_testing_class import MARBL_testcase
 from general import pause
 

--- a/tests/python_for_tests/machines.py
+++ b/tests/python_for_tests/machines.py
@@ -22,7 +22,7 @@ def load_module(mach, compiler, module_name):
   print "Loading module %s..." % module_name
 
   if mach == 'yellowstone':
-    sys.path.insert(0,'/glade/apps/opt/lmod/lmod/init')
+    sys.path.insert(0, os.path.join(os.sep, 'glade', 'apps', 'opt', 'lmod', 'lmod', 'init'))
     from env_modules_python import module
     module('purge')
     module('load', module_name)
@@ -30,7 +30,7 @@ def load_module(mach, compiler, module_name):
     module('load', 'ncarbinlibs')
 
   if mach == 'cheyenne':
-    sys.path.insert(0,'/glade/u/apps/ch/opt/lmod/7.2.1/lmod/lmod/init')
+    sys.path.insert(0, os.path.join(os.sep, 'glade', 'u', 'apps', 'ch', 'opt', 'lmod', '7.2.1', 'lmod', 'lmod', 'init'))
     from env_modules_python import module
     module('purge')
     module('load', module_name)
@@ -38,13 +38,13 @@ def load_module(mach, compiler, module_name):
     module('load', 'mpt/2.15')
 
   if mach == 'hobart':
-    sys.path.insert(0,'/usr/share/Modules/init')
+    sys.path.insert(0, os.path.join(os.sep, 'usr', 'share', 'Modules', 'init'))
     from python import module
     module('purge')
     module(['load', module_name])
 
   if mach == 'edison':
-    sys.path.insert(0,'/opt/modules/default/init')
+    sys.path.insert(0, os.path.join('opt', 'modules', 'default', 'init'))
     from python import module
     module('purge')
     module(['load', module_name])

--- a/tests/python_for_tests/machines.py
+++ b/tests/python_for_tests/machines.py
@@ -44,12 +44,11 @@ def load_module(mach, compiler, module_name):
     module(['load', module_name])
 
   if mach == 'edison':
-    sys.path.insert(0, os.path.join('opt', 'modules', 'default', 'init'))
+    sys.path.insert(0, os.path.join(os.sep, 'opt', 'modules', 'default', 'init'))
     from python import module
     module('purge')
+    module(['load', 'craype/2.5.12'])
     module(['load', module_name])
-    if compiler == 'cray':
-      module(['swap', 'cce', 'cce/8.5.0.4664'])
 
 # -----------------------------------------------
 

--- a/tests/python_for_tests/machines.py
+++ b/tests/python_for_tests/machines.py
@@ -71,7 +71,7 @@ def machine_specific(mach, supported_compilers, module_names):
     supported_compilers.append('gnu')
     supported_compilers.append('pgi')
     module_names['intel'] = 'intel/17.0.1'
-    module_names['gnu'] = 'gnu/7.1.0'
+    module_names['gnu'] = 'gnu/6.1.0'
     module_names['pgi'] = 'pgi/17.5'
     return
 

--- a/tests/python_for_tests/marbl_testing_class.py
+++ b/tests/python_for_tests/marbl_testing_class.py
@@ -1,12 +1,11 @@
 import sys
 import machines as machs
+import os
 from os import system as sh_command
 
 class MARBL_testcase(object):
 
   def __init__(self):
-    from os import path
-
     # supported_compilers is public, needed by the build tests
     self.supported_compilers = []
 
@@ -18,7 +17,7 @@ class MARBL_testcase(object):
     self._namelist_file = None
     self._input_file = None
     self._mpitasks = 0
-    self._marbl_dir = path.abspath('%s/../..' % path.dirname(__file__))
+    self._marbl_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
 
   # -----------------------------------------------
 
@@ -125,7 +124,7 @@ class MARBL_testcase(object):
     if loc_compiler == None:
       loc_compiler = self._compiler
 
-    src_dir = '%s/src' % self._marbl_dir
+    src_dir = os.path.join(self._marbl_dir, 'src')
 
     if self._machine != 'local':
       machs.load_module(self._machine, loc_compiler, self._module_names[loc_compiler])
@@ -143,7 +142,7 @@ class MARBL_testcase(object):
     if loc_compiler == None:
       loc_compiler = self._compiler
 
-    drv_dir = '%s/tests/driver_src' % self._marbl_dir
+    drv_dir = os.path.join(self._marbl_dir, 'tests', 'driver_src')
 
     if self._machine != 'local':
       machs.load_module(self._machine, loc_compiler, self._module_names[loc_compiler])
@@ -159,7 +158,7 @@ class MARBL_testcase(object):
   def run_exe(self):
 
     # build the executable command string
-    execmd = '%s/tests/driver_exe/' % self._marbl_dir
+    execmd = os.path.join(self._marbl_dir, 'tests', 'driver_exe') + os.sep
 
     # if running in parallel, executable is marbl-mpi.exe
     if self._mpitasks > 0:
@@ -201,7 +200,7 @@ class MARBL_testcase(object):
   # clean libmarbl.a
   def _clean_lib(self):
 
-    src_dir = '%s/src' % self._marbl_dir
+    src_dir = os.path.join(self._marbl_dir, 'src')
     sh_command('cd %s; make clean' % src_dir)
 
   # -----------------------------------------------
@@ -209,6 +208,6 @@ class MARBL_testcase(object):
   # Clean marbl.exe
   def _clean_exe(self):
 
-    drv_dir = '%s/tests/driver_src' % self._marbl_dir
+    drv_dir = os.path.join(self._marbl_dir, 'tests', 'driver_src')
     sh_command('cd %s; make clean' % drv_dir)
 

--- a/tests/regression_tests/gen_input_file/gen_input_file.py
+++ b/tests/regression_tests/gen_input_file/gen_input_file.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 from sys import path
+import os
 
-path.insert(0,'../../python_for_tests')
+path.insert(0, os.path.join('..', '..', 'python_for_tests'))
 from marbl_testing_class import MARBL_testcase
 
 mt = MARBL_testcase()

--- a/tests/regression_tests/init-twice/init-twice.py
+++ b/tests/regression_tests/init-twice/init-twice.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 from sys import path
+import os
 
-path.insert(0,'../../python_for_tests')
+path.insert(0, os.path.join('..', '..', 'python_for_tests'))
 from marbl_testing_class import MARBL_testcase
 
 mt = MARBL_testcase()

--- a/tests/regression_tests/init/init.py
+++ b/tests/regression_tests/init/init.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 from sys import path
+import os
 
-path.insert(0,'../../python_for_tests')
+path.insert(0, os.path.join('..', '..', 'python_for_tests'))
 from marbl_testing_class import MARBL_testcase
 
 mt = MARBL_testcase()

--- a/tests/regression_tests/requested_diags/requested_diags.py
+++ b/tests/regression_tests/requested_diags/requested_diags.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 from sys import path
+import os
 
-path.insert(0,'../../python_for_tests')
+path.insert(0, os.path.join('..', '..', 'python_for_tests'))
 from marbl_testing_class import MARBL_testcase
 
 mt = MARBL_testcase()

--- a/tests/regression_tests/requested_forcings/requested_forcings.py
+++ b/tests/regression_tests/requested_forcings/requested_forcings.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 from sys import path
+import os
 
-path.insert(0,'../../python_for_tests')
+path.insert(0, os.path.join('..', '..', 'python_for_tests'))
 from marbl_testing_class import MARBL_testcase
 
 mt = MARBL_testcase()

--- a/tests/regression_tests/requested_restoring/requested_restoring.py
+++ b/tests/regression_tests/requested_restoring/requested_restoring.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 from sys import path
+import os
 
-path.insert(0,'../../python_for_tests')
+path.insert(0, os.path.join('..', '..', 'python_for_tests'))
 from marbl_testing_class import MARBL_testcase
 
 mt = MARBL_testcase()

--- a/tests/regression_tests/requested_tracers/requested_tracers.py
+++ b/tests/regression_tests/requested_tracers/requested_tracers.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 from sys import path
+import os
 
-path.insert(0,'../../python_for_tests')
+path.insert(0, os.path.join('..', '..', 'python_for_tests'))
 from marbl_testing_class import MARBL_testcase
 
 mt = MARBL_testcase()

--- a/tests/unit_tests/get_put/get_put.py
+++ b/tests/unit_tests/get_put/get_put.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 from sys import path
+import os
 
-path.insert(0,'../../python_for_tests')
+path.insert(0, os.path.join('..', '..', 'python_for_tests'))
 from marbl_testing_class import MARBL_testcase
 
 mt = MARBL_testcase()

--- a/tests/unit_tests/utils_routines/marbl_utils.py
+++ b/tests/unit_tests/utils_routines/marbl_utils.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
 from sys import path
+import os
 
-path.insert(0,'../../python_for_tests')
+path.insert(0, os.path.join('..', '..', 'python_for_tests'))
 from marbl_testing_class import MARBL_testcase
 
 mt = MARBL_testcase()


### PR DESCRIPTION
Per issue #199 we should use `os.path.join` instead of assuming paths are separated via `/`. Also cleaned up some of the module loads on "supported machines" (I don't often run the standalone tests on `yellowstone` or `edison` and some of their module load statements were out of date)