### PR TITLE
Apply restoring to all tracers

### DIFF
--- a/autogenerated_src/default_settings.json
+++ b/autogenerated_src/default_settings.json
@@ -923,19 +923,22 @@
                "PO4",
                "NO3",
                "SiO3",
-               "ALK"
+               "ALK",
+               "ALK_ALT_CO2"
             ],
             "GRID = CESM_x1": [
                "PO4",
                "NO3",
                "SiO3",
-               "ALK"
+               "ALK",
+               "ALK_ALT_CO2"
             ],
             "GRID = CESM_x3": [
                "PO4",
                "NO3",
                "SiO3",
-               "ALK"
+               "ALK",
+               "ALK_ALT_CO2"
             ],
             "default": ""
          },

--- a/src/default_settings.yaml
+++ b/src/default_settings.yaml
@@ -840,5 +840,6 @@ tracer_dependent :
             - 'NO3'
             - 'SiO3'
             - 'ALK'
+            - 'ALK_ALT_CO2'
          GRID = CESM_x3 : *CESM_TRACER_RESTORE
          GRID = CESM_x1 : *CESM_TRACER_RESTORE

--- a/src/marbl_diagnostics_mod.F90
+++ b/src/marbl_diagnostics_mod.F90
@@ -3275,7 +3275,7 @@ contains
          sed_denitrif, other_remin, marbl_interior_forcing_diags)
 
     call store_diagnostics_carbon_fluxes(domain, POC, P_CaCO3, dtracers,      &
-         interior_restore, marbl_tracer_indices, marbl_interior_forcing_diags)
+         marbl_tracer_indices, marbl_interior_forcing_diags)
 
     call store_diagnostics_nitrification(&
          nitrif, denitrif, marbl_interior_forcing_diags)
@@ -3297,18 +3297,18 @@ contains
 
     call store_diagnostics_nitrogen_fluxes(domain, &
          PON_sed_loss, denitrif, sed_denitrif, autotroph_secondary_species, dtracers, &
-         interior_restore, marbl_tracer_indices, marbl_interior_forcing_diags)
+         marbl_tracer_indices, marbl_interior_forcing_diags)
 
     call store_diagnostics_phosphorus_fluxes(domain, POP, &
-         autotroph_secondary_species, dtracers, interior_restore, &
+         autotroph_secondary_species, dtracers, &
          marbl_tracer_indices, marbl_interior_forcing_diags)
 
     call store_diagnostics_silicon_fluxes(domain, P_SiO2, dtracers,           &
-         interior_restore, marbl_tracer_indices, marbl_interior_forcing_diags)
+         marbl_tracer_indices, marbl_interior_forcing_diags)
 
     call store_diagnostics_iron_fluxes(domain, P_iron, dust,                  &
          interior_forcings(interior_forcing_ind%fesedflux_id)%field_1d(1,:),  &
-         dtracers, interior_restore, marbl_tracer_indices, marbl_interior_forcing_diags)
+         dtracers, marbl_tracer_indices, marbl_interior_forcing_diags)
 
     call store_diagnostics_interior_restore(interior_restore,                 &
                                             marbl_interior_forcing_diags)
@@ -4035,13 +4035,12 @@ contains
   !***********************************************************************
 
   subroutine store_diagnostics_carbon_fluxes(marbl_domain, POC, P_CaCO3, dtracers, &
-             interior_restore, marbl_tracer_indices, marbl_diags)
+             marbl_tracer_indices, marbl_diags)
 
     type(marbl_domain_type)     , intent(in)    :: marbl_domain
     type(column_sinking_particle_type) , intent(in)    :: POC
     type(column_sinking_particle_type) , intent(in)    :: P_CaCO3
     real(r8)                           , intent(in)    :: dtracers(:,:)         ! tracer_cnt, km
-    real(r8)                           , intent(in)    :: interior_restore(:,:) ! tracer_cnt, km
     type(marbl_tracer_index_type)      , intent(in)    :: marbl_tracer_indices
     type(marbl_diagnostics_type)       , intent(inout) :: marbl_diags
 
@@ -4069,17 +4068,10 @@ contains
          sum(dtracers(marbl_tracer_indices%zoo_inds(:)%C_ind,:), dim=1) +     &
          sum(dtracers(marbl_tracer_indices%auto_inds(:)%C_ind,:),dim=1)
 
-    ! subtract tracer restoring terms
-    work = work - (interior_restore(dic_ind,:) + interior_restore(doc_ind,:) +              &
-                   interior_restore(docr_ind,:) +                                           &
-                   sum(interior_restore(marbl_tracer_indices%zoo_inds(:)%C_ind,:), dim=1) + &
-                   sum(interior_restore(marbl_tracer_indices%auto_inds(:)%C_ind,:),dim=1))
-
     do auto_ind = 1, autotroph_cnt
        n = marbl_tracer_indices%auto_inds(auto_ind)%CaCO3_ind
        if (n .gt. 0) then
           work = work + dtracers(n,:)
-          work = work - interior_restore(n,:)
        end if
     end do
 
@@ -4096,7 +4088,7 @@ contains
 
   subroutine store_diagnostics_nitrogen_fluxes(marbl_domain, &
        PON_sed_loss, denitrif, sed_denitrif, autotroph_secondary_species, dtracers, &
-       interior_restore, marbl_tracer_indices, marbl_diags)
+       marbl_tracer_indices, marbl_diags)
 
     use marbl_settings_mod, only : Q
 
@@ -4106,7 +4098,6 @@ contains
     real(r8)                               , intent(in)    :: sed_denitrif(:) ! km
     type(autotroph_secondary_species_type) , intent(in)    :: autotroph_secondary_species(:,:)
     real(r8)                               , intent(in)    :: dtracers(:,:)         ! tracer_cnt, km
-    real(r8)                               , intent(in)    :: interior_restore(:,:) ! tracer_cnt, km
     type(marbl_tracer_index_type)          , intent(in)    :: marbl_tracer_indices
     type(marbl_diagnostics_type)           , intent(inout) :: marbl_diags
 
@@ -4136,12 +4127,6 @@ contains
            Q * sum(dtracers(marbl_tracer_indices%auto_inds(:)%C_ind,:), dim=1) + &
            denitrif(:) + sed_denitrif(:)
 
-    ! subtract tracer restoring terms
-    work = work - (interior_restore(no3_ind,:) + interior_restore(nh4_ind,:) +                  &
-                   interior_restore(don_ind,:) + interior_restore(donr_ind,:) +                 &
-                   Q * sum(interior_restore(marbl_tracer_indices%zoo_inds(:)%C_ind,:), dim=1) + &
-                   Q * sum(interior_restore(marbl_tracer_indices%auto_inds(:)%C_ind,:), dim=1))
-
     ! subtract out N fixation
     do n = 1, autotroph_cnt
        if (autotrophs(n)%Nfixer) then
@@ -4161,7 +4146,7 @@ contains
   !***********************************************************************
 
   subroutine store_diagnostics_phosphorus_fluxes(marbl_domain, POP, &
-       autotroph_secondary_species, dtracers, interior_restore, &
+       autotroph_secondary_species, dtracers, &
        marbl_tracer_indices, marbl_diags)
 
     use marbl_pft_mod, only : Qp_zoo
@@ -4171,7 +4156,6 @@ contains
     type(column_sinking_particle_type)     , intent(in)    :: POP
     type(autotroph_secondary_species_type) , intent(in)    :: autotroph_secondary_species(:,:)
     real(r8)                               , intent(in)    :: dtracers(:,:)         ! tracer_cnt, km
-    real(r8)                               , intent(in)    :: interior_restore(:,:) ! tracer_cnt, km
     type(marbl_tracer_index_type)          , intent(in)    :: marbl_tracer_indices
     type(marbl_diagnostics_type)           , intent(inout) :: marbl_diags
 
@@ -4204,18 +4188,6 @@ contains
        end do
     endif
 
-    ! subtract restoring terms
-    work = work - (interior_restore(po4_ind,:) + interior_restore(dop_ind,:) + interior_restore(dopr_ind,:) + &
-                   Qp_zoo * sum(interior_restore(marbl_tracer_indices%zoo_inds(:)%C_ind,:), dim=1))
-
-    if (lvariable_PtoC) then
-       work = work - sum(interior_restore(marbl_tracer_indices%auto_inds(:)%P_ind,:),dim=1)
-    else
-       do n = 1, autotroph_cnt
-          work = work - autotroph_secondary_species(n,:)%Qp * interior_restore(marbl_tracer_indices%auto_inds(n)%C_ind,:)
-       end do
-    endif
-
     call compute_vertical_integrals(work, delta_z, kmt,                       &
          full_depth_integral=diags(ind%Jint_Ptot)%field_2d(1),                &
          near_surface_integral=diags(ind%Jint_100m_Ptot)%field_2d(1),         &
@@ -4228,12 +4200,11 @@ contains
   !***********************************************************************
 
   subroutine store_diagnostics_silicon_fluxes(marbl_domain, P_SiO2, dtracers, &
-       interior_restore, marbl_tracer_indices, marbl_diags)
+       marbl_tracer_indices, marbl_diags)
 
     type(marbl_domain_type)            , intent(in)    :: marbl_domain
     type(column_sinking_particle_type) , intent(in)    :: P_SiO2
     real(r8)                           , intent(in)    :: dtracers(:,:)         ! tracer_cnt, km
-    real(r8)                           , intent(in)    :: interior_restore(:,:) ! tracer_cnt, km
     type(marbl_tracer_index_type)      , intent(in)    :: marbl_tracer_indices
     type(marbl_diagnostics_type)       , intent(inout) :: marbl_diags
 
@@ -4255,13 +4226,9 @@ contains
     ! vertical integrals
     work = dtracers(marbl_tracer_indices%sio3_ind,:)
 
-    ! subtract tracer restoring terms
-    work = work - interior_restore(marbl_tracer_indices%sio3_ind,:)
-
     do n = 1, autotroph_cnt
        if (marbl_tracer_indices%auto_inds(n)%Si_ind > 0) then
           work = work + dtracers(marbl_tracer_indices%auto_inds(n)%Si_ind,:)
-          work = work - interior_restore(marbl_tracer_indices%auto_inds(n)%Si_ind,:)
        end if
     end do
 
@@ -4277,7 +4244,7 @@ contains
   !***********************************************************************
 
   subroutine store_diagnostics_iron_fluxes(marbl_domain, P_iron, dust, &
-             fesedflux, dtracers, interior_restore, marbl_tracer_indices, marbl_diags)
+             fesedflux, dtracers, marbl_tracer_indices, marbl_diags)
 
     use marbl_settings_mod, only : Qfe_zoo
     use marbl_settings_mod, only : dust_to_Fe
@@ -4287,7 +4254,6 @@ contains
     type(column_sinking_particle_type) , intent(in)    :: dust
     real(r8)                           , intent(in)    :: fesedflux(:)          ! km
     real(r8)                           , intent(in)    :: dtracers(:,:)         ! tracer_cnt, km
-    real(r8)                           , intent(in)    :: interior_restore(:,:) ! tracer_cnt, km
     type(marbl_tracer_index_type)      , intent(in)    :: marbl_tracer_indices
     type(marbl_diagnostics_type)       , intent(inout) :: marbl_diags
 
@@ -4311,11 +4277,6 @@ contains
            sum(dtracers(marbl_tracer_indices%auto_inds(:)%Fe_ind, :),dim=1) + &
            Qfe_zoo * sum(dtracers(marbl_tracer_indices%zoo_inds(:)%C_ind, :),dim=1) - &
            dust%remin(:) * dust_to_Fe
-
-    ! subtract tracer restoring terms
-    work = work - (interior_restore(fe_ind, :) +                                              &
-                   sum(interior_restore(marbl_tracer_indices%auto_inds(:)%Fe_ind, :),dim=1) + &
-                   Qfe_zoo * sum(interior_restore(marbl_tracer_indices%zoo_inds(:)%C_ind, :),dim=1))
 
     call compute_vertical_integrals(work, delta_z, kmt,                       &
          full_depth_integral=diags(ind%Jint_Fetot)%field_2d(1),               &

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -1,3 +1,4 @@
+
 ! -*- mode: f90; indent-tabs-mode: nil; f90-do-indent:3; f90-if-indent:3; f90-type-indent:3; f90-program-indent:2; f90-associate-indent:0; f90-continuation-indent:5  -*-
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 
@@ -833,6 +834,9 @@ contains
     end if
 
     end associate
+
+    ! ADD RESTORING
+    dtracers = dtracers + interior_restore
 
   end subroutine marbl_set_interior_forcing
 
@@ -4368,9 +4372,9 @@ contains
     !  phosphate
     !-----------------------------------------------------------------------
 
-    dtracers(po4_ind) = DOP_remin + DOPr_remin - sum(PO4_V(:)) +           &
-           (c1 - POPremin_refract) * POP_remin + sum(remaining_P_dip(:)) + &
-           Qp_zoo * ( sum(zoo_loss_dic(:)) + sum(zoo_graze_dic(:)) )
+    dtracers(po4_ind) = DOP_remin + DOPr_remin - sum(PO4_V(:)) &
+         + (c1 - POPremin_refract) * POP_remin + sum(remaining_P_dip(:)) &
+         + Qp_zoo * ( sum(zoo_loss_dic(:)) + sum(zoo_graze_dic(:)) )
 
     !-----------------------------------------------------------------------
     !  zoo Carbon
@@ -4498,9 +4502,6 @@ contains
          / parm_Remin_D_C_O2 + (c2 * nitrif))
 
     dtracers(o2_ind) = o2_production - o2_consumption
-
-    ! ADD RESTORING
-    dtracers(:) = dtracers(:) + interior_restore(:)
 
     end associate
   end subroutine marbl_compute_dtracer_local

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -1,4 +1,3 @@
-
 ! -*- mode: f90; indent-tabs-mode: nil; f90-do-indent:3; f90-if-indent:3; f90-type-indent:3; f90-program-indent:2; f90-associate-indent:0; f90-continuation-indent:5  -*-
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -4317,7 +4317,7 @@ contains
     !  nitrate & ammonium
     !-----------------------------------------------------------------------
 
-    dtracers(no3_ind) = interior_restore(no3_ind) + nitrif - denitrif - sed_denitrif - sum(NO3_V(:))
+    dtracers(no3_ind) = nitrif - denitrif - sed_denitrif - sum(NO3_V(:))
 
     dtracers(nh4_ind) = -sum(NH4_V(:)) - nitrif + DON_remin + DONr_remin  &
          + Q * (sum(zoo_loss_dic(:)) + sum(zoo_graze_dic(:)) + sum(auto_loss_dic(:)) + sum(auto_graze_dic(:)) &
@@ -4354,7 +4354,7 @@ contains
     !  dissolved SiO3
     !-----------------------------------------------------------------------
 
-    dtracers(sio3_ind) = interior_restore(sio3_ind) + P_SiO2_remin
+    dtracers(sio3_ind) = P_SiO2_remin
 
     do auto_ind = 1, auto_cnt
        if (marbl_tracer_indices%auto_inds(auto_ind)%Si_ind > 0) then
@@ -4368,9 +4368,9 @@ contains
     !  phosphate
     !-----------------------------------------------------------------------
 
-    dtracers(po4_ind) = interior_restore(po4_ind) + DOP_remin + DOPr_remin - sum(PO4_V(:)) &
-         + (c1 - POPremin_refract) * POP_remin + sum(remaining_P_dip(:)) &
-         + Qp_zoo * ( sum(zoo_loss_dic(:)) + sum(zoo_graze_dic(:)) )
+    dtracers(po4_ind) = DOP_remin + DOPr_remin - sum(PO4_V(:)) +           &
+           (c1 - POPremin_refract) * POP_remin + sum(remaining_P_dip(:)) + &
+           Qp_zoo * ( sum(zoo_loss_dic(:)) + sum(zoo_graze_dic(:)) )
 
     !-----------------------------------------------------------------------
     !  zoo Carbon
@@ -4498,6 +4498,9 @@ contains
          / parm_Remin_D_C_O2 + (c2 * nitrif))
 
     dtracers(o2_ind) = o2_production - o2_consumption
+
+    ! ADD RESTORING
+    dtracers(:) = dtracers(:) + interior_restore(:)
 
     end associate
   end subroutine marbl_compute_dtracer_local


### PR DESCRIPTION
Apply restoring to all tracers, not just `PO4`, `NO3`, and `SiO3`. Computes
tendency on its own and then applies restoring, so there is an
order-of-operations change on these tendencies (and the `ALK` tendency
depends on the `NO3` tendency, so it now gets the pre-restoring tendency).