### PR TITLE
Tag Summary: bugfix for #215

### DIFF
--- a/autogenerated_src/default_diagnostics.json
+++ b/autogenerated_src/default_diagnostics.json
@@ -440,62 +440,62 @@
       "units": "permil",
       "vertical_grid": "layer_avg"
    },
-   "CISO_DO13C_prod": {
+   "CISO_DO13Ctot_prod": {
       "dependencies": {
          "ciso_on": ".true."
       },
       "frequency": "medium",
-      "longname": "DO13C Production",
+      "longname": "DO13Ctot Production",
       "operator": "average",
       "units": "mmol/m^3/s",
       "vertical_grid": "layer_avg"
    },
-   "CISO_DO13C_remin": {
+   "CISO_DO13Ctot_remin": {
       "dependencies": {
          "ciso_on": ".true."
       },
       "frequency": "medium",
-      "longname": "DO13C Remineralization",
+      "longname": "DO13Ctot Remineralization",
       "operator": "average",
       "units": "mmol/m^3/s",
       "vertical_grid": "layer_avg"
    },
-   "CISO_DO14C_prod": {
+   "CISO_DO14Ctot_prod": {
       "dependencies": {
          "ciso_on": ".true."
       },
       "frequency": "medium",
-      "longname": "DO14C Production",
+      "longname": "DO14Ctot Production",
       "operator": "average",
       "units": "mmol/m^3/s",
       "vertical_grid": "layer_avg"
    },
-   "CISO_DO14C_remin": {
+   "CISO_DO14Ctot_remin": {
       "dependencies": {
          "ciso_on": ".true."
       },
       "frequency": "medium",
-      "longname": "DO14C Remineralization",
+      "longname": "DO14Ctot Remineralization",
       "operator": "average",
       "units": "mmol/m^3/s",
       "vertical_grid": "layer_avg"
    },
-   "CISO_DOC_d13C": {
+   "CISO_DOCtot_d13C": {
       "dependencies": {
          "ciso_on": ".true."
       },
       "frequency": "medium",
-      "longname": "d13C of DOC",
+      "longname": "d13C of DOCtot",
       "operator": "average",
       "units": "permil",
       "vertical_grid": "layer_avg"
    },
-   "CISO_DOC_d14C": {
+   "CISO_DOCtot_d14C": {
       "dependencies": {
          "ciso_on": ".true."
       },
       "frequency": "medium",
-      "longname": "d14C of DOC",
+      "longname": "d14C of DOCtot",
       "operator": "average",
       "units": "permil",
       "vertical_grid": "layer_avg"

--- a/autogenerated_src/default_settings.json
+++ b/autogenerated_src/default_settings.json
@@ -678,18 +678,18 @@
          "long_name": "Dissolved Inorganic Carbon, Alternative CO2",
          "units": "mmol/m^3"
       },
-      "DO13C": {
+      "DO13Ctot": {
          "dependencies": {
             "ciso_on": ".true."
          },
-         "long_name": "Dissolved Organic Carbon-13",
+         "long_name": "Dissolved Organic Carbon-13 (semi-labile+refractoy)",
          "units": "mmol/m^3"
       },
-      "DO14C": {
+      "DO14Ctot": {
          "dependencies": {
             "ciso_on": ".true."
          },
-         "long_name": "Dissolved Organic Carbon-14",
+         "long_name": "Dissolved Organic Carbon-14 (semi-labile+refractoy)",
          "units": "mmol/m^3"
       },
       "DOC": {

--- a/src/default_diagnostics.yaml
+++ b/src/default_diagnostics.yaml
@@ -1140,18 +1140,18 @@ CISO_PO13C_REMIN :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
-CISO_DO13C_prod :
+CISO_DO13Ctot_prod :
    dependencies :
       ciso_on : .true.
-   longname : DO13C Production
+   longname : DO13Ctot Production
    units : mmol/m^3/s
    vertical_grid : layer_avg
    frequency : medium
    operator : average
-CISO_DO13C_remin :
+CISO_DO13Ctot_remin :
    dependencies :
       ciso_on : .true.
-   longname : DO13C Remineralization
+   longname : DO13Ctot Remineralization
    units : mmol/m^3/s
    vertical_grid : layer_avg
    frequency : medium
@@ -1196,10 +1196,10 @@ CISO_DIC_d13C :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
-CISO_DOC_d13C :
+CISO_DOCtot_d13C :
    dependencies :
       ciso_on : .true.
-   longname : d13C of DOC
+   longname : d13C of DOCtot
    units : permil
    vertical_grid : layer_avg
    frequency : medium
@@ -1236,18 +1236,18 @@ CISO_PO14C_REMIN :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
-CISO_DO14C_prod :
+CISO_DO14Ctot_prod :
    dependencies :
       ciso_on : .true.
-   longname : DO14C Production
+   longname : DO14Ctot Production
    units : mmol/m^3/s
    vertical_grid : layer_avg
    frequency : medium
    operator : average
-CISO_DO14C_remin :
+CISO_DO14Ctot_remin :
    dependencies :
       ciso_on : .true.
-   longname : DO14C Remineralization
+   longname : DO14Ctot Remineralization
    units : mmol/m^3/s
    vertical_grid : layer_avg
    frequency : medium
@@ -1292,10 +1292,10 @@ CISO_DIC_d14C :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
-CISO_DOC_d14C :
+CISO_DOCtot_d14C :
    dependencies :
       ciso_on : .true.
-   longname : d14C of DOC
+   longname : d14C of DOCtot
    units : permil
    vertical_grid : layer_avg
    frequency : medium

--- a/src/default_settings.yaml
+++ b/src/default_settings.yaml
@@ -107,20 +107,20 @@ _tracer_list :
          ciso_on : .true.
       long_name : Dissolved Inorganic Carbon-13
       units : mmol/m^3
-   DO13C :
+   DO13Ctot :
       dependencies :
          ciso_on : .true.
-      long_name : Dissolved Organic Carbon-13
+      long_name : Dissolved Organic Carbon-13 (semi-labile+refractoy)
       units : mmol/m^3
    DI14C :
       dependencies :
          ciso_on : .true.
       long_name : Dissolved Inorganic Carbon-14
       units : mmol/m^3
-   DO14C :
+   DO14Ctot :
       dependencies :
          ciso_on : .true.
-      long_name : Dissolved Organic Carbon-14
+      long_name : Dissolved Organic Carbon-14 (semi-labile+refractoy)
       units : mmol/m^3
 
    # Per-autotroph tracers

--- a/src/marbl_ciso_mod.F90
+++ b/src/marbl_ciso_mod.F90
@@ -113,10 +113,10 @@ contains
     !-----------------------------------------------------------------------
 
     associate(di13c_ind         => marbl_tracer_indices%di13c_ind,            &
-              do13c_ind         => marbl_tracer_indices%do13c_ind,            &
+              do13ctot_ind      => marbl_tracer_indices%do13ctot_ind,         &
               zoo13c_ind        => marbl_tracer_indices%zoo13c_ind,           &
               di14c_ind         => marbl_tracer_indices%di14c_ind,            &
-              do14c_ind         => marbl_tracer_indices%do14c_ind,            &
+              do14ctot_ind      => marbl_tracer_indices%do14ctot_ind,         &
               zoo14c_ind        => marbl_tracer_indices%zoo14c_ind,           &
               ciso_ind_beg      => marbl_tracer_indices%ciso%ind_beg,         &
               ciso_ind_end      => marbl_tracer_indices%ciso%ind_end          &
@@ -133,8 +133,8 @@ contains
     marbl_tracer_metadata(di13c_ind)%short_name='DI13C'
     marbl_tracer_metadata(di13c_ind)%long_name='Dissolved Inorganic Carbon-13'
 
-    marbl_tracer_metadata(do13c_ind)%short_name='DO13C'
-    marbl_tracer_metadata(do13c_ind)%long_name='Dissolved Organic Carbon-13'
+    marbl_tracer_metadata(do13ctot_ind)%short_name='DO13Ctot'
+    marbl_tracer_metadata(do13ctot_ind)%long_name='Dissolved Organic Carbon-13 (semi-labile+refractory)'
 
     marbl_tracer_metadata(zoo13C_ind)%short_name='zoo13C'
     marbl_tracer_metadata(zoo13C_ind)%long_name='Zooplankton Carbon-13'
@@ -142,8 +142,8 @@ contains
     marbl_tracer_metadata(di14c_ind)%short_name='DI14C'
     marbl_tracer_metadata(di14c_ind)%long_name='Dissolved Inorganic Carbon-14'
 
-    marbl_tracer_metadata(do14c_ind)%short_name='DO14C'
-    marbl_tracer_metadata(do14c_ind)%long_name='Dissolved Organic Carbon-14'
+    marbl_tracer_metadata(do14ctot_ind)%short_name='DO14Ctot'
+    marbl_tracer_metadata(do14ctot_ind)%long_name='Dissolved Organic Carbon-14 (semi-labile+refractory)'
 
     marbl_tracer_metadata(zoo14C_ind)%short_name='zoo14C'
     marbl_tracer_metadata(zoo14C_ind)%long_name='Zooplankton Carbon-14'
@@ -283,10 +283,10 @@ contains
          P_Ca14CO3         ! base units = nmol CaCO3 14C
 
     real (r8), dimension (marbl_domain%km) :: &
-         DO13C_loc,         & ! local copy of model DO13C
+         DO13Ctot_loc,      & ! local copy of model DO13Ctot
          DI13C_loc,         & ! local copy of model DI13C
          zoo13C_loc,        & ! local copy of model zoo13C
-         DO14C_loc,         & ! local copy of model DO14C
+         DO14Ctot_loc,      & ! local copy of model DO14Ctot
          DI14C_loc,         & ! local copy of model DI14C
          zoo14C_loc           ! local copy of model zoo14C
 
@@ -297,12 +297,12 @@ contains
          R13C_CaCO3_form,   & ! 13C/12C in CaCO3 production of small phyto
          R13C_CO2STAR,      & ! 13C/12C in CO2* water
          R13C_DIC,          & ! 13C/12C in total DIC
-         R13C_DOC,          & ! 13C/12C in total DOC
+         R13C_DOCtot,       & ! 13C/12C in total DOCtot
          R13C_zooC,         & ! 13C/12C in total zooplankton
          R14C_CaCO3_form,   & ! 14C/12C in CaCO3 production of small phyto
          R14C_CO2STAR,      & ! 14C/12C in CO2* water
          R14C_DIC,          & ! 14C/12C in total DIC
-         R14C_DOC,          & ! 14C/12C in total DOC
+         R14C_DOCtot,       & ! 14C/12C in total DOCtot
          R14C_zooC            ! 14C/12C in total zooplankton
 
     real (r8), dimension(autotroph_cnt, marbl_domain%km) :: &
@@ -326,25 +326,25 @@ contains
     real (r8), dimension(marbl_domain%km) :: &
          frac_co3,          & ! carbonate fraction fCO3 = [CO3--]/DIC
          CO2STAR_int,       & ! [CO2*] water (mmol/m^3) in interior domain (not only surface)
-         DO13C_prod,        & ! production of 13C DOC (mmol C/m^3/sec)
-         DO13C_remin,       & ! remineralization of 13C DOC (mmol C/m^3/sec)
+         DO13Ctot_prod,     & ! production of 13C DOCtot (mmol C/m^3/sec)
+         DO13Ctot_remin,    & ! remineralization of 13C DOCtot (mmol C/m^3/sec)
          eps_aq_g,          & ! equilibrium fractionation (CO2_gaseous <-> CO2_aq)
          eps_dic_g,         & ! equilibrium fractionation between total DIC and gaseous CO2
          alpha_aq_g,        & ! eps = ( alpa -1 ) * 1000
          alpha_dic_g,       & ! eps = ( alpa -1 ) * 1000
          delta_C13_Corg,    & ! deltaC13 of Net Primary Production
          delta_C13_CO2STAR, & ! deltaC13 of CO2*
-         DO14C_prod,        & ! production of 13C DOC (mmol C/m^3/sec)
-         DO14C_remin,       & ! remineralization of 13C DOC (mmol C/m^3/sec)
+         DO14Ctot_prod,     & ! production of 13C DOCtot (mmol C/m^3/sec)
+         DO14Ctot_remin,    & ! remineralization of 13C DOCtot (mmol C/m^3/sec)
          alpha_aq_g_14c,    & ! alpha for 14C, with fractionation twice as large as for 13C
          alpha_dic_g_14c,   & ! alpha for 14C, with fractionation twice as large as for 13C
          delta_C14_Corg,    & ! deltaC14 of Net Primary Production
          delta_C14_CO2STAR, & ! deltaC14 of CO2*
          DIC_d13C,          & ! d13C of DIC
-         DOC_d13C,          & ! d13C of DOC
+         DOCtot_d13C,       & ! d13C of DOCtot
          zooC_d13C,         & ! d13C of zooC
          DIC_d14C,          & ! d14C of DIC
-         DOC_d14C,          & ! d14C of DOC
+         DOCtot_d14C,       & ! d14C of DOCtot
          zooC_d14C            ! d14C of zooC
     !-------------------------------------------------------------
 
@@ -353,11 +353,11 @@ contains
          column_kmt         => marbl_domain%kmt                                , &
 
          DIC_loc            => marbl_interior_share%DIC_loc_fields             , & ! INPUT local copy of model DIC
-         DOC_loc            => marbl_interior_share%DOC_loc_fields             , & ! INPUT local copy of model DOC
+         DOCtot_loc         => marbl_interior_share%DOCtot_loc_fields          , & ! INPUT local copy of model DOCtot
          CO3                => marbl_interior_share%CO3_fields                 , & ! INPUT carbonate ion
          HCO3               => marbl_interior_share%HCO3_fields                , & ! INPUT bicarbonate ion
          H2CO3              => marbl_interior_share%H2CO3_fields               , & ! INPUT carbonic acid
-         DOC_remin          => marbl_interior_share%DOC_remin_fields           , & ! INPUT remineralization of 13C DOC (mmol C/m^3/sec)
+         DOCtot_remin       => marbl_interior_share%DOCtot_remin_fields        , & ! INPUT remineralization of DOCtot (mmol C/m^3/sec)
 
          autotrophCaCO3_loc => marbl_autotroph_share%autotrophCaCO3_loc_fields , & ! INPUT local copy of model autotroph CaCO3
          autotrophC_loc     => marbl_autotroph_share%autotrophC_loc_fields     , & ! INPUT local copy of model autotroph C
@@ -386,10 +386,10 @@ contains
          P_CaCO3            => marbl_particulate_share%P_CaCO3                 , & ! INPUT
 
          di13c_ind          => marbl_tracer_indices%di13c_ind                  , &
-         do13c_ind          => marbl_tracer_indices%do13c_ind                  , &
+         do13ctot_ind       => marbl_tracer_indices%do13ctot_ind               , &
          zoo13c_ind         => marbl_tracer_indices%zoo13c_ind                 , &
          di14c_ind          => marbl_tracer_indices%di14c_ind                  , &
-         do14c_ind          => marbl_tracer_indices%do14c_ind                  , &
+         do14ctot_ind       => marbl_tracer_indices%do14ctot_ind               , &
          zoo14c_ind         => marbl_tracer_indices%zoo14c_ind                   &
          )
 
@@ -425,9 +425,9 @@ contains
     !  Create local copies of model column_tracer, treat negative values as zero
     !-----------------------------------------------------------------------
 
-    call setup_local_column_tracers(column_km, column_kmt, column_tracer,     &
-           marbl_tracer_indices, DI13C_loc, DO13c_loc, zoo13C_loc, DI14C_loc, &
-           DO14C_loc, zoo14C_loc)
+    call setup_local_column_tracers(column_km, column_kmt, column_tracer, &
+           marbl_tracer_indices, DI13C_loc, DO13Ctot_loc, zoo13C_loc, DI14C_loc, &
+           DO14Ctot_loc, zoo14C_loc)
 
     !-----------------------------------------------------------------------
     !  Create local copies of model column autotrophs, treat negative values as zero
@@ -462,12 +462,12 @@ contains
        !  Calculate fraction of CO3
        !-----------------------------------------------------------------------
 
-       if (DOC_loc(k) > c0) then
-          R13C_DOC(k) = DO13C_loc(k) / DOC_loc(k)
-          R14C_DOC(k) = DO14C_loc(k) / DOC_loc(k)
+       if (DOCtot_loc(k) > c0) then
+          R13C_DOCtot(k) = DO13Ctot_loc(k) / DOCtot_loc(k)
+          R14C_DOCtot(k) = DO14Ctot_loc(k) / DOCtot_loc(k)
        else
-          R13C_DOC(k) = c0
-          R14C_DOC(k) = c0
+          R13C_DOCtot(k) = c0
+          R14C_DOCtot(k) = c0
        end if
 
        if (DIC_loc(k) > c0) then
@@ -673,19 +673,19 @@ contains
        end do ! end loop over auto_ind
 
        !-----------------------------------------------------------------------
-       !  compute terms for DO13C and DO14C
+       !  compute terms for DO13Ctot and DO14Ctot
        !-----------------------------------------------------------------------
 
-       DO13C_prod(k) = &
+       DO13Ctot_prod(k) = &
             sum(zoo_loss_doc(:,k),dim=1)*R13C_zooC(k) + &
             sum((auto_loss_doc(:,k) + auto_graze_doc(:,k)) * R13C_autotroph(:,k),dim=1)
 
-       DO14C_prod(k) = &
+       DO14Ctot_prod(k) = &
             sum(zoo_loss_doc(:,k),dim=1)*R14C_zooC(k) + &
             sum((auto_loss_doc(:,k) + auto_graze_doc(:,k)) * R14C_autotroph(:,k),dim=1)
 
-       DO13C_remin(k) = DOC_remin(k) * R13C_DOC(k)
-       DO14C_remin(k) = DOC_remin(k) * R14C_DOC(k)
+       DO13Ctot_remin(k) = DOCtot_remin(k) * R13C_DOCtot(k)
+       DO14Ctot_remin(k) = DOCtot_remin(k) * R14C_DOCtot(k)
 
        !-----------------------------------------------------------------------
        !  large detritus 13C and 14C
@@ -717,8 +717,8 @@ contains
        DIC_d13C(k) =  ( R13C_DIC(k) / R13C_std - c1 ) * c1000
        DIC_d14C(k) =  ( R14C_DIC(k) / R14C_std - c1 ) * c1000
 
-       DOC_d13C(k) =  ( R13C_DOC(k) / R13C_std - c1 ) * c1000
-       DOC_d14C(k) =  ( R14C_DOC(k) / R14C_std - c1 ) * c1000
+       DOCtot_d13C(k) =  ( R13C_DOCtot(k) / R13C_std - c1 ) * c1000
+       DOCtot_d14C(k) =  ( R14C_DOCtot(k) / R14C_std - c1 ) * c1000
 
        zooC_d13C(k)=  ( R13C_zooC(k) / R13C_std - c1 ) * c1000
        zooC_d14C(k)=  ( R14C_zooC(k) / R14C_std - c1 ) * c1000
@@ -795,9 +795,9 @@ contains
        !  column_dtracer: dissolved organic Matter 13C and 14C
        !-----------------------------------------------------------------------
 
-       column_dtracer(do13c_ind,k) = DO13C_prod(k) - DO13C_remin(k)
+       column_dtracer(do13ctot_ind,k) = DO13Ctot_prod(k) - DO13Ctot_remin(k)
 
-       column_dtracer(do14c_ind,k) = DO14C_prod(k) - DO14C_remin(k) - c14_lambda_inv_sec * DO14C_loc(k)
+       column_dtracer(do14ctot_ind,k) = DO14Ctot_prod(k) - DO14Ctot_remin(k) - c14_lambda_inv_sec * DO14Ctot_loc(k)
 
        !-----------------------------------------------------------------------
        !   column_dtracer: dissolved inorganic Carbon 13 and 14
@@ -806,15 +806,15 @@ contains
        column_dtracer(di13c_ind,k) =                                                       &
             sum( (auto_loss_dic(:,k) + auto_graze_dic(:,k)) * R13C_autotroph(:,k), dim=1 ) &
           - sum(photo13C(:,k),dim=1)                                                       &
-          + DO13C_remin(k) + PO13C%remin(k)                                                &
-          + sum(zoo_loss_dic(:,k),dim=1) * R13C_zooC(k)                                    &
+          + DO13Ctot_remin(k) + PO13C%remin(k)                                             &
+          + sum(zoo_loss_dic(:,k),dim=1) * R13C_zooC(k)                 &
           + P_Ca13CO3%remin(k)
 
        column_dtracer(di14c_ind,k) =                                                       &
             sum( (auto_loss_dic(:,k) + auto_graze_dic(:,k)) * R14C_autotroph(:,k), dim=1 ) &
           - sum(photo14C(:,k),dim=1)                                                       &
-          + DO14C_remin(k) + PO14C%remin(k)                                                &
-          + sum(zoo_loss_dic(:,k),dim=1) * R14C_zooC(k)                                    &
+          + DO14Ctot_remin(k) + PO14C%remin(k)                                             &
+          + sum(zoo_loss_dic(:,k),dim=1) * R14C_zooC(k)                 &
           + P_Ca14CO3%remin(k)                                                             &
           - c14_lambda_inv_sec * DI14C_loc(k)
 
@@ -858,8 +858,8 @@ contains
        autotrophCaCO3_d14C, &
        DIC_d13C,            &
        DIC_d14C,            &
-       DOC_d13C,            &
-       DOC_d14C,            &
+       DOCtot_d13C,         &
+       DOCtot_d14C,         &
        zooC_d13C,           &
        zooC_d14C,           &
        photo13C,            &
@@ -868,10 +868,10 @@ contains
        mui_to_co2star,      &
        Ca13CO3_prod,        &
        Ca14CO3_prod,        &
-       DO13C_prod,          &
-       DO14C_prod,          &
-       DO13C_remin,         &
-       DO14C_remin,         &
+       DO13Ctot_prod,       &
+       DO14Ctot_prod,       &
+       DO13Ctot_remin,      &
+       DO14Ctot_remin,      &
        eps_aq_g,            &
        eps_dic_g,           &
        PO13C,               &
@@ -1001,8 +1001,8 @@ contains
   !***********************************************************************
 
   subroutine setup_local_column_tracers(column_km, column_kmt, column_tracer, &
-           marbl_tracer_indices, DI13C_loc, DO13c_loc, zoo13C_loc, DI14C_loc, &
-           DO14C_loc, zoo14C_loc)
+           marbl_tracer_indices, DI13C_loc, DO13Ctot_loc, zoo13C_loc, DI14C_loc, &
+           DO14Ctot_loc, zoo14C_loc)
 
     !-----------------------------------------------------------------------
     !  create local copies of model column_tracer
@@ -1017,10 +1017,10 @@ contains
     type(marbl_tracer_index_type), intent(in) :: marbl_tracer_indices
 
     real (r8)         , intent(out) :: DI13C_loc(:)     ! (km) local copy of model DI13C
-    real (r8)         , intent(out) :: DO13C_loc(:)     ! (km) local copy of model DO13C
+    real (r8)         , intent(out) :: DO13Ctot_loc(:)  ! (km) local copy of model DO13Ctot
     real (r8)         , intent(out) :: zoo13C_loc(:)    ! (km) local copy of model zoo13C
     real (r8)         , intent(out) :: DI14C_loc(:)     ! (km) local copy of model DI14C
-    real (r8)         , intent(out) :: DO14C_loc(:)     ! (km) local copy of model DO14C
+    real (r8)         , intent(out) :: DO14Ctot_loc(:)  ! (km) local copy of model DO14Ctot
     real (r8)         , intent(out) :: zoo14C_loc(:)    ! (km) local copy of model zoo14C
     !-----------------------------------------------------------------------
     !  local variables
@@ -1028,32 +1028,32 @@ contains
     integer :: k
     !-----------------------------------------------------------------------
 
-    associate(di13c_ind  => marbl_tracer_indices%di13c_ind,                   &
-              do13c_ind  => marbl_tracer_indices%do13c_ind,                   &
-              zoo13c_ind => marbl_tracer_indices%zoo13c_ind,                  &
-              di14c_ind  => marbl_tracer_indices%di14c_ind,                   &
-              do14c_ind  => marbl_tracer_indices%do14c_ind,                   &
-              zoo14c_ind => marbl_tracer_indices%zoo14c_ind)
+    associate(di13c_ind     => marbl_tracer_indices%di13c_ind,                   &
+              do13ctot_ind  => marbl_tracer_indices%do13ctot_ind,                &
+              zoo13c_ind    => marbl_tracer_indices%zoo13c_ind,                  &
+              di14c_ind     => marbl_tracer_indices%di14c_ind,                   &
+              do14ctot_ind  => marbl_tracer_indices%do14ctot_ind,                &
+              zoo14c_ind    => marbl_tracer_indices%zoo14c_ind)
     do k = 1,column_kmt
-       DI13C_loc(k)  = max(c0, column_tracer(di13c_ind,k))
-       DI14C_loc(k)  = max(c0, column_tracer(di14c_ind,k))
+       DI13C_loc(k)    = max(c0, column_tracer(di13c_ind,k))
+       DI14C_loc(k)    = max(c0, column_tracer(di14c_ind,k))
 
-       DO13C_loc(k)  = max(c0, column_tracer(do13c_ind,k))
-       DO14C_loc(k)  = max(c0, column_tracer(do14c_ind,k))
+       DO13Ctot_loc(k) = max(c0, column_tracer(do13ctot_ind,k))
+       DO14Ctot_loc(k) = max(c0, column_tracer(do14ctot_ind,k))
 
-       zoo13C_loc(k) = max(c0, column_tracer(zoo13C_ind,k))
-       zoo14C_loc(k) = max(c0, column_tracer(zoo14C_ind,k))
+       zoo13C_loc(k)   = max(c0, column_tracer(zoo13C_ind,k))
+       zoo14C_loc(k)   = max(c0, column_tracer(zoo14C_ind,k))
     end do
 
     do k = column_kmt+1, column_km
-       DI13C_loc(k)  = c0
-       DI14C_loc(k)  = c0
+       DI13C_loc(k)    = c0
+       DI14C_loc(k)    = c0
 
-       DO13C_loc(k)  = c0
-       DO14C_loc(k)  = c0
+       DO13Ctot_loc(k) = c0
+       DO14Ctot_loc(k) = c0
 
-       zoo13C_loc(k) = c0
-       zoo14C_loc(k) = c0
+       zoo13C_loc(k)   = c0
+       zoo14C_loc(k)   = c0
     end do
     end associate
 
@@ -1752,9 +1752,9 @@ contains
          co3_surf_fields     => marbl_surface_forcing_share%co3_surf_fields      , & ! in/out
 
          di13c_ind          => marbl_tracer_indices%di13c_ind                  , &
-         do13c_ind          => marbl_tracer_indices%do13c_ind                  , &
+         do13ctot_ind       => marbl_tracer_indices%do13ctot_ind               , &
          di14c_ind          => marbl_tracer_indices%di14c_ind                  , &
-         do14c_ind          => marbl_tracer_indices%do14c_ind                  , &
+         do14ctot_ind       => marbl_tracer_indices%do14ctot_ind               , &
          ciso_ind_beg       => marbl_tracer_indices%ciso%ind_beg               , &
          ciso_ind_end       => marbl_tracer_indices%ciso%ind_end                 &
          )

--- a/src/marbl_diagnostics_mod.F90
+++ b/src/marbl_diagnostics_mod.F90
@@ -313,18 +313,18 @@ module marbl_diagnostics_mod
 
      integer (int_kind) :: CISO_eps_aq_g                                      ! eps_aq_g
      integer (int_kind) :: CISO_eps_dic_g                                     ! eps_dic_g
-     integer (int_kind) :: CISO_DO13C_prod                                    ! do13c production
-     integer (int_kind) :: CISO_DO14C_prod                                    ! do14c production
-     integer (int_kind) :: CISO_DO13C_remin                                   ! do13c remineralization
-     integer (int_kind) :: CISO_DO14C_remin                                   ! do14c remineralization
+     integer (int_kind) :: CISO_DO13Ctot_prod                                 ! do13ctot production
+     integer (int_kind) :: CISO_DO14Ctot_prod                                 ! do14ctot production
+     integer (int_kind) :: CISO_DO13Ctot_remin                                ! do13ctot remineralization
+     integer (int_kind) :: CISO_DO14Ctot_remin                                ! do14ctot remineralization
      integer (int_kind) :: CISO_Jint_13Ctot                                   ! vertically integrated source sink term, 13Ctot
      integer (int_kind) :: CISO_Jint_14Ctot                                   ! vertically integrated source sink term, 14Ctot
      integer (int_kind) :: CISO_Jint_100m_13Ctot                              ! vertically integrated source sink term, 0-100m, 13Ctot
      integer (int_kind) :: CISO_Jint_100m_14Ctot                              ! vertically integrated source sink term, 0-100m, 14Ctot
      integer (int_kind) :: CISO_zooC_d13C                                     ! if for d13C of zooC
      integer (int_kind) :: CISO_zooC_d14C                                     ! if for d14C of zooC
-     integer (int_kind) :: CISO_DOC_d13C                                      ! if for d13C of DOC
-     integer (int_kind) :: CISO_DOC_d14C                                      ! if for d14C of DOC
+     integer (int_kind) :: CISO_DOCtot_d13C                                   ! if for d13C of DOCtot
+     integer (int_kind) :: CISO_DOCtot_d14C                                   ! if for d14C of DOCtot
      integer (int_kind) :: CISO_DIC_d13C                                      ! if for d13C of DIC
      integer (int_kind) :: CISO_DIC_d14C                                      ! if for d14C of DIC
      integer (int_kind) :: calcToSed_13C                                      ! calcite flux sedimentary burial
@@ -3352,25 +3352,25 @@ contains
           return
         end if
 
-        lname    = 'DO13C Production'
-        sname    = 'CISO_DO13C_prod'
+        lname    = 'DO13Ctot Production'
+        sname    = 'CISO_DO13Ctot_prod'
         units    = 'mmol/m^3/s'
         vgrid    = 'layer_avg'
         truncate = .false.
         call diags%add_diagnostic(lname, sname, units, vgrid, truncate,  &
-             ind%CISO_DO13C_prod, marbl_status_log)
+             ind%CISO_DO13Ctot_prod, marbl_status_log)
         if (marbl_status_log%labort_marbl) then
           call log_add_diagnostics_error(marbl_status_log, sname, subname)
           return
         end if
 
-        lname    = 'DO13C Remineralization'
-        sname    = 'CISO_DO13C_remin'
+        lname    = 'DO13Ctot Remineralization'
+        sname    = 'CISO_DO13Ctot_remin'
         units    = 'mmol/m^3/s'
         vgrid    = 'layer_avg'
         truncate = .false.
         call diags%add_diagnostic(lname, sname, units, vgrid, truncate,  &
-             ind%CISO_DO13C_remin, marbl_status_log)
+             ind%CISO_DO13Ctot_remin, marbl_status_log)
         if (marbl_status_log%labort_marbl) then
           call log_add_diagnostics_error(marbl_status_log, sname, subname)
           return
@@ -3436,13 +3436,13 @@ contains
           return
         end if
 
-        lname    = 'd13C of DOC'
-        sname    = 'CISO_DOC_d13C'
+        lname    = 'd13C of DOCtot'
+        sname    = 'CISO_DOCtot_d13C'
         units    = 'permil'
         vgrid    = 'layer_avg'
         truncate = .false.
         call diags%add_diagnostic(lname, sname, units, vgrid, truncate,  &
-             ind%CISO_DOC_d13C, marbl_status_log)
+             ind%CISO_DOCtot_d13C, marbl_status_log)
         if (marbl_status_log%labort_marbl) then
           call log_add_diagnostics_error(marbl_status_log, sname, subname)
           return
@@ -3496,25 +3496,25 @@ contains
           return
         end if
 
-        lname    = 'DO14C Production'
-        sname    = 'CISO_DO14C_prod'
+        lname    = 'DO14Ctot Production'
+        sname    = 'CISO_DO14Ctot_prod'
         units    = 'mmol/m^3/s'
         vgrid    = 'layer_avg'
         truncate = .false.
         call diags%add_diagnostic(lname, sname, units, vgrid, truncate,  &
-             ind%CISO_DO14C_prod, marbl_status_log)
+             ind%CISO_DO14Ctot_prod, marbl_status_log)
         if (marbl_status_log%labort_marbl) then
           call log_add_diagnostics_error(marbl_status_log, sname, subname)
           return
         end if
 
-        lname    = 'DO14C Remineralization'
-        sname    = 'CISO_DO14C_remin'
+        lname    = 'DO14Ctot Remineralization'
+        sname    = 'CISO_DO14Ctot_remin'
         units    = 'mmol/m^3/s'
         vgrid    = 'layer_avg'
         truncate = .false.
         call diags%add_diagnostic(lname, sname, units, vgrid, truncate,  &
-             ind%CISO_DO14C_remin, marbl_status_log)
+             ind%CISO_DO14Ctot_remin, marbl_status_log)
         if (marbl_status_log%labort_marbl) then
           call log_add_diagnostics_error(marbl_status_log, sname, subname)
           return
@@ -3580,13 +3580,13 @@ contains
           return
         end if
 
-        lname    = 'd14C of DOC'
-        sname    = 'CISO_DOC_d14C'
+        lname    = 'd14C of DOCtot'
+        sname    = 'CISO_DOCtot_d14C'
         units    = 'permil'
         vgrid    = 'layer_avg'
         truncate = .false.
         call diags%add_diagnostic(lname, sname, units, vgrid, truncate,  &
-             ind%CISO_DOC_d14C, marbl_status_log)
+             ind%CISO_DOCtot_d14C, marbl_status_log)
         if (marbl_status_log%labort_marbl) then
           call log_add_diagnostics_error(marbl_status_log, sname, subname)
           return
@@ -5251,8 +5251,8 @@ contains
        autotrophCaCO3_d14C, &
        DIC_d13C,            &
        DIC_d14C,            &
-       DOC_d13C,            &
-       DOC_d14C,            &
+       DOCtot_d13C,         &
+       DOCtot_d14C,         &
        zooC_d13C,           &
        zooC_d14C,           &
        photo13C,            &
@@ -5261,10 +5261,10 @@ contains
        mui_to_co2star,      &
        Ca13CO3_prod,        &
        Ca14CO3_prod,        &
-       DO13C_prod,          &
-       DO14C_prod,          &
-       DO13C_remin,         &
-       DO14C_remin,         &
+       DO13Ctot_prod,       &
+       DO14Ctot_prod,       &
+       DO13Ctot_remin,      &
+       DO14Ctot_remin,      &
        eps_aq_g,            &
        eps_dic_g,           &
        PO13C,               &
@@ -5297,18 +5297,18 @@ contains
          Ca14CO3_prod            ! prod. of 13C CaCO3 by small phyto (mmol CaCO3/m^3/sec)
 
     real (r8), intent(in),  dimension(marbl_domain%km) :: &
-         DIC_d13C    , & ! d13C of DIC
-         DOC_d13C    , & ! d13C of DOC
-         zooC_d13C   , & ! d13C of zooC
-         DIC_d14C    , & ! d14C of DIC
-         DOC_d14C    , & ! d14C of DOC
-         zooC_d14C   , & ! d14C of zooC
-         DO13C_prod  , & ! production of 13C DOC (mmol C/m^3/sec)
-         DO13C_remin , & ! remineralization of 13C DOC (mmol C/m^3/sec)
-         DO14C_prod  , & ! production of 13C DOC (mmol C/m^3/sec)
-         DO14C_remin , & ! remineralization of 13C DOC (mmol C/m^3/sec)
-         eps_aq_g    , & ! equilibrium fractionation (CO2_gaseous <-> CO2_aq)
-         eps_dic_g       ! equilibrium fractionation between total DIC and gaseous CO2
+         DIC_d13C       , & ! d13C of DIC
+         DOCtot_d13C    , & ! d13C of DOCtot
+         zooC_d13C      , & ! d13C of zooC
+         DIC_d14C       , & ! d14C of DIC
+         DOCtot_d14C    , & ! d14C of DOCtot
+         zooC_d14C      , & ! d14C of zooC
+         DO13Ctot_prod  , & ! production of 13C DOCtot (mmol C/m^3/sec)
+         DO13Ctot_remin , & ! remineralization of 13C DOCtot (mmol C/m^3/sec)
+         DO14Ctot_prod  , & ! production of 14C DOCtot (mmol C/m^3/sec)
+         DO14Ctot_remin , & ! remineralization of 14C DOCtot (mmol C/m^3/sec)
+         eps_aq_g       , & ! equilibrium fractionation (CO2_gaseous <-> CO2_aq)
+         eps_dic_g          ! equilibrium fractionation between total DIC and gaseous CO2
 
     real (r8), intent(in) :: dtracers(:,:) ! (tracer_cnt, km) computed source/sink terms
 
@@ -5336,13 +5336,13 @@ contains
          zw      => marbl_domain%zw,         &
          delta_z => marbl_domain%delta_z,    &
          diags   => marbl_diags%diags,       &
-         ind     => marbl_interior_diag_ind,  &
-         di13c_ind  => marbl_tracer_indices%di13c_ind,                   &
-         do13c_ind  => marbl_tracer_indices%do13c_ind,                   &
-         zoo13c_ind => marbl_tracer_indices%zoo13c_ind,                  &
-         di14c_ind  => marbl_tracer_indices%di14c_ind,                   &
-         do14c_ind  => marbl_tracer_indices%do14c_ind,                   &
-         zoo14c_ind => marbl_tracer_indices%zoo14c_ind                   &
+         ind     => marbl_interior_diag_ind, &
+         di13c_ind     => marbl_tracer_indices%di13c_ind,    &
+         do13ctot_ind  => marbl_tracer_indices%do13ctot_ind, &
+         zoo13c_ind    => marbl_tracer_indices%zoo13c_ind,   &
+         di14c_ind     => marbl_tracer_indices%di14c_ind,    &
+         do14ctot_ind  => marbl_tracer_indices%do14ctot_ind, &
+         zoo14c_ind    => marbl_tracer_indices%zoo14c_ind    &
          )
 
     diags(ind%calcToSed_13C)%field_2d(1) = sum(P_Ca13CO3%sed_loss)
@@ -5359,7 +5359,7 @@ contains
 
     ! Vertical integrals - CISO_Jint_13Ctot and Jint_100m_13Ctot
 
-    work(:) = dtracers(di13c_ind,:) + dtracers(do13c_ind,:) + dtracers(zoo13C_ind,:) &
+    work(:) = dtracers(di13c_ind,:) + dtracers(do13ctot_ind,:) + dtracers(zoo13C_ind,:) &
          + sum(dtracers(marbl_tracer_indices%auto_inds(:)%C13_ind,:), dim=1)
     do auto_ind = 1, autotroph_cnt
        n = marbl_tracer_indices%auto_inds(auto_ind)%Ca13CO3_ind
@@ -5374,7 +5374,7 @@ contains
 
     ! Vertical integral - CISO_Jint_14Ctot and Jint_100m_14Ctot
 
-    work(:) = dtracers(di14c_ind,:) + dtracers(do14c_ind,:) + dtracers(zoo14C_ind,:) &
+    work(:) = dtracers(di14c_ind,:) + dtracers(do14ctot_ind,:) + dtracers(zoo14C_ind,:) &
          + sum(dtracers(marbl_tracer_indices%auto_inds(:)%C14_ind,:), dim=1)
     do auto_ind = 1, autotroph_cnt
        n = marbl_tracer_indices%auto_inds(auto_ind)%Ca14CO3_ind
@@ -5433,14 +5433,14 @@ contains
        diags(ind%CISO_DIC_d13C)%field_3d(k, 1)        = DIC_d13C(k)
        diags(ind%CISO_DIC_d14C)%field_3d(k, 1)        = DIC_d14C(k)
 
-       diags(ind%CISO_DOC_d13C)%field_3d(k, 1)        = DOC_d13C(k)
-       diags(ind%CISO_DOC_d14C)%field_3d(k, 1)        = DOC_d14C(k)
+       diags(ind%CISO_DOCtot_d13C)%field_3d(k, 1)     = DOCtot_d13C(k)
+       diags(ind%CISO_DOCtot_d14C)%field_3d(k, 1)     = DOCtot_d14C(k)
 
-       diags(ind%CISO_DO13C_prod)%field_3d(k, 1)      = DO13C_prod(k)
-       diags(ind%CISO_DO14C_prod)%field_3d(k, 1)      = DO14C_prod(k)
+       diags(ind%CISO_DO13Ctot_prod)%field_3d(k, 1)   = DO13Ctot_prod(k)
+       diags(ind%CISO_DO14Ctot_prod)%field_3d(k, 1)   = DO14Ctot_prod(k)
 
-       diags(ind%CISO_DO13C_remin)%field_3d(k, 1)     = DO13C_remin(k)
-       diags(ind%CISO_DO14C_remin)%field_3d(k, 1)     = DO14C_remin(k)
+       diags(ind%CISO_DO13Ctot_remin)%field_3d(k, 1)  = DO13Ctot_remin(k)
+       diags(ind%CISO_DO14Ctot_remin)%field_3d(k, 1)  = DO14Ctot_remin(k)
 
        diags(ind%CISO_zooC_d13C)%field_3d(k, 1)       = zooC_d13C(k)
        diags(ind%CISO_zooC_d14C)%field_3d(k, 1)       = zooC_d14C(k)

--- a/src/marbl_interface_private_types.F90
+++ b/src/marbl_interface_private_types.F90
@@ -84,16 +84,16 @@ module marbl_interface_private_types
   !****************************************************************************
 
   type, public :: marbl_interior_share_type
-     real(r8) :: QA_dust_def      ! incoming deficit in the QA(dust) POC flux
-     real(r8) :: DIC_loc_fields   ! local copy of model DIC
-     real(r8) :: DOC_loc_fields   ! local copy of model DOC
-     real(r8) :: O2_loc_fields    ! local copy of model O2
-     real(r8) :: NO3_loc_fields   ! local copy of model NO3
+     real(r8) :: QA_dust_def         ! incoming deficit in the QA(dust) POC flux
+     real(r8) :: DIC_loc_fields      ! local copy of model DIC
+     real(r8) :: DOCtot_loc_fields   ! local copy of model DOC+DOCr
+     real(r8) :: O2_loc_fields       ! local copy of model O2
+     real(r8) :: NO3_loc_fields      ! local copy of model NO3
      real(r8) :: CO3_fields
-     real(r8) :: HCO3_fields      ! bicarbonate ion
-     real(r8) :: H2CO3_fields     ! carbonic acid
+     real(r8) :: HCO3_fields         ! bicarbonate ion
+     real(r8) :: H2CO3_fields        ! carbonic acid
      real(r8) :: CO3_sat_calcite
-     real(r8) :: DOC_remin_fields ! remineralization of 13C DOC (mmol C/m^3/sec)
+     real(r8) :: DOCtot_remin_fields ! remineralization of DOC+DOCr (mmol C/m^3/sec)
   end type marbl_interior_share_type
 
   !***********************************************************************
@@ -222,9 +222,9 @@ module marbl_interface_private_types
 
     ! CISO tracers
     integer (int_kind) :: di13c_ind       = 0 ! dissolved inorganic carbon 13
-    integer (int_kind) :: do13c_ind       = 0 ! dissolved organic carbon 13
+    integer (int_kind) :: do13ctot_ind    = 0 ! dissolved organic carbon 13 (semi-labile+refractory)
     integer (int_kind) :: di14c_ind       = 0 ! dissolved inorganic carbon 14
-    integer (int_kind) :: do14c_ind       = 0 ! dissolved organic carbon 14
+    integer (int_kind) :: do14ctot_ind    = 0 ! dissolved organic carbon 14 (semi-labile+refractory)
 
     ! Living tracers
     type(marbl_living_tracer_index_type), allocatable :: auto_inds(:)
@@ -603,12 +603,12 @@ contains
     end do
 
     if (ciso_on) then
-      call this%add_tracer_index('di13c', 'ciso', this%di13c_ind, marbl_status_log)
-      call this%add_tracer_index('do13c', 'ciso', this%do13c_ind, marbl_status_log)
-      call this%add_tracer_index('di14c', 'ciso', this%di14c_ind, marbl_status_log)
-      call this%add_tracer_index('do14c', 'ciso', this%do14c_ind, marbl_status_log)
-      call this%add_tracer_index('zoo13c', 'ciso', this%zoo13C_ind, marbl_status_log)
-      call this%add_tracer_index('zoo14c', 'ciso', this%zoo14C_ind, marbl_status_log)
+      call this%add_tracer_index('di13c',    'ciso', this%di13c_ind,    marbl_status_log)
+      call this%add_tracer_index('do13ctot', 'ciso', this%do13ctot_ind, marbl_status_log)
+      call this%add_tracer_index('di14c',    'ciso', this%di14c_ind,    marbl_status_log)
+      call this%add_tracer_index('do14ctot', 'ciso', this%do14ctot_ind, marbl_status_log)
+      call this%add_tracer_index('zoo13c',   'ciso', this%zoo13C_ind,   marbl_status_log)
+      call this%add_tracer_index('zoo14c',   'ciso', this%zoo14C_ind,   marbl_status_log)
 
       do n=1,autotroph_cnt
         write(ind_name, "(2A)") trim(autotrophs(n)%sname), "C13"

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -4513,7 +4513,8 @@ contains
 
     marbl_interior_share%QA_dust_def    = QA_dust_def
     marbl_interior_share%DIC_loc_fields = tracer_local(marbl_tracer_indices%DIC_ind)
-    marbl_interior_share%DOC_loc_fields = tracer_local(marbl_tracer_indices%DOC_ind)
+    marbl_interior_share%DOCtot_loc_fields = &
+         tracer_local(marbl_tracer_indices%DOC_ind) + tracer_local(marbl_tracer_indices%DOCr_ind)
     marbl_interior_share%O2_loc_fields  = tracer_local(marbl_tracer_indices%O2_ind)
     marbl_interior_share%NO3_loc_fields = tracer_local(marbl_tracer_indices%NO3_ind)
 
@@ -4523,7 +4524,8 @@ contains
     marbl_interior_share%H2CO3_fields = carbonate%H2CO3
     marbl_interior_share%CO3_sat_calcite = carbonate%CO3_sat_calcite
 
-    marbl_interior_share%DOC_remin_fields = dissolved_organic_matter%DOC_remin
+    marbl_interior_share%DOCtot_remin_fields = &
+         dissolved_organic_matter%DOC_remin + dissolved_organic_matter%DOCr_remin
 
   end subroutine marbl_export_interior_shared_variables
 


### PR DESCRIPTION
pass DOCtot=DOC+DOCr from base to ciso, instead of DOC

replace do1{3,4}c with do1{3,4}ctot

DO1{3,4}C now initialized with DOCtot in IC file

Testing:
marbl_dev_klindsay_n113_marbl_dev_n78_cesm_pop_2_1_20180205

aux_pop_MARBL cheyenne/{intel,gnu}: (baseline comparison to marbl_dev_klindsay_n112)
   except for tests mentioned below, all tests pass
      NLCOMP failed for all tests because of changes to ciso_tracer_init_ext in POP
      BASELINE failed for ciso tests because of changed IC and source term

Files Modified:
	modified:   src/marbl_init_mod.F90
	modified:   src/marbl_interface_private_types.F90
	modified:   src/marbl_mod.F90
	modified:   src/marbl_restore_mod.F90
	modified:   autogenerated_src/default_diagnostics.json
	modified:   autogenerated_src/default_settings.json
	modified:   src/default_diagnostics.yaml
	modified:   src/default_settings.yaml
	modified:   src/marbl_ciso_mod.F90
	modified:   src/marbl_diagnostics_mod.F90
	modified:   src/marbl_interface_private_types.F90
	modified:   src/marbl_mod.F90

goes with POP tag marbl_dev_klindsay_n113_marbl_dev_n78_cesm_pop_2_1_20180205