### PR TITLE
Enhancement/check flux units

### DIFF
--- a/autogenerated_src/default_diagnostics.json
+++ b/autogenerated_src/default_diagnostics.json
@@ -1204,13 +1204,6 @@
       "units": "atmospheres",
       "vertical_grid": "none"
    },
-   "ECOSYS_FESEDFLUX": {
-      "frequency": "never",
-      "longname": "Iron Sediment Flux",
-      "operator": "average",
-      "units": "need_units",
-      "vertical_grid": "layer_avg"
-   },
    "ECOSYS_IFRAC": {
       "frequency": [
          "medium",
@@ -1236,6 +1229,13 @@
       ],
       "units": "cm/s",
       "vertical_grid": "none"
+   },
+   "FESEDFLUX": {
+      "frequency": "never",
+      "longname": "Iron Sediment Flux",
+      "operator": "average",
+      "units": "nmol/cm^2/s",
+      "vertical_grid": "layer_avg"
    },
    "FG_ALT_CO2": {
       "frequency": "medium",

--- a/autogenerated_src/default_diagnostics.json
+++ b/autogenerated_src/default_diagnostics.json
@@ -1224,6 +1224,13 @@
       "units": "atmospheres",
       "vertical_grid": "none"
    },
+   "ECOSYS_FESEDFLUX": {
+      "frequency": "never",
+      "longname": "Iron Sediment Flux",
+      "operator": "average",
+      "units": "need_units",
+      "vertical_grid": "layer_avg"
+   },
    "ECOSYS_IFRAC": {
       "frequency": [
          "medium",

--- a/src/default_diagnostics.yaml
+++ b/src/default_diagnostics.yaml
@@ -742,9 +742,9 @@ Lig_deg :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
-ECOSYS_FESEDFLUX :
+FESEDFLUX :
    longname : Iron Sediment Flux
-   units : need_units
+   units : nmol/cm^2/s
    vertical_grid : layer_avg
    frequency : never
    operator : average

--- a/src/default_diagnostics.yaml
+++ b/src/default_diagnostics.yaml
@@ -772,6 +772,12 @@ Lig_deg :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+ECOSYS_FESEDFLUX :
+   longname : Iron Sediment Flux
+   units : need_units
+   vertical_grid : layer_avg
+   frequency : never
+   operator : average
 
 # Particulate 2D diags
 POC_FLUX_((particulate_flux_ref_depth_str)) :

--- a/src/marbl_diagnostics_mod.F90
+++ b/src/marbl_diagnostics_mod.F90
@@ -2293,7 +2293,7 @@ contains
 
       lname = 'Iron Sediment Flux'
       sname = 'ECOSYS_FESEDFLUX'
-      units = 'need_units'
+      units = 'nmolFe/cm^2/s'
       vgrid = 'layer_avg'
       truncate = .false.
       call diags%add_diagnostic(lname, sname, units, vgrid, truncate,     &

--- a/src/marbl_diagnostics_mod.F90
+++ b/src/marbl_diagnostics_mod.F90
@@ -2292,8 +2292,8 @@ contains
       end if
 
       lname = 'Iron Sediment Flux'
-      sname = 'ECOSYS_FESEDFLUX'
-      units = 'nmolFe/cm^2/s'
+      sname = 'FESEDFLUX'
+      units = 'nmol/cm^2/s'
       vgrid = 'layer_avg'
       truncate = .false.
       call diags%add_diagnostic(lname, sname, units, vgrid, truncate,     &

--- a/src/marbl_diagnostics_mod.F90
+++ b/src/marbl_diagnostics_mod.F90
@@ -194,6 +194,8 @@ module marbl_diagnostics_mod
     integer(int_kind) :: Fefree
     integer(int_kind) :: Lig_photochem
     integer(int_kind) :: Lig_deg
+    integer(int_kind) :: fesedflux
+
 
     ! Particulate 2D diags
     integer(int_kind) :: POC_FLUX_at_ref_depth
@@ -2351,6 +2353,18 @@ contains
       truncate = .false.
       call diags%add_diagnostic(lname, sname, units, vgrid, truncate,     &
            ind%Lig_deg, marbl_status_log)
+      if (marbl_status_log%labort_marbl) then
+        call log_add_diagnostics_error(marbl_status_log, sname, subname)
+        return
+      end if
+
+      lname = 'Iron Sediment Flux'
+      sname = 'ECOSYS_FESEDFLUX'
+      units = 'need_units'
+      vgrid = 'layer_avg'
+      truncate = .false.
+      call diags%add_diagnostic(lname, sname, units, vgrid, truncate,     &
+           ind%fesedflux, marbl_status_log)
       if (marbl_status_log%labort_marbl) then
         call log_add_diagnostics_error(marbl_status_log, sname, subname)
         return
@@ -5204,6 +5218,7 @@ contains
          fe_ind  => marbl_tracer_indices%fe_ind &
          )
 
+    diags(ind%fesedflux)%field_3d(1,:) = fesedflux(:)
     ! vertical integrals
     work = dtracers(fe_ind, :) +                                              &
            sum(dtracers(marbl_tracer_indices%auto_inds(:)%Fe_ind, :),dim=1) + &

--- a/src/marbl_init_mod.F90
+++ b/src/marbl_init_mod.F90
@@ -890,7 +890,7 @@ contains
         if (id .eq. ind%dustflux_id) then
           found = .true.
           interior_forcings(id)%metadata%varname     = 'Dust Flux'
-          interior_forcings(id)%metadata%field_units = 'need_units'
+          interior_forcings(id)%metadata%field_units = 'g/cm^2/s'
           call interior_forcings(id)%set_rank(num_elements, 0, marbl_status_log)
         end if
 
@@ -906,7 +906,7 @@ contains
         if (id .eq. ind%surf_shortwave_id) then
           found = .true.
           interior_forcings(id)%metadata%varname     = 'Surface Shortwave'
-          interior_forcings(id)%metadata%field_units = 'need_units' ! W/m^2?
+          interior_forcings(id)%metadata%field_units = 'W/m^2'
           call interior_forcings(id)%set_rank(num_elements, 1, marbl_status_log, &
                                               dim1 = num_PAR_subcols)
         end if
@@ -925,7 +925,7 @@ contains
         if (id .eq. ind%salinity_id) then
           found = .true.
           interior_forcings(id)%metadata%varname     = 'Salinity'
-          interior_forcings(id)%metadata%field_units = 'need_units'
+          interior_forcings(id)%metadata%field_units = 'psu'
           call interior_forcings(id)%set_rank(num_elements, 1, marbl_status_log, &
                                               dim1 = num_levels)
         end if
@@ -934,7 +934,7 @@ contains
         if (id .eq. ind%pressure_id) then
           found = .true.
           interior_forcings(id)%metadata%varname     = 'Pressure'
-          interior_forcings(id)%metadata%field_units = 'need_units'
+          interior_forcings(id)%metadata%field_units = 'bars'
           call interior_forcings(id)%set_rank(num_elements, 1, marbl_status_log, &
                                               dim1 = num_levels)
         end if
@@ -943,7 +943,7 @@ contains
         if (id .eq. ind%fesedflux_id) then
           found = .true.
           interior_forcings(id)%metadata%varname     = 'Iron Sediment Flux'
-          interior_forcings(id)%metadata%field_units = 'need_units'
+          interior_forcings(id)%metadata%field_units = 'nmol/cm^2/s'
           call interior_forcings(id)%set_rank(num_elements, 1, marbl_status_log, &
                                               dim1 = num_levels)
         end if


### PR DESCRIPTION
Some forcing fields were initialized with units of `need_units`; I went through and determined the units of the data POP was passing to MARBL so I could populate these fields correctly.

Also, I added `ECOSYS_FESEDFLUX` as a diagnostic output. Other surface forcing fields are provided as diagnostics (e.g. `ECOSYS_IFRAC`), and having it will be useful for constructing forcing datasets from POP history files. Default frequency is `never`, so it only appears in POP history output if `lecosys_tavg_all = .true.`.