### PR TITLE
Correct units of dust-related diagnostics

### DIFF
--- a/autogenerated_src/default_diagnostics.json
+++ b/autogenerated_src/default_diagnostics.json
@@ -1779,14 +1779,14 @@
       "frequency": "medium",
       "longname": "Dust Flux into Cell",
       "operator": "average",
-      "units": "ng/s/m^2",
+      "units": "g/cm^2/s",
       "vertical_grid": "layer_avg"
    },
    "dust_REMIN": {
       "frequency": "medium",
       "longname": "Dust Remineralization",
       "operator": "average",
-      "units": "mmol/m^3/s",
+      "units": "g/cm^3/s",
       "vertical_grid": "layer_avg"
    },
    "graze_((autotroph_sname))": {

--- a/src/default_diagnostics.yaml
+++ b/src/default_diagnostics.yaml
@@ -958,13 +958,13 @@ SiO2_REMIN :
    operator : average
 dust_FLUX_IN :
    longname : Dust Flux into Cell
-   units : ng/s/m^2
+   units : g/cm^2/s
    vertical_grid : layer_avg
    frequency : medium
    operator : average
 dust_REMIN :
    longname : Dust Remineralization
-   units : mmol/m^3/s
+   units : g/cm^3/s
    vertical_grid : layer_avg
    frequency : medium
    operator : average

--- a/src/marbl_diagnostics_mod.F90
+++ b/src/marbl_diagnostics_mod.F90
@@ -2718,7 +2718,7 @@ contains
 
       lname = 'Dust Flux into Cell'
       sname = 'dust_FLUX_IN'
-      units = 'ng/s/m^2'
+      units = 'g/cm^2/s'
       vgrid = 'layer_avg'
       truncate = .false.
       call diags%add_diagnostic(lname, sname, units, vgrid, truncate,     &
@@ -2730,7 +2730,7 @@ contains
 
       lname = 'Dust Remineralization'
       sname = 'dust_REMIN'
-      units = 'mmol/m^3/s'
+      units = 'g/cm^3/s'
       vgrid = 'layer_avg'
       truncate = .false.
       call diags%add_diagnostic(lname, sname, units, vgrid, truncate,     &
@@ -4250,10 +4250,7 @@ contains
     endif
 
     diags(ind_diag%NHx_SURFACE_EMIS)%field_2d(:) = nhx_surface_emis(:)
-
-    ! FIXME #63 : reported units of DUST_FLUX are g/cm^2/s, so this comment doesn't make sense
-    ! multiply DUST flux by mpercm (.01) to convert from model units (cm/s)(mmol/m^3) to mmol/s/m^2
-    diags(ind_diag%DUST_FLUX)%field_2d(:) = DUST_FLUX_IN(:)*mpercm
+    diags(ind_diag%DUST_FLUX)%field_2d(:) = DUST_FLUX_IN(:)
 
     end associate
 
@@ -4637,7 +4634,7 @@ contains
     diags(ind%SiO2_REMIN)%field_3d(:, 1)          = P_SiO2%remin
 
     diags(ind%dust_FLUX_IN)%field_3d(:, 1) = dust%sflux_in + dust%hflux_in
-    diags(ind%dust_REMIN)%field_3d(:, 1)   = P_SiO2%remin
+    diags(ind%dust_REMIN)%field_3d(:, 1)   = dust%remin
 
     diags(ind%P_iron_FLUX_at_ref_depth)%field_2d(1) = P_iron%flux_at_ref_depth
     diags(ind%P_iron_FLUX_IN)%field_3d(:, 1)        = P_iron%sflux_in + P_iron%hflux_in

--- a/src/marbl_init_mod.F90
+++ b/src/marbl_init_mod.F90
@@ -719,7 +719,7 @@ contains
         if (id .eq. ind%sss_id) then
           found = .true.
           surface_forcings(id)%metadata%varname       = 'sss'
-          surface_forcings(id)%metadata%field_units   = 'unknown units'
+          surface_forcings(id)%metadata%field_units   = 'psu'
         end if
 
         ! Sea-surface temperature
@@ -754,14 +754,14 @@ contains
         if (id .eq. ind%nox_flux_id) then
           found = .true.
           surface_forcings(id)%metadata%varname       = 'NOx Flux'
-          surface_forcings(id)%metadata%field_units   = 'unknown units'
+          surface_forcings(id)%metadata%field_units   = 'mmol/m^2/s'
         end if
 
         ! NHy Flux
         if (id .eq. ind%nhy_flux_id) then
           found = .true.
           surface_forcings(id)%metadata%varname       = 'NHy Flux'
-          surface_forcings(id)%metadata%field_units   = 'unknown units'
+          surface_forcings(id)%metadata%field_units   = 'mmol/m^2/s'
         end if
 
         ! external C Flux
@@ -789,35 +789,35 @@ contains
         if (id .eq. ind%atm_pressure_id) then
           found = .true.
           surface_forcings(id)%metadata%varname       = 'Atmospheric Pressure'
-          surface_forcings(id)%metadata%field_units   = 'unknown units'
+          surface_forcings(id)%metadata%field_units   = 'atmospheres'
         end if
 
         ! xco2
         if (id .eq. ind%xco2_id) then
           found = .true.
           surface_forcings(id)%metadata%varname       = 'xco2'
-          surface_forcings(id)%metadata%field_units   = 'unknown units'
+          surface_forcings(id)%metadata%field_units   = 'ppmv'
         end if
 
         ! xco2_alt_co2
         if (id .eq. ind%xco2_alt_co2_id) then
           found = .true.
           surface_forcings(id)%metadata%varname       = 'xco2_alt_co2'
-          surface_forcings(id)%metadata%field_units   = 'unknown units'
+          surface_forcings(id)%metadata%field_units   = 'ppmv'
         end if
 
         ! d13c
         if (id .eq. ind%d13c_id) then
           found = .true.
           surface_forcings(id)%metadata%varname       = 'd13c'
-          surface_forcings(id)%metadata%field_units   = 'unknown units'
+          surface_forcings(id)%metadata%field_units   = 'mmol/m^3'
         end if
 
         ! d14c
         if (id .eq. ind%d14c_id) then
           found = .true.
           surface_forcings(id)%metadata%varname       = 'd14c'
-          surface_forcings(id)%metadata%field_units   = 'unknown units'
+          surface_forcings(id)%metadata%field_units   = 'mmol/m^3'
         end if
 
         if (.not.found) then

--- a/src/marbl_init_mod.F90
+++ b/src/marbl_init_mod.F90
@@ -754,14 +754,14 @@ contains
         if (id .eq. ind%nox_flux_id) then
           found = .true.
           surface_forcings(id)%metadata%varname       = 'NOx Flux'
-          surface_forcings(id)%metadata%field_units   = 'mmol/m^2/s'
+          surface_forcings(id)%metadata%field_units   = 'nmol/cm^2/s'
         end if
 
         ! NHy Flux
         if (id .eq. ind%nhy_flux_id) then
           found = .true.
           surface_forcings(id)%metadata%varname       = 'NHy Flux'
-          surface_forcings(id)%metadata%field_units   = 'mmol/m^2/s'
+          surface_forcings(id)%metadata%field_units   = 'nmol/cm^2/s'
         end if
 
         ! external C Flux
@@ -810,14 +810,14 @@ contains
         if (id .eq. ind%d13c_id) then
           found = .true.
           surface_forcings(id)%metadata%varname       = 'd13c'
-          surface_forcings(id)%metadata%field_units   = 'mmol/m^3'
+          surface_forcings(id)%metadata%field_units   = 'permil'
         end if
 
         ! d14c
         if (id .eq. ind%d14c_id) then
           found = .true.
           surface_forcings(id)%metadata%varname       = 'd14c'
-          surface_forcings(id)%metadata%field_units   = 'mmol/m^3'
+          surface_forcings(id)%metadata%field_units   = 'permil'
         end if
 
         if (.not.found) then
@@ -916,7 +916,7 @@ contains
         if (id .eq. ind%potemp_id) then
           found = .true.
           interior_forcings(id)%metadata%varname     = 'Potential Temperature'
-          interior_forcings(id)%metadata%field_units = 'Degrees C'
+          interior_forcings(id)%metadata%field_units = 'degrees C'
           call interior_forcings(id)%set_rank(num_elements, 1, marbl_status_log, &
                                               dim1 = num_levels)
         end if

--- a/tests/driver_src/marbl.F90
+++ b/tests/driver_src/marbl.F90
@@ -330,15 +330,17 @@ Program marbl
       ! Log requested surface forcing fields
       call driver_status_log%log_header('Requested surface forcing fields', subname)
       do n=1,size(marbl_instance%surface_input_forcings)
-        write(log_message, "(I0, 2A)") n, '. ', &
-              trim(marbl_instance%surface_input_forcings(n)%metadata%varname)
+        write(log_message, "(I0, 5A)") n, '. ', &
+              trim(marbl_instance%surface_input_forcings(n)%metadata%varname), &
+              ' (units: ', trim(marbl_instance%surface_input_forcings(n)%metadata%field_units),')'
         call driver_status_log%log_noerror(log_message, subname)
       end do
       ! Log requested interior forcing fields
       call driver_status_log%log_header('Requested interior forcing fields', subname)
       do n=1,size(marbl_instance%interior_input_forcings)
-        write(log_message, "(I0, 2A)") n, '. ',                               &
-             trim(marbl_instance%interior_input_forcings(n)%metadata%varname)
+        write(log_message, "(I0, 5A)") n, '. ',                               &
+             trim(marbl_instance%interior_input_forcings(n)%metadata%varname), &
+             ' (units: ', trim(marbl_instance%interior_input_forcings(n)%metadata%field_units),')'
         call driver_status_log%log_noerror(log_message, subname)
       end do
       call marbl_instance%shutdown()

--- a/tests/driver_src/marbl.F90
+++ b/tests/driver_src/marbl.F90
@@ -294,7 +294,8 @@ Program marbl
       associate(diags => marbl_instance%surface_forcing_diags%diags)
         call driver_status_log%log_header('Surface forcing diagnostics', subname)
         do n=1, size(diags)
-          write(log_message, "(I0,4A)") n, '. ', trim(diags(n)%short_name), ': ', trim(diags(n)%long_name)
+          write(log_message, "(I0,7A)") n, '. ', trim(diags(n)%short_name), ': ', trim(diags(n)%long_name), &
+                                        ' (units: ', trim(diags(n)%units),')'
           call driver_status_log%log_noerror(log_message, subname)
         end do
       end associate
@@ -302,7 +303,8 @@ Program marbl
       associate(diags => marbl_instance%interior_forcing_diags%diags)
         call driver_status_log%log_header('Interior forcing diagnostics', subname)
         do n=1, size(diags)
-          write(log_message, "(I0,4A)") n, '. ', trim(diags(n)%short_name), ': ', trim(diags(n)%long_name)
+          write(log_message, "(I0,7A)") n, '. ', trim(diags(n)%short_name), ': ', trim(diags(n)%long_name), &
+                                        ' (units: ', trim(diags(n)%units),')'
           call driver_status_log%log_noerror(log_message, subname)
         end do
       end associate


### PR DESCRIPTION
Fixes #63 (and also fixes bug in dust_remin diagnostic)

Verified via single POP run that changes are all expected:

```
Variable: dust_FLUX_IN ...
... variable attribute 'units' does not match ...
    'ng/s/m^2'
    'g/cm^2/s'

Variable: dust_REMIN ...
... variable attribute 'units' does not match ...
    'mmol/m^3/s'
    'g/cm^3/s'
... variable is double ...
... Biggest (absolute) diff = 3.234357947886002e-05
... Biggest (relative) diff = 0.9999999999999964

Variable: DUST_FLUX ...
... variable is double ...
... Biggest (absolute) diff = 4.094564726256528e-10
... Biggest (relative) diff = 99.00000000000003
```

`dust_FLUX_IN` and `dust_REMIN` have proper units; `DUST_FLUX` is no longer multiplied by `.01` in a misguided attempt at unit conversion, and `dust_REMIN` is actually `dust%remin` instead of `P_SiO2%remin`.

I also updated the stand-alone driver to include units in the `requested_diagnostics` test output.