### PR TITLE
Rename zoo1[34]C to zoo1[34]Ctot

### DIFF
--- a/autogenerated_src/default_settings.json
+++ b/autogenerated_src/default_settings.json
@@ -630,20 +630,6 @@
          "long_name": "((autotroph_lname)) Silicon",
          "units": "mmol/m^3"
       },
-      "((zooplankton_sname))13C": {
-         "dependencies": {
-            "ciso_on": ".true."
-         },
-         "long_name": "((zooplankton_lname)) Carbon-13",
-         "units": "mmol/m^3"
-      },
-      "((zooplankton_sname))14C": {
-         "dependencies": {
-            "ciso_on": ".true."
-         },
-         "long_name": "((zooplankton_lname)) Carbon-14",
-         "units": "mmol/m^3"
-      },
       "((zooplankton_sname))C": {
          "long_name": "((zooplankton_lname)) Carbon",
          "units": "mmol/m^3"
@@ -742,6 +728,20 @@
       },
       "SiO3": {
          "long_name": "Dissolved Inorganic Silicate",
+         "units": "mmol/m^3"
+      },
+      "zoo13Ctot": {
+         "dependencies": {
+            "ciso_on": ".true."
+         },
+         "long_name": "Zooplankton Carbon-13 (sum over all zooplankton)",
+         "units": "mmol/m^3"
+      },
+      "zoo14Ctot": {
+         "dependencies": {
+            "ciso_on": ".true."
+         },
+         "long_name": "Zooplankton Carbon-14 (sum over all zooplankton)",
          "units": "mmol/m^3"
       }
    },

--- a/src/default_settings.yaml
+++ b/src/default_settings.yaml
@@ -177,15 +177,15 @@ _tracer_list :
       long_name : ((zooplankton_lname)) Carbon
       units : mmol/m^3
    # Per-zooplankton (ciso only)
-   ((zooplankton_sname))13C :
+   zoo13Ctot :
       dependencies :
          ciso_on : .true.
-      long_name : ((zooplankton_lname)) Carbon-13
+      long_name : Zooplankton Carbon-13 (sum over all zooplankton)
       units : mmol/m^3
-   ((zooplankton_sname))14C :
+   zoo14Ctot :
       dependencies :
          ciso_on : .true.
-      long_name : ((zooplankton_lname)) Carbon-14
+      long_name : Zooplankton Carbon-14 (sum over all zooplankton)
       units : mmol/m^3
 
 ################################################################################

--- a/src/marbl_ciso_mod.F90
+++ b/src/marbl_ciso_mod.F90
@@ -114,10 +114,10 @@ contains
 
     associate(di13c_ind         => marbl_tracer_indices%di13c_ind,            &
               do13ctot_ind      => marbl_tracer_indices%do13ctot_ind,         &
-              zoo13c_ind        => marbl_tracer_indices%zoo13c_ind,           &
+              zoo13Ctot_ind     => marbl_tracer_indices%zoo13Ctot_ind,        &
               di14c_ind         => marbl_tracer_indices%di14c_ind,            &
               do14ctot_ind      => marbl_tracer_indices%do14ctot_ind,         &
-              zoo14c_ind        => marbl_tracer_indices%zoo14c_ind,           &
+              zoo14Ctot_ind     => marbl_tracer_indices%zoo14Ctot_ind,        &
               ciso_ind_beg      => marbl_tracer_indices%ciso%ind_beg,         &
               ciso_ind_end      => marbl_tracer_indices%ciso%ind_end          &
              )
@@ -136,8 +136,8 @@ contains
     marbl_tracer_metadata(do13ctot_ind)%short_name='DO13Ctot'
     marbl_tracer_metadata(do13ctot_ind)%long_name='Dissolved Organic Carbon-13 (semi-labile+refractory)'
 
-    marbl_tracer_metadata(zoo13C_ind)%short_name='zoo13C'
-    marbl_tracer_metadata(zoo13C_ind)%long_name='Zooplankton Carbon-13'
+    marbl_tracer_metadata(zoo13Ctot_ind)%short_name='zoo13Ctot'
+    marbl_tracer_metadata(zoo13Ctot_ind)%long_name='Zooplankton Carbon-13 (sum over all zooplankton)'
 
     marbl_tracer_metadata(di14c_ind)%short_name='DI14C'
     marbl_tracer_metadata(di14c_ind)%long_name='Dissolved Inorganic Carbon-14'
@@ -145,8 +145,8 @@ contains
     marbl_tracer_metadata(do14ctot_ind)%short_name='DO14Ctot'
     marbl_tracer_metadata(do14ctot_ind)%long_name='Dissolved Organic Carbon-14 (semi-labile+refractory)'
 
-    marbl_tracer_metadata(zoo14C_ind)%short_name='zoo14C'
-    marbl_tracer_metadata(zoo14C_ind)%long_name='Zooplankton Carbon-14'
+    marbl_tracer_metadata(zoo14Ctot_ind)%short_name='zoo14Ctot'
+    marbl_tracer_metadata(zoo14Ctot_ind)%long_name='Zooplankton Carbon-14 (sum over all zooplankton)'
 
     !-----------------------------------------------------------------------
     !  initialize autotroph tracer_d values and tracer indices
@@ -178,8 +178,8 @@ contains
     !  set lfull_depth_tavg flag for short-lived ecosystem tracers
     !-----------------------------------------------------------------------
 
-    marbl_tracer_metadata(zoo13C_ind   )%lfull_depth_tavg = ciso_lecovars_full_depth_tavg
-    marbl_tracer_metadata(zoo14C_ind   )%lfull_depth_tavg = ciso_lecovars_full_depth_tavg
+    marbl_tracer_metadata(zoo13Ctot_ind)%lfull_depth_tavg = ciso_lecovars_full_depth_tavg
+    marbl_tracer_metadata(zoo14Ctot_ind)%lfull_depth_tavg = ciso_lecovars_full_depth_tavg
 
     do auto_ind = 1, autotroph_cnt
        n = marbl_tracer_indices%auto_inds(auto_ind)%C13_ind
@@ -285,10 +285,10 @@ contains
     real (r8), dimension (marbl_domain%km) :: &
          DO13Ctot_loc,      & ! local copy of model DO13Ctot
          DI13C_loc,         & ! local copy of model DI13C
-         zoo13C_loc,        & ! local copy of model zoo13C
+         zoo13Ctot_loc,     & ! local copy of model zoo13Ctot
          DO14Ctot_loc,      & ! local copy of model DO14Ctot
          DI14C_loc,         & ! local copy of model DI14C
-         zoo14C_loc           ! local copy of model zoo14C
+         zoo14Ctot_loc        ! local copy of model zoo14Ctot
 
     real (r8), dimension(marbl_domain%km) :: &
          mui_to_co2star_loc     ! local carbon autotroph instanteous growth rate over [CO2*] (m^3 /mol C /s)
@@ -389,10 +389,10 @@ contains
 
          di13c_ind          => marbl_tracer_indices%di13c_ind                  , &
          do13ctot_ind       => marbl_tracer_indices%do13ctot_ind               , &
-         zoo13c_ind         => marbl_tracer_indices%zoo13c_ind                 , &
+         zoo13Ctot_ind      => marbl_tracer_indices%zoo13Ctot_ind              , &
          di14c_ind          => marbl_tracer_indices%di14c_ind                  , &
          do14ctot_ind       => marbl_tracer_indices%do14ctot_ind               , &
-         zoo14c_ind         => marbl_tracer_indices%zoo14c_ind                   &
+         zoo14Ctot_ind      => marbl_tracer_indices%zoo14Ctot_ind                &
          )
 
     !-----------------------------------------------------------------------
@@ -428,8 +428,8 @@ contains
     !-----------------------------------------------------------------------
 
     call setup_local_column_tracers(column_km, column_kmt, column_tracer, &
-           marbl_tracer_indices, DI13C_loc, DO13Ctot_loc, zoo13C_loc, DI14C_loc, &
-           DO14Ctot_loc, zoo14C_loc)
+           marbl_tracer_indices, DI13C_loc, DO13Ctot_loc, zoo13Ctot_loc, DI14C_loc, &
+           DO14Ctot_loc, zoo14Ctot_loc)
 
     !-----------------------------------------------------------------------
     !  Create local copies of model column autotrophs, treat negative values as zero
@@ -484,8 +484,8 @@ contains
 
        work1 = sum(zooC_loc(:,k),dim=1)
        if (work1 > c0) then
-          R13C_zooC(k) = zoo13C_loc(k) / work1
-          R14C_zooC(k) = zoo14C_loc(k) / work1
+          R13C_zooC(k) = zoo13Ctot_loc(k) / work1
+          R14C_zooC(k) = zoo14Ctot_loc(k) / work1
        else
           R13C_zooC(k) = c0
           R14C_zooC(k) = c0
@@ -790,16 +790,16 @@ contains
        !  column_dtracer: zoo 13 and 14 Carbon
        !-----------------------------------------------------------------------
 
-       column_dtracer(zoo13C_ind,k) = &
+       column_dtracer(zoo13Ctot_ind,k) = &
               sum(auto_graze_zoo(:,k) * R13C_autotroph(:,k),dim=1) &
             - sum(zoo_loss(:,k),dim=1) * R13C_zooC(k)
 
-       column_dtracer(zoo14C_ind,k) = &
+       column_dtracer(zoo14Ctot_ind,k) = &
               sum(auto_graze_zoo(:,k) * R14C_autotroph(:,k),dim=1) &
             - sum(zoo_loss(:,k),dim=1) * R14C_zooC(k) &
-            - c14_lambda_inv_sec * zoo14C_loc(k)
+            - c14_lambda_inv_sec * zoo14Ctot_loc(k)
 
-       decay_14Ctot(k) = decay_14Ctot(k) + c14_lambda_inv_sec * zoo14C_loc(k)
+       decay_14Ctot(k) = decay_14Ctot(k) + c14_lambda_inv_sec * zoo14Ctot_loc(k)
 
        !-----------------------------------------------------------------------
        !  column_dtracer: dissolved organic Matter 13C and 14C
@@ -1022,8 +1022,8 @@ contains
   !***********************************************************************
 
   subroutine setup_local_column_tracers(column_km, column_kmt, column_tracer, &
-           marbl_tracer_indices, DI13C_loc, DO13Ctot_loc, zoo13C_loc, DI14C_loc, &
-           DO14Ctot_loc, zoo14C_loc)
+           marbl_tracer_indices, DI13C_loc, DO13Ctot_loc, zoo13Ctot_loc, DI14C_loc, &
+           DO14Ctot_loc, zoo14Ctot_loc)
 
     !-----------------------------------------------------------------------
     !  create local copies of model column_tracer
@@ -1039,10 +1039,10 @@ contains
 
     real (r8)         , intent(out) :: DI13C_loc(:)     ! (km) local copy of model DI13C
     real (r8)         , intent(out) :: DO13Ctot_loc(:)  ! (km) local copy of model DO13Ctot
-    real (r8)         , intent(out) :: zoo13C_loc(:)    ! (km) local copy of model zoo13C
+    real (r8)         , intent(out) :: zoo13Ctot_loc(:) ! (km) local copy of model zoo13Ctot
     real (r8)         , intent(out) :: DI14C_loc(:)     ! (km) local copy of model DI14C
     real (r8)         , intent(out) :: DO14Ctot_loc(:)  ! (km) local copy of model DO14Ctot
-    real (r8)         , intent(out) :: zoo14C_loc(:)    ! (km) local copy of model zoo14C
+    real (r8)         , intent(out) :: zoo14Ctot_loc(:) ! (km) local copy of model zoo14Ctot
     !-----------------------------------------------------------------------
     !  local variables
     !-----------------------------------------------------------------------
@@ -1051,30 +1051,30 @@ contains
 
     associate(di13c_ind     => marbl_tracer_indices%di13c_ind,                   &
               do13ctot_ind  => marbl_tracer_indices%do13ctot_ind,                &
-              zoo13c_ind    => marbl_tracer_indices%zoo13c_ind,                  &
+              zoo13Ctot_ind => marbl_tracer_indices%zoo13Ctot_ind,               &
               di14c_ind     => marbl_tracer_indices%di14c_ind,                   &
               do14ctot_ind  => marbl_tracer_indices%do14ctot_ind,                &
-              zoo14c_ind    => marbl_tracer_indices%zoo14c_ind)
+              zoo14Ctot_ind => marbl_tracer_indices%zoo14Ctot_ind)
     do k = 1,column_kmt
-       DI13C_loc(k)    = max(c0, column_tracer(di13c_ind,k))
-       DI14C_loc(k)    = max(c0, column_tracer(di14c_ind,k))
+       DI13C_loc(k) = max(c0, column_tracer(di13c_ind,k))
+       DI14C_loc(k) = max(c0, column_tracer(di14c_ind,k))
 
        DO13Ctot_loc(k) = max(c0, column_tracer(do13ctot_ind,k))
        DO14Ctot_loc(k) = max(c0, column_tracer(do14ctot_ind,k))
 
-       zoo13C_loc(k)   = max(c0, column_tracer(zoo13C_ind,k))
-       zoo14C_loc(k)   = max(c0, column_tracer(zoo14C_ind,k))
+       zoo13Ctot_loc(k) = max(c0, column_tracer(zoo13Ctot_ind,k))
+       zoo14Ctot_loc(k) = max(c0, column_tracer(zoo14Ctot_ind,k))
     end do
 
     do k = column_kmt+1, column_km
-       DI13C_loc(k)    = c0
-       DI14C_loc(k)    = c0
+       DI13C_loc(k) = c0
+       DI14C_loc(k) = c0
 
        DO13Ctot_loc(k) = c0
        DO14Ctot_loc(k) = c0
 
-       zoo13C_loc(k)   = c0
-       zoo14C_loc(k)   = c0
+       zoo13Ctot_loc(k) = c0
+       zoo14Ctot_loc(k) = c0
     end do
     end associate
 

--- a/src/marbl_diagnostics_mod.F90
+++ b/src/marbl_diagnostics_mod.F90
@@ -5338,10 +5338,10 @@ contains
          ind     => marbl_interior_diag_ind, &
          di13c_ind     => marbl_tracer_indices%di13c_ind,    &
          do13ctot_ind  => marbl_tracer_indices%do13ctot_ind, &
-         zoo13c_ind    => marbl_tracer_indices%zoo13c_ind,   &
+         zoo13Ctot_ind    => marbl_tracer_indices%zoo13Ctot_ind,   &
          di14c_ind     => marbl_tracer_indices%di14c_ind,    &
          do14ctot_ind  => marbl_tracer_indices%do14ctot_ind, &
-         zoo14c_ind    => marbl_tracer_indices%zoo14c_ind    &
+         zoo14Ctot_ind    => marbl_tracer_indices%zoo14Ctot_ind    &
          )
 
     diags(ind%calcToSed_13C)%field_2d(1) = sum(P_Ca13CO3%sed_loss)
@@ -5358,7 +5358,7 @@ contains
 
     ! Vertical integrals - CISO_Jint_13Ctot
 
-    work(:) = dtracers(di13c_ind,:) + dtracers(do13ctot_ind,:) + dtracers(zoo13C_ind,:) &
+    work(:) = dtracers(di13c_ind,:) + dtracers(do13ctot_ind,:) + dtracers(zoo13Ctot_ind,:) &
          + sum(dtracers(marbl_tracer_indices%auto_inds(:)%C13_ind,:), dim=1)
     do auto_ind = 1, autotroph_cnt
        n = marbl_tracer_indices%auto_inds(auto_ind)%Ca13CO3_ind
@@ -5380,7 +5380,7 @@ contains
 
     ! Vertical integral - CISO_Jint_14Ctot
 
-    work(:) = dtracers(di14c_ind,:) + dtracers(do14ctot_ind,:) + dtracers(zoo14C_ind,:) &
+    work(:) = dtracers(di14c_ind,:) + dtracers(do14ctot_ind,:) + dtracers(zoo14Ctot_ind,:) &
          + sum(dtracers(marbl_tracer_indices%auto_inds(:)%C14_ind,:), dim=1) + decay_14Ctot
     do auto_ind = 1, autotroph_cnt
        n = marbl_tracer_indices%auto_inds(auto_ind)%Ca14CO3_ind

--- a/src/marbl_interface_private_types.F90
+++ b/src/marbl_interface_private_types.F90
@@ -232,8 +232,8 @@ module marbl_interface_private_types
     ! For CISO, don't want individual C13 and C14 tracers for each zooplankton
     ! Instead we collect them into one tracer for each isotope, regardless of
     ! zooplankton_cnt
-    integer (int_kind) :: zoo13C_ind      = 0 ! zooplankton carbon 13
-    integer (int_kind) :: zoo14C_ind      = 0 ! zooplankton carbon 14
+    integer (int_kind) :: zoo13Ctot_ind   = 0 ! zooplankton carbon 13
+    integer (int_kind) :: zoo14Ctot_ind   = 0 ! zooplankton carbon 14
 
   contains
     procedure, public :: add_tracer_index
@@ -607,8 +607,8 @@ contains
       call this%add_tracer_index('do13ctot', 'ciso', this%do13ctot_ind, marbl_status_log)
       call this%add_tracer_index('di14c',    'ciso', this%di14c_ind,    marbl_status_log)
       call this%add_tracer_index('do14ctot', 'ciso', this%do14ctot_ind, marbl_status_log)
-      call this%add_tracer_index('zoo13c',   'ciso', this%zoo13C_ind,   marbl_status_log)
-      call this%add_tracer_index('zoo14c',   'ciso', this%zoo14C_ind,   marbl_status_log)
+      call this%add_tracer_index('zoo13Ctot',   'ciso', this%zoo13Ctot_ind,   marbl_status_log)
+      call this%add_tracer_index('zoo14Ctot',   'ciso', this%zoo14Ctot_ind,   marbl_status_log)
 
       do n=1,autotroph_cnt
         write(ind_name, "(2A)") trim(autotrophs(n)%sname), "C13"


### PR DESCRIPTION
Also updated default_settings because this is NOT a per-zooplankton
tracer.

Note that this requires a POP update to handle the tracer name change:

```
$ svn diff
Index: bld/namelist_files/namelist_defaults_pop.xml
===================================================================
--- bld/namelist_files/namelist_defaults_pop.xml	(revision 88890)
+++ bld/namelist_files/namelist_defaults_pop.xml	(working copy)
@@ -1377,7 +1377,7 @@
 <ciso_tracer_init_ext(2)%file_varname>DOCtot</ciso_tracer_init_ext(2)%file_varname>
 <ciso_tracer_init_ext(2)%scale_factor>1.0</ciso_tracer_init_ext(2)%scale_factor>

-<ciso_tracer_init_ext(3)%mod_varname>zoo13C</ciso_tracer_init_ext(3)%mod_varname>
+<ciso_tracer_init_ext(3)%mod_varname>zoo13Ctot</ciso_tracer_init_ext(3)%mod_varname>
 <ciso_tracer_init_ext(3)%file_varname>zooC</ciso_tracer_init_ext(3)%file_varname>
 <ciso_tracer_init_ext(3)%scale_factor>1.0</ciso_tracer_init_ext(3)%scale_factor>

@@ -1389,7 +1389,7 @@
 <ciso_tracer_init_ext(5)%file_varname>DOCtot</ciso_tracer_init_ext(5)%file_varname>
 <ciso_tracer_init_ext(5)%scale_factor>1.0</ciso_tracer_init_ext(5)%scale_factor>

-<ciso_tracer_init_ext(6)%mod_varname>zoo14C</ciso_tracer_init_ext(6)%mod_varname>
+<ciso_tracer_init_ext(6)%mod_varname>zoo14Ctot</ciso_tracer_init_ext(6)%mod_varname>
 <ciso_tracer_init_ext(6)%file_varname>zooC</ciso_tracer_init_ext(6)%file_varname>
 <ciso_tracer_init_ext(6)%scale_factor>1.0</ciso_tracer_init_ext(6)%scale_factor>
```