### PR TITLE
updated default_settings values from jkmoore

### DIFF
--- a/autogenerated_src/default_settings.json
+++ b/autogenerated_src/default_settings.json
@@ -52,7 +52,7 @@
                "datatype": "real",
                "default_value": {
                   "((autotroph_sname)) == \"diat\"": 5,
-                  "((autotroph_sname)) == \"diaz\"": 2.2,
+                  "((autotroph_sname)) == \"diaz\"": 2.5,
                   "((autotroph_sname)) == \"sp\"": 5,
                   "default": "1e34"
                },
@@ -133,9 +133,9 @@
             "gQfe_min": {
                "datatype": "real",
                "default_value": {
-                  "((autotroph_sname)) == \"diat\"": "3e-6",
-                  "((autotroph_sname)) == \"diaz\"": "6e-6",
-                  "((autotroph_sname)) == \"sp\"": "3e-6",
+                  "((autotroph_sname)) == \"diat\"": 2.7e-06,
+                  "((autotroph_sname)) == \"diaz\"": 5.4e-06,
+                  "((autotroph_sname)) == \"sp\"": 2.7e-06,
                   "default": "1e34"
                },
                "longname": "Minimum Fe/C ratio for growth",
@@ -471,8 +471,8 @@
             "z_umax_0_per_day": {
                "datatype": "real",
                "default_value": {
-                  "((grazing_sname)) == \"diat_zoo\"": 3.05,
-                  "((grazing_sname)) == \"diaz_zoo\"": 3.1,
+                  "((grazing_sname)) == \"diat_zoo\"": 3.1,
+                  "((grazing_sname)) == \"diaz_zoo\"": 3.25,
                   "((grazing_sname)) == \"sp_zoo\"": 3.3,
                   "default": "1e34"
                },
@@ -899,7 +899,7 @@
       },
       "parm_FeLig_scavenge_rate0": {
          "datatype": "real",
-         "default_value": 1.3,
+         "default_value": 1.4,
          "longname": "Scavenging base rate for bound iron",
          "subcategory": "4. general parameters (scavenging)",
          "units": "unitless"
@@ -920,7 +920,7 @@
       },
       "parm_Fe_scavenge_rate0": {
          "datatype": "real",
-         "default_value": 15,
+         "default_value": 18.0,
          "longname": "Scavenging base rate for Fe",
          "subcategory": "4. general parameters (scavenging)",
          "units": "unitless"
@@ -1040,9 +1040,9 @@
             ],
             "default": [
                1,
-               2.2,
-               4,
-               5
+               3.0,
+               4.5,
+               5.5
             ]
          },
          "longname": "Prescribed scalelen values",

--- a/src/default_settings.yaml
+++ b/src/default_settings.yaml
@@ -352,7 +352,7 @@ general_parms :
       subcategory : 4. general parameters (scavenging)
       units : unitless
       datatype : real
-      default_value : 15
+      default_value : 18.0
    parm_Lig_scavenge_rate0 :
       longname : Scavenging base rate for bound ligand
       subcategory : 4. general parameters (scavenging)
@@ -364,7 +364,7 @@ general_parms :
       subcategory : 4. general parameters (scavenging)
       units : unitless
       datatype : real
-      default_value : 1.3
+      default_value : 1.4
    parm_Lig_degrade_rate0 :
       longname : Fe-binding ligand bacterial degradation base rate coefficient
       subcategory : 4. general parameters
@@ -437,9 +437,9 @@ general_parms :
       default_value :
          default :
             - 1
-            - 2.2
-            - 4
-            - 5
+            - 3.0
+            - 4.5
+            - 5.5
          GRID == "CESM_x3" :
             - 1
             - 3.3
@@ -676,9 +676,9 @@ PFT_derived_types :
             datatype : real
             default_value :
                default : 1e34
-               ((autotroph_sname)) == "sp" : 3e-6
-               ((autotroph_sname)) == "diat" : 3e-6
-               ((autotroph_sname)) == "diaz" : 6e-6
+               ((autotroph_sname)) == "sp" : 2.7e-6
+               ((autotroph_sname)) == "diat" : 2.7e-6
+               ((autotroph_sname)) == "diaz" : 5.4e-6
          alphaPI_per_day :
             longname : Initial slope of P_I curve (GD98)
             subcategory : 10. autotrophs
@@ -698,7 +698,7 @@ PFT_derived_types :
                default : 1e34
                ((autotroph_sname)) == "sp" : 5
                ((autotroph_sname)) == "diat" : 5
-               ((autotroph_sname)) == "diaz" : 2.2
+               ((autotroph_sname)) == "diaz" : 2.5
          thetaN_max :
             longname : Maximum thetaN (Chl / N)
             subcategory : 10. autotrophs
@@ -892,8 +892,8 @@ PFT_derived_types :
             default_value :
                default : 1e34
                ((grazing_sname)) == "sp_zoo" : 3.3
-               ((grazing_sname)) == "diat_zoo" : 3.05
-               ((grazing_sname)) == "diaz_zoo" : 3.1
+               ((grazing_sname)) == "diat_zoo" : 3.1
+               ((grazing_sname)) == "diaz_zoo" : 3.25
          z_grz :
             longname : Grazing coefficient
             subcategory : 12. grazing

--- a/src/marbl_pft_mod.F90
+++ b/src/marbl_pft_mod.F90
@@ -221,7 +221,7 @@ contains
         self%kSiO3           = 0.0_r8            ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE in marbl_settings_mod
         self%Qp_fixed        =  Qp_zoo           ! only used for lvariable_PtoC=.false.
         self%gQfe_0          = 35.0e-6_r8
-        self%gQfe_min        = 3.0e-6_r8
+        self%gQfe_min        = 2.7e-6_r8
         self%alphaPI_per_day = 0.39_r8
         self%PCref_per_day   = 5.0_r8
         self%thetaN_max      = 2.5_r8
@@ -248,7 +248,7 @@ contains
         self%kSiO3           = 0.7_r8            ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE in marbl_settings_mod
         self%Qp_fixed        =  Qp_zoo           ! only used for lvariable_PtoC=.false.
         self%gQfe_0          = 35.0e-6_r8
-        self%gQfe_min        = 3.0e-6_r8
+        self%gQfe_min        = 2.7e-6_r8
         self%alphaPI_per_day = 0.29_r8
         self%PCref_per_day   = 5.0_r8
         self%thetaN_max      = 4.0_r8
@@ -275,9 +275,9 @@ contains
         self%kSiO3           = 0.0_r8            ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE in marbl_settings_mod
         self%Qp_fixed        = 0.32_r8 * Qp_zoo  ! only used for lvariable_PtoC=.false.
         self%gQfe_0          = 70.0e-6_r8
-        self%gQfe_min        = 6.0e-6_r8
+        self%gQfe_min        = 5.4e-6_r8
         self%alphaPI_per_day = 0.39_r8
-        self%PCref_per_day   = 2.2_r8
+        self%PCref_per_day   = 2.5_r8
         self%thetaN_max      = 2.5_r8
         self%loss_thres      = 0.02_r8
         self%loss_thres2     = 0.001_r8
@@ -384,7 +384,7 @@ contains
         self%lname = 'Grazing of diat by zoo'             ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE in marbl_settings_mod
         self%auto_ind_cnt = 1                             ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE in marbl_settings_mod
         self%zoo_ind_cnt = 0                              ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE in marbl_settings_mod
-        self%z_umax_0_per_day = 3.05_r8                   ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE in marbl_settings_mod
+        self%z_umax_0_per_day = 3.1_r8                    ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE in marbl_settings_mod
         self%z_grz            = 1.2_r8                    ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE in marbl_settings_mod
         self%graze_zoo        = 0.25_r8                   ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE in marbl_settings_mod
         self%graze_poc        = 0.38_r8                   ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE in marbl_settings_mod
@@ -397,7 +397,7 @@ contains
         self%lname = 'Grazing of diaz by zoo'             ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE in marbl_settings_mod
         self%auto_ind_cnt = 1                             ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE in marbl_settings_mod
         self%zoo_ind_cnt = 0                              ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE in marbl_settings_mod
-        self%z_umax_0_per_day = 3.1_r8                    ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE in marbl_settings_mod
+        self%z_umax_0_per_day = 3.25_r8                   ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE in marbl_settings_mod
         self%z_grz            = 1.2_r8                    ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE in marbl_settings_mod
         self%graze_zoo        = 0.3_r8                    ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE in marbl_settings_mod
         self%graze_poc        = 0.1_r8                    ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE in marbl_settings_mod

--- a/src/marbl_settings_mod.F90
+++ b/src/marbl_settings_mod.F90
@@ -365,9 +365,9 @@ contains
     parm_init_POC_bury_coeff      = 1.1_r8          ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
     parm_init_POP_bury_coeff      = 1.1_r8          ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
     parm_init_bSi_bury_coeff      = 1.0_r8          ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
-    parm_Fe_scavenge_rate0        = 15.0_r8         ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
+    parm_Fe_scavenge_rate0        = 18.0_r8         ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
     parm_Lig_scavenge_rate0       = 0.015_r8        ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
-    parm_FeLig_scavenge_rate0     = 1.3_r8          ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
+    parm_FeLig_scavenge_rate0     = 1.4_r8          ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
     parm_Lig_degrade_rate0        = 0.000094_r8     ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
     parm_Fe_desorption_rate0      = 1.0e-6_r8       ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
     parm_f_prod_sp_CaCO3          = 0.070_r8        ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
@@ -377,7 +377,7 @@ contains
     parm_sed_denitrif_coeff       = 1.0_r8          ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
     bury_coeff_rmean_timescale_years = 10.0_r8      ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
     parm_scalelen_z    = (/ 100.0e2_r8, 250.0e2_r8, 500.0e2_r8, 1000.0e2_r8 /)  ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
-    parm_scalelen_vals = (/     1.0_r8,     2.2_r8,     4.0_r8,      5.0_r8 /)  ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
+    parm_scalelen_vals = (/     1.0_r8,     3.0_r8,     4.5_r8,      5.5_r8 /)  ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
 
     caco3_bury_thres_opt   = 'omega_calc'           ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
     caco3_bury_thres_depth = 3000.0e2               ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above


### PR DESCRIPTION
fix for #253 

Testing:
marbl_dev_klindsay_n117_marbl_dev_n80_cesm_pop_2_1_20180205

aux_pop_MARBL cheyenne/{intel,gnu}: (baseline comparison to MARBL master)
   except for tests mentioned below, all tests pass
      NLCOMP failed for all tests because of settings changes
      BASELINE failed for all tests because of settings changes
      some MEMCOMP failures

Files Modified:
	modified:   autogenerated_src/default_settings.json
	modified:   src/default_settings.yaml
	modified:   src/marbl_pft_mod.F90
	modified:   src/marbl_settings_mod.F90