### PR TITLE
POP%prod should be non-negative

### DIFF
--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -3975,7 +3975,7 @@ contains
 
     POP%prod(k) = Qp_zoo * (sum(zoo_loss_poc(:)) + sum(zoo_graze_poc(:))) + sum(remaining_P_pop(:))
 
-    if (POC%prod(k) <= c0) POP%prod(k) = c0
+    if (POP%prod(k) < c0) POP%prod(k) = c0
 
     !-----------------------------------------------------------------------
     !  large detrital CaCO3


### PR DESCRIPTION
It was inadvertently set to zero when POC%prod was not positive. Testing
seems to show that the cases where POC%prod <= 0 and POP%prod > 0 were
rare, because CESM tests are remaining bit-for-bit with this change.

Fixes #241