### PR TITLE
Bugfix/240

### DIFF
--- a/autogenerated_src/default_diagnostics.json
+++ b/autogenerated_src/default_diagnostics.json
@@ -920,22 +920,22 @@
       "units": "mmol/m^3 cm/s",
       "vertical_grid": "none"
    },
-   "CISO_zooC_d13C": {
+   "CISO_zoototC_d13C": {
       "dependencies": {
          "ciso_on": ".true."
       },
       "frequency": "medium",
-      "longname": "d13C of zooC",
+      "longname": "d13C of total zooC",
       "operator": "average",
       "units": "permil",
       "vertical_grid": "layer_avg"
    },
-   "CISO_zooC_d14C": {
+   "CISO_zoototC_d14C": {
       "dependencies": {
          "ciso_on": ".true."
       },
       "frequency": "medium",
-      "longname": "d14C of zooC",
+      "longname": "d14C of total zooC",
       "operator": "average",
       "units": "permil",
       "vertical_grid": "layer_avg"

--- a/autogenerated_src/default_settings.json
+++ b/autogenerated_src/default_settings.json
@@ -730,14 +730,14 @@
          "long_name": "Dissolved Inorganic Silicate",
          "units": "mmol/m^3"
       },
-      "zoo13Ctot": {
+      "zootot13C": {
          "dependencies": {
             "ciso_on": ".true."
          },
          "long_name": "Zooplankton Carbon-13 (sum over all zooplankton)",
          "units": "mmol/m^3"
       },
-      "zoo14Ctot": {
+      "zootot14C": {
          "dependencies": {
             "ciso_on": ".true."
          },

--- a/src/default_diagnostics.yaml
+++ b/src/default_diagnostics.yaml
@@ -1164,10 +1164,10 @@ CISO_DOCtot_d13C :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
-CISO_zooC_d13C :
+CISO_zoototC_d13C :
    dependencies :
       ciso_on : .true.
-   longname : d13C of zooC
+   longname : d13C of total zooC
    units : permil
    vertical_grid : layer_avg
    frequency : medium
@@ -1260,10 +1260,10 @@ CISO_DOCtot_d14C :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
-CISO_zooC_d14C :
+CISO_zoototC_d14C :
    dependencies :
       ciso_on : .true.
-   longname : d14C of zooC
+   longname : d14C of total zooC
    units : permil
    vertical_grid : layer_avg
    frequency : medium

--- a/src/default_settings.yaml
+++ b/src/default_settings.yaml
@@ -176,13 +176,13 @@ _tracer_list :
    ((zooplankton_sname))C :
       long_name : ((zooplankton_lname)) Carbon
       units : mmol/m^3
-   # Per-zooplankton (ciso only)
-   zoo13Ctot :
+   # Total zooplankton tracers (ciso only)
+   zootot13C :
       dependencies :
          ciso_on : .true.
       long_name : Zooplankton Carbon-13 (sum over all zooplankton)
       units : mmol/m^3
-   zoo14Ctot :
+   zootot14C :
       dependencies :
          ciso_on : .true.
       long_name : Zooplankton Carbon-14 (sum over all zooplankton)

--- a/src/marbl_ciso_mod.F90
+++ b/src/marbl_ciso_mod.F90
@@ -389,6 +389,12 @@ contains
          zoo_loss_poc       => marbl_zooplankton_share%zoo_loss_poc_fields     , & ! INPUT zoo_loss routed to large detrital pool (mmol C/m^3/sec)
          zoo_loss_doc       => marbl_zooplankton_share%zoo_loss_doc_fields     , & ! INPUT zoo_loss routed to doc (mmol C/m^3/sec)
          zoo_loss_dic       => marbl_zooplankton_share%zoo_loss_dic_fields     , & ! INPUT zoo_loss routed to dic (mmol C/m^3/sec)
+         x_graze_zoo        => marbl_zooplankton_share%x_graze_zoo_fields      , & ! INPUT {auto, zoo}_graze routed to zoo (mmol C/m^3/sec)
+         zoo_graze          => marbl_zooplankton_share%zoo_graze_fields        , & ! INPUT zooplankton losses due to grazing (mmol C/m^3/sec)
+         zoo_graze_zoo      => marbl_zooplankton_share%zoo_graze_zoo_fields    , & ! INPUT grazing of zooplankton routed to zoo (mmol C/m^3/sec)
+         zoo_graze_poc      => marbl_zooplankton_share%zoo_graze_poc_fields    , & ! INPUT grazing of zooplankton routed to poc (mmol C/m^3/sec)
+         zoo_graze_doc      => marbl_zooplankton_share%zoo_graze_doc_fields    , & ! INPUT grazing of zooplankton routed to doc (mmol C/m^3/sec)
+         zoo_graze_dic      => marbl_zooplankton_share%zoo_graze_dic_fields    , & ! INPUT grazing of zooplankton routed to dic (mmol C/m^3/sec)
 
          POC                => marbl_particulate_share%POC                     , & ! INPUT
          P_CaCO3            => marbl_particulate_share%P_CaCO3                 , & ! INPUT

--- a/src/marbl_ciso_mod.F90
+++ b/src/marbl_ciso_mod.F90
@@ -486,12 +486,14 @@ contains
              R14C_autotroph(auto_ind,k) = c0
           end if
 
-          if (autotroph_local(auto_ind,k)%CaCO3 > c0) then
-             R13C_autotrophCaCO3(auto_ind,k) = autotroph_local(auto_ind,k)%Ca13CO3 / autotroph_local(auto_ind,k)%CaCO3
-             R14C_autotrophCaCO3(auto_ind,k) = autotroph_local(auto_ind,k)%Ca14CO3 / autotroph_local(auto_ind,k)%CaCO3
-          else
-             R13C_autotrophCaCO3(auto_ind,k) = c0
-             R14C_autotrophCaCO3(auto_ind,k) = c0
+          if (marbl_tracer_indices%auto_inds(auto_ind)%CaCO3_ind > 0) then
+             if (autotroph_local(auto_ind,k)%CaCO3 > c0) then
+                R13C_autotrophCaCO3(auto_ind,k) = autotroph_local(auto_ind,k)%Ca13CO3 / autotroph_local(auto_ind,k)%CaCO3
+                R14C_autotrophCaCO3(auto_ind,k) = autotroph_local(auto_ind,k)%Ca14CO3 / autotroph_local(auto_ind,k)%CaCO3
+             else
+                R13C_autotrophCaCO3(auto_ind,k) = c0
+                R14C_autotrophCaCO3(auto_ind,k) = c0
+             end if
           end if
        end do
 

--- a/src/marbl_ciso_mod.F90
+++ b/src/marbl_ciso_mod.F90
@@ -691,11 +691,11 @@ contains
        !-----------------------------------------------------------------------
 
        DO13Ctot_prod(k) = &
-            sum(zoo_loss_doc(:,k),dim=1)*R13C_zooC(k) + &
+            sum(zoo_loss_doc(:,k) + zoo_graze_doc(:,k),dim=1)*R13C_zooC(k) + &
             sum((auto_loss_doc(:,k) + auto_graze_doc(:,k)) * R13C_autotroph(:,k),dim=1)
 
        DO14Ctot_prod(k) = &
-            sum(zoo_loss_doc(:,k),dim=1)*R14C_zooC(k) + &
+            sum(zoo_loss_doc(:,k) + zoo_graze_doc(:,k),dim=1)*R14C_zooC(k) + &
             sum((auto_loss_doc(:,k) + auto_graze_doc(:,k)) * R14C_autotroph(:,k),dim=1)
 
        DO13Ctot_remin(k) = DOCtot_remin(k) * R13C_DOCtot(k)
@@ -706,11 +706,11 @@ contains
        !-----------------------------------------------------------------------
 
        PO13C%prod(k) = &
-            sum(zoo_loss_poc(:,k),dim=1)*R13C_zooC(k) + &
+            sum(zoo_loss_poc(:,k) + zoo_graze_poc(:,k),dim=1)*R13C_zooC(k) + &
             sum((auto_graze_poc(:,k) + auto_agg(:,k) + auto_loss_poc(:,k)) * R13C_autotroph(:,k),dim=1)
 
        PO14C%prod(k) = &
-            sum(zoo_loss_poc(:,k),dim=1)*R14C_zooC(k) + &
+            sum(zoo_loss_poc(:,k) + zoo_graze_poc(:,k),dim=1)*R14C_zooC(k) + &
             sum((auto_graze_poc(:,k) + auto_agg(:,k) + auto_loss_poc(:,k)) * R14C_autotroph(:,k),dim=1)
 
        !-----------------------------------------------------------------------
@@ -804,12 +804,13 @@ contains
 
        column_dtracer(zoo13Ctot_ind,k) = &
               sum(auto_graze_zoo(:,k) * R13C_autotroph(:,k),dim=1) &
-            - sum(zoo_loss(:,k),dim=1) * R13C_zooC(k)
+            + sum(zoo_graze_zoo(:,k) - zoo_graze(:,k) - zoo_loss(:,k),dim=1) &
+            * R13C_zooC(k)
 
        column_dtracer(zoo14Ctot_ind,k) = &
               sum(auto_graze_zoo(:,k) * R14C_autotroph(:,k),dim=1) &
-            - sum(zoo_loss(:,k),dim=1) * R14C_zooC(k) &
-            - c14_lambda_inv_sec * zoo14Ctot_loc(k)
+            + sum(zoo_graze_zoo(:,k) - zoo_graze(:,k) - zoo_loss(:,k),dim=1) &
+            * R14C_zooC(k) - c14_lambda_inv_sec * zoo14Ctot_loc(k)
 
        decay_14Ctot(k) = decay_14Ctot(k) + c14_lambda_inv_sec * zoo14Ctot_loc(k)
 
@@ -831,14 +832,14 @@ contains
             sum( (auto_loss_dic(:,k) + auto_graze_dic(:,k)) * R13C_autotroph(:,k), dim=1 ) &
           - sum(photo13C(:,k),dim=1)                                                       &
           + DO13Ctot_remin(k) + PO13C%remin(k)                                             &
-          + sum(zoo_loss_dic(:,k),dim=1) * R13C_zooC(k)                                    &
+          + sum(zoo_loss_dic(:,k) + zoo_graze_dic(:,k),dim=1) * R13C_zooC(k)               &
           + P_Ca13CO3%remin(k)
 
        column_dtracer(di14c_ind,k) =                                                       &
             sum( (auto_loss_dic(:,k) + auto_graze_dic(:,k)) * R14C_autotroph(:,k), dim=1 ) &
           - sum(photo14C(:,k),dim=1)                                                       &
           + DO14Ctot_remin(k) + PO14C%remin(k)                                             &
-          + sum(zoo_loss_dic(:,k),dim=1) * R14C_zooC(k)                                    &
+          + sum(zoo_loss_dic(:,k) + zoo_graze_dic(:,k),dim=1) * R14C_zooC(k)               &
           + P_Ca14CO3%remin(k)                                                             &
           - c14_lambda_inv_sec * DI14C_loc(k)
 

--- a/src/marbl_ciso_mod.F90
+++ b/src/marbl_ciso_mod.F90
@@ -348,7 +348,7 @@ contains
          H2CO3              => marbl_interior_share%H2CO3_fields               , & ! INPUT carbonic acid
          DOCtot_remin       => marbl_interior_share%DOCtot_remin_fields        , & ! INPUT remineralization of DOCtot (mmol C/m^3/sec)
          DOCtot_loc         => marbl_interior_share%DOCtot_loc_fields          , & ! INPUT local copy of model DOCtot
-         DO13Ctot_loc       => tracer_local(marbl_tracer_indices%DO14Ctot_ind,:) , & ! local copy of model DO14Ctot
+         DO13Ctot_loc       => tracer_local(marbl_tracer_indices%DO13Ctot_ind,:) , & ! local copy of model DO14Ctot
          DO14Ctot_loc       => tracer_local(marbl_tracer_indices%DO14Ctot_ind,:) , & ! local copy of model DO14Ctot
          DIC_loc            => tracer_local(marbl_tracer_indices%DIC_ind,:)    , & ! INPUT local copy of model DIC
          DI13C_loc          => tracer_local(marbl_tracer_indices%DI13C_ind,:)    , & ! local copy of model DI13C

--- a/src/marbl_ciso_mod.F90
+++ b/src/marbl_ciso_mod.F90
@@ -372,7 +372,7 @@ contains
 
          autotrophCaCO3_loc => marbl_autotroph_share%autotrophCaCO3_loc_fields , & ! INPUT local copy of model autotroph CaCO3
          autotrophC_loc     => marbl_autotroph_share%autotrophC_loc_fields     , & ! INPUT local copy of model autotroph C
-         QCaCO3             => marbl_autotroph_share%QCaCO3_fields             , & ! INPUT small phyto CaCO3/C ratio (mmol CaCO3/mmol C)
+         QCaCO3             => autotroph_secondary_species%QCaCO3              , & ! INPUT small phyto CaCO3/C ratio (mmol CaCO3/mmol C)
          auto_graze         => autotroph_secondary_species%auto_graze          , & ! INPUT autotroph grazing rate (mmol C/m^3/sec)
          auto_graze_zoo     => autotroph_secondary_species%auto_graze_zoo      , & ! INPUT auto_graze routed to zoo (mmol C/m^3/sec)
          auto_graze_poc     => autotroph_secondary_species%auto_graze_poc      , & ! INPUT auto_graze routed to poc (mmol C/m^3/sec)
@@ -382,10 +382,10 @@ contains
          auto_loss_poc      => autotroph_secondary_species%auto_loss_poc       , & ! INPUT auto_loss routed to poc (mmol C/m^3/sec)
          auto_loss_doc      => autotroph_secondary_species%auto_loss_doc       , & ! INPUT auto_loss routed to doc (mmol C/m^3/sec)
          auto_loss_dic      => autotroph_secondary_species%auto_loss_dic       , & ! INPUT auto_loss routed to dic (mmol C/m^3/sec)
-         auto_agg           => marbl_autotroph_share%auto_agg_fields           , & ! INPUT autotroph aggregation (mmol C/m^3/sec)
-         photoC             => marbl_autotroph_share%photoC_fields             , & ! INPUT C-fixation (mmol C/m^3/sec)
-         CaCO3_form         => marbl_autotroph_share%CaCO3_form_fields         , & ! INPUT prod. of CaCO3 by small phyto (mmol CaCO3/m^3/sec)
-         PCphoto            => marbl_autotroph_share%PCphoto_fields            , & ! INPUT C-specific rate of photosynth. (1/sec)
+         auto_agg           => autotroph_secondary_species%auto_agg            , & ! INPUT autotroph aggregation (mmol C/m^3/sec)
+         photoC             => autotroph_secondary_species%photoC              , & ! INPUT C-fixation (mmol C/m^3/sec)
+         CaCO3_form         => autotroph_secondary_species%CaCO3_form          , & ! INPUT prod. of CaCO3 by small phyto (mmol CaCO3/m^3/sec)
+         PCphoto            => autotroph_secondary_species%PCphoto             , & ! INPUT C-specific rate of photosynth. (1/sec)
 
          zooC_loc           => marbl_zooplankton_share%zooC_loc_fields         , & ! INPUT local copy of model zooC
          zoo_loss           => marbl_zooplankton_share%zoo_loss_fields         , & ! INPUT mortality & higher trophic grazing on zooplankton (mmol C/m^3/sec)

--- a/src/marbl_ciso_mod.F90
+++ b/src/marbl_ciso_mod.F90
@@ -121,10 +121,10 @@ contains
 
     associate(di13c_ind         => marbl_tracer_indices%di13c_ind,            &
               do13ctot_ind      => marbl_tracer_indices%do13ctot_ind,         &
-              zoo13Ctot_ind     => marbl_tracer_indices%zoo13Ctot_ind,        &
+              zootot13C_ind     => marbl_tracer_indices%zootot13C_ind,        &
               di14c_ind         => marbl_tracer_indices%di14c_ind,            &
               do14ctot_ind      => marbl_tracer_indices%do14ctot_ind,         &
-              zoo14Ctot_ind     => marbl_tracer_indices%zoo14Ctot_ind,        &
+              zootot14C_ind     => marbl_tracer_indices%zootot14C_ind,        &
               ciso_ind_beg      => marbl_tracer_indices%ciso%ind_beg,         &
               ciso_ind_end      => marbl_tracer_indices%ciso%ind_end          &
              )
@@ -143,8 +143,8 @@ contains
     marbl_tracer_metadata(do13ctot_ind)%short_name='DO13Ctot'
     marbl_tracer_metadata(do13ctot_ind)%long_name='Dissolved Organic Carbon-13 (semi-labile+refractory)'
 
-    marbl_tracer_metadata(zoo13Ctot_ind)%short_name='zoo13Ctot'
-    marbl_tracer_metadata(zoo13Ctot_ind)%long_name='Zooplankton Carbon-13 (sum over all zooplankton)'
+    marbl_tracer_metadata(zootot13C_ind)%short_name='zootot13C'
+    marbl_tracer_metadata(zootot13C_ind)%long_name='Zooplankton Carbon-13 (sum over all zooplankton)'
 
     marbl_tracer_metadata(di14c_ind)%short_name='DI14C'
     marbl_tracer_metadata(di14c_ind)%long_name='Dissolved Inorganic Carbon-14'
@@ -152,8 +152,8 @@ contains
     marbl_tracer_metadata(do14ctot_ind)%short_name='DO14Ctot'
     marbl_tracer_metadata(do14ctot_ind)%long_name='Dissolved Organic Carbon-14 (semi-labile+refractory)'
 
-    marbl_tracer_metadata(zoo14Ctot_ind)%short_name='zoo14Ctot'
-    marbl_tracer_metadata(zoo14Ctot_ind)%long_name='Zooplankton Carbon-14 (sum over all zooplankton)'
+    marbl_tracer_metadata(zootot14C_ind)%short_name='zootot14C'
+    marbl_tracer_metadata(zootot14C_ind)%long_name='Zooplankton Carbon-14 (sum over all zooplankton)'
 
     !-----------------------------------------------------------------------
     !  initialize autotroph tracer_d values and tracer indices
@@ -185,8 +185,8 @@ contains
     !  set lfull_depth_tavg flag for short-lived ecosystem tracers
     !-----------------------------------------------------------------------
 
-    marbl_tracer_metadata(zoo13Ctot_ind)%lfull_depth_tavg = ciso_lecovars_full_depth_tavg
-    marbl_tracer_metadata(zoo14Ctot_ind)%lfull_depth_tavg = ciso_lecovars_full_depth_tavg
+    marbl_tracer_metadata(zootot13C_ind)%lfull_depth_tavg = ciso_lecovars_full_depth_tavg
+    marbl_tracer_metadata(zootot14C_ind)%lfull_depth_tavg = ciso_lecovars_full_depth_tavg
 
     do auto_ind = 1, autotroph_cnt
        n = marbl_tracer_indices%auto_inds(auto_ind)%C13_ind
@@ -294,10 +294,10 @@ contains
     real (r8), dimension (marbl_domain%km) :: &
          DO13Ctot_loc,      & ! local copy of model DO13Ctot
          DI13C_loc,         & ! local copy of model DI13C
-         zoo13Ctot_loc,     & ! local copy of model zoo13Ctot
+         zootot13C_loc,     & ! local copy of model zootot13C
          DO14Ctot_loc,      & ! local copy of model DO14Ctot
          DI14C_loc,         & ! local copy of model DI14C
-         zoo14Ctot_loc        ! local copy of model zoo14Ctot
+         zootot14C_loc        ! local copy of model zootot14C
 
     real (r8), dimension(marbl_domain%km) :: &
          mui_to_co2star_loc     ! local carbon autotroph instanteous growth rate over [CO2*] (m^3 /mol C /s)
@@ -403,10 +403,10 @@ contains
 
          di13c_ind          => marbl_tracer_indices%di13c_ind                  , &
          do13ctot_ind       => marbl_tracer_indices%do13ctot_ind               , &
-         zoo13Ctot_ind      => marbl_tracer_indices%zoo13Ctot_ind              , &
+         zootot13C_ind      => marbl_tracer_indices%zootot13C_ind              , &
          di14c_ind          => marbl_tracer_indices%di14c_ind                  , &
          do14ctot_ind       => marbl_tracer_indices%do14ctot_ind               , &
-         zoo14Ctot_ind      => marbl_tracer_indices%zoo14Ctot_ind                &
+         zootot14C_ind      => marbl_tracer_indices%zootot14C_ind                &
          )
 
     !-----------------------------------------------------------------------
@@ -442,8 +442,8 @@ contains
     !-----------------------------------------------------------------------
 
     call setup_local_column_tracers(column_km, column_kmt, column_tracer, &
-           marbl_tracer_indices, DI13C_loc, DO13Ctot_loc, zoo13Ctot_loc, DI14C_loc, &
-           DO14Ctot_loc, zoo14Ctot_loc)
+           marbl_tracer_indices, DI13C_loc, DO13Ctot_loc, zootot13C_loc, DI14C_loc, &
+           DO14Ctot_loc, zootot14C_loc)
 
     !-----------------------------------------------------------------------
     !  Create local copies of model column autotrophs, treat negative values as zero
@@ -497,8 +497,8 @@ contains
        end if
 
        if (zooC_loc(k) > c0) then
-          R13C_zooC(k) = zoo13Ctot_loc(k) / zooC_loc(k)
-          R14C_zooC(k) = zoo14Ctot_loc(k) / zooC_loc(k)
+          R13C_zooC(k) = zootot13C_loc(k) / zooC_loc(k)
+          R14C_zooC(k) = zootot14C_loc(k) / zooC_loc(k)
        else
           R13C_zooC(k) = c0
           R14C_zooC(k) = c0
@@ -803,17 +803,17 @@ contains
        !  column_dtracer: zoo 13 and 14 Carbon
        !-----------------------------------------------------------------------
 
-       column_dtracer(zoo13Ctot_ind,k) = &
+       column_dtracer(zootot13C_ind,k) = &
               sum(auto_graze_zoo(:,k) * R13C_autotroph(:,k),dim=1) &
             + (zoo_graze_zoo(k) - zoo_graze(k) - zoo_loss(k)) &
             * R13C_zooC(k)
 
-       column_dtracer(zoo14Ctot_ind,k) = &
+       column_dtracer(zootot14C_ind,k) = &
               sum(auto_graze_zoo(:,k) * R14C_autotroph(:,k),dim=1) &
             + (zoo_graze_zoo(k) - zoo_graze(k) - zoo_loss(k)) &
-            * R14C_zooC(k) - c14_lambda_inv_sec * zoo14Ctot_loc(k)
+            * R14C_zooC(k) - c14_lambda_inv_sec * zootot14C_loc(k)
 
-       decay_14Ctot(k) = decay_14Ctot(k) + c14_lambda_inv_sec * zoo14Ctot_loc(k)
+       decay_14Ctot(k) = decay_14Ctot(k) + c14_lambda_inv_sec * zootot14C_loc(k)
 
        !-----------------------------------------------------------------------
        !  column_dtracer: dissolved organic Matter 13C and 14C
@@ -1036,8 +1036,8 @@ contains
   !***********************************************************************
 
   subroutine setup_local_column_tracers(column_km, column_kmt, column_tracer, &
-           marbl_tracer_indices, DI13C_loc, DO13Ctot_loc, zoo13Ctot_loc, DI14C_loc, &
-           DO14Ctot_loc, zoo14Ctot_loc)
+           marbl_tracer_indices, DI13C_loc, DO13Ctot_loc, zootot13C_loc, DI14C_loc, &
+           DO14Ctot_loc, zootot14C_loc)
 
     !-----------------------------------------------------------------------
     !  create local copies of model column_tracer
@@ -1053,10 +1053,10 @@ contains
 
     real (r8)         , intent(out) :: DI13C_loc(:)     ! (km) local copy of model DI13C
     real (r8)         , intent(out) :: DO13Ctot_loc(:)  ! (km) local copy of model DO13Ctot
-    real (r8)         , intent(out) :: zoo13Ctot_loc(:) ! (km) local copy of model zoo13Ctot
+    real (r8)         , intent(out) :: zootot13C_loc(:) ! (km) local copy of model zootot13C
     real (r8)         , intent(out) :: DI14C_loc(:)     ! (km) local copy of model DI14C
     real (r8)         , intent(out) :: DO14Ctot_loc(:)  ! (km) local copy of model DO14Ctot
-    real (r8)         , intent(out) :: zoo14Ctot_loc(:) ! (km) local copy of model zoo14Ctot
+    real (r8)         , intent(out) :: zootot14C_loc(:) ! (km) local copy of model zootot14C
     !-----------------------------------------------------------------------
     !  local variables
     !-----------------------------------------------------------------------
@@ -1065,10 +1065,10 @@ contains
 
     associate(di13c_ind     => marbl_tracer_indices%di13c_ind,                   &
               do13ctot_ind  => marbl_tracer_indices%do13ctot_ind,                &
-              zoo13Ctot_ind => marbl_tracer_indices%zoo13Ctot_ind,               &
+              zootot13C_ind => marbl_tracer_indices%zootot13C_ind,               &
               di14c_ind     => marbl_tracer_indices%di14c_ind,                   &
               do14ctot_ind  => marbl_tracer_indices%do14ctot_ind,                &
-              zoo14Ctot_ind => marbl_tracer_indices%zoo14Ctot_ind)
+              zootot14C_ind => marbl_tracer_indices%zootot14C_ind)
     do k = 1,column_kmt
        DI13C_loc(k) = max(c0, column_tracer(di13c_ind,k))
        DI14C_loc(k) = max(c0, column_tracer(di14c_ind,k))
@@ -1076,8 +1076,8 @@ contains
        DO13Ctot_loc(k) = max(c0, column_tracer(do13ctot_ind,k))
        DO14Ctot_loc(k) = max(c0, column_tracer(do14ctot_ind,k))
 
-       zoo13Ctot_loc(k) = max(c0, column_tracer(zoo13Ctot_ind,k))
-       zoo14Ctot_loc(k) = max(c0, column_tracer(zoo14Ctot_ind,k))
+       zootot13C_loc(k) = max(c0, column_tracer(zootot13C_ind,k))
+       zootot14C_loc(k) = max(c0, column_tracer(zootot14C_ind,k))
     end do
 
     do k = column_kmt+1, column_km
@@ -1087,8 +1087,8 @@ contains
        DO13Ctot_loc(k) = c0
        DO14Ctot_loc(k) = c0
 
-       zoo13Ctot_loc(k) = c0
-       zoo14Ctot_loc(k) = c0
+       zootot13C_loc(k) = c0
+       zootot14C_loc(k) = c0
     end do
     end associate
 

--- a/src/marbl_ciso_mod.F90
+++ b/src/marbl_ciso_mod.F90
@@ -351,10 +351,10 @@ contains
          delta_C14_CO2STAR, & ! deltaC14 of CO2*
          DIC_d13C,          & ! d13C of DIC
          DOCtot_d13C,       & ! d13C of DOCtot
-         zooC_d13C,         & ! d13C of zooC
+         zoototC_d13C,      & ! d13C of zooC
          DIC_d14C,          & ! d14C of DIC
          DOCtot_d14C,       & ! d14C of DOCtot
-         zooC_d14C,         & ! d14C of zooC
+         zoototC_d14C,      & ! d14C of zooC
          decay_14Ctot         ! 14C decay loss term
 
     !-------------------------------------------------------------
@@ -387,16 +387,16 @@ contains
          CaCO3_form         => autotroph_secondary_species%CaCO3_form          , & ! INPUT prod. of CaCO3 by small phyto (mmol CaCO3/m^3/sec)
          PCphoto            => autotroph_secondary_species%PCphoto             , & ! INPUT C-specific rate of photosynth. (1/sec)
 
-         zooC_loc           => marbl_zooplankton_share%zooC_loc_fields         , & ! INPUT local copy of model zooC
-         zoo_loss           => marbl_zooplankton_share%zoo_loss_fields         , & ! INPUT mortality & higher trophic grazing on zooplankton (mmol C/m^3/sec)
-         zoo_loss_poc       => marbl_zooplankton_share%zoo_loss_poc_fields     , & ! INPUT zoo_loss routed to large detrital pool (mmol C/m^3/sec)
-         zoo_loss_doc       => marbl_zooplankton_share%zoo_loss_doc_fields     , & ! INPUT zoo_loss routed to doc (mmol C/m^3/sec)
-         zoo_loss_dic       => marbl_zooplankton_share%zoo_loss_dic_fields     , & ! INPUT zoo_loss routed to dic (mmol C/m^3/sec)
-         zoo_graze          => marbl_zooplankton_share%zoo_graze_fields        , & ! INPUT zooplankton losses due to grazing (mmol C/m^3/sec)
-         zoo_graze_zoo      => marbl_zooplankton_share%zoo_graze_zoo_fields    , & ! INPUT grazing of zooplankton routed to zoo (mmol C/m^3/sec)
-         zoo_graze_poc      => marbl_zooplankton_share%zoo_graze_poc_fields    , & ! INPUT grazing of zooplankton routed to poc (mmol C/m^3/sec)
-         zoo_graze_doc      => marbl_zooplankton_share%zoo_graze_doc_fields    , & ! INPUT grazing of zooplankton routed to doc (mmol C/m^3/sec)
-         zoo_graze_dic      => marbl_zooplankton_share%zoo_graze_dic_fields    , & ! INPUT grazing of zooplankton routed to dic (mmol C/m^3/sec)
+         zoototC_loc        => marbl_zooplankton_share%zoototC_loc_fields      , & ! INPUT local copy of model zooC
+         zootot_loss        => marbl_zooplankton_share%zootot_loss_fields      , & ! INPUT mortality & higher trophic grazing on zooplankton (mmol C/m^3/sec)
+         zootot_loss_poc    => marbl_zooplankton_share%zootot_loss_poc_fields  , & ! INPUT zootot_loss routed to large detrital pool (mmol C/m^3/sec)
+         zootot_loss_doc    => marbl_zooplankton_share%zootot_loss_doc_fields  , & ! INPUT zootot_loss routed to doc (mmol C/m^3/sec)
+         zootot_loss_dic    => marbl_zooplankton_share%zootot_loss_dic_fields  , & ! INPUT zootot_loss routed to dic (mmol C/m^3/sec)
+         zootot_graze       => marbl_zooplankton_share%zootot_graze_fields     , & ! INPUT zooplankton losses due to grazing (mmol C/m^3/sec)
+         zootot_graze_zoo   => marbl_zooplankton_share%zootot_graze_zoo_fields , & ! INPUT grazing of zooplankton routed to zoo (mmol C/m^3/sec)
+         zootot_graze_poc   => marbl_zooplankton_share%zootot_graze_poc_fields , & ! INPUT grazing of zooplankton routed to poc (mmol C/m^3/sec)
+         zootot_graze_doc   => marbl_zooplankton_share%zootot_graze_doc_fields , & ! INPUT grazing of zooplankton routed to doc (mmol C/m^3/sec)
+         zootot_graze_dic   => marbl_zooplankton_share%zootot_graze_dic_fields , & ! INPUT grazing of zooplankton routed to dic (mmol C/m^3/sec)
 
          POC                => marbl_particulate_share%POC                     , & ! INPUT
          P_CaCO3            => marbl_particulate_share%P_CaCO3                 , & ! INPUT
@@ -496,9 +496,9 @@ contains
           frac_co3(k) = c0
        end if
 
-       if (zooC_loc(k) > c0) then
-          R13C_zooC(k) = zootot13C_loc(k) / zooC_loc(k)
-          R14C_zooC(k) = zootot14C_loc(k) / zooC_loc(k)
+       if (zoototC_loc(k) > c0) then
+          R13C_zooC(k) = zootot13C_loc(k) / zoototC_loc(k)
+          R14C_zooC(k) = zootot14C_loc(k) / zoototC_loc(k)
        else
           R13C_zooC(k) = c0
           R14C_zooC(k) = c0
@@ -692,11 +692,11 @@ contains
        !-----------------------------------------------------------------------
 
        DO13Ctot_prod(k) = &
-            (zoo_loss_doc(k) + zoo_graze_doc(k))*R13C_zooC(k) + &
+            (zootot_loss_doc(k) + zootot_graze_doc(k))*R13C_zooC(k) + &
             sum((auto_loss_doc(:,k) + auto_graze_doc(:,k)) * R13C_autotroph(:,k),dim=1)
 
        DO14Ctot_prod(k) = &
-            (zoo_loss_doc(k) + zoo_graze_doc(k))*R14C_zooC(k) + &
+            (zootot_loss_doc(k) + zootot_graze_doc(k))*R14C_zooC(k) + &
             sum((auto_loss_doc(:,k) + auto_graze_doc(:,k)) * R14C_autotroph(:,k),dim=1)
 
        DO13Ctot_remin(k) = DOCtot_remin(k) * R13C_DOCtot(k)
@@ -707,11 +707,11 @@ contains
        !-----------------------------------------------------------------------
 
        PO13C%prod(k) = &
-            (zoo_loss_poc(k) + zoo_graze_poc(k))*R13C_zooC(k) + &
+            (zootot_loss_poc(k) + zootot_graze_poc(k))*R13C_zooC(k) + &
             sum((auto_graze_poc(:,k) + auto_agg(:,k) + auto_loss_poc(:,k)) * R13C_autotroph(:,k),dim=1)
 
        PO14C%prod(k) = &
-            (zoo_loss_poc(k) + zoo_graze_poc(k))*R14C_zooC(k) + &
+            (zootot_loss_poc(k) + zootot_graze_poc(k))*R14C_zooC(k) + &
             sum((auto_graze_poc(:,k) + auto_agg(:,k) + auto_loss_poc(:,k)) * R14C_autotroph(:,k),dim=1)
 
        !-----------------------------------------------------------------------
@@ -735,8 +735,8 @@ contains
        DOCtot_d13C(k) =  ( R13C_DOCtot(k) / R13C_std - c1 ) * c1000
        DOCtot_d14C(k) =  ( R14C_DOCtot(k) / R14C_std - c1 ) * c1000
 
-       zooC_d13C(k)=  ( R13C_zooC(k) / R13C_std - c1 ) * c1000
-       zooC_d14C(k)=  ( R14C_zooC(k) / R14C_std - c1 ) * c1000
+       zoototC_d13C(k)=  ( R13C_zooC(k) / R13C_std - c1 ) * c1000
+       zoototC_d14C(k)=  ( R14C_zooC(k) / R14C_std - c1 ) * c1000
 
        do auto_ind = 1, autotroph_cnt
           if (marbl_tracer_indices%auto_inds(auto_ind)%CaCO3_ind > 0) then
@@ -805,12 +805,12 @@ contains
 
        column_dtracer(zootot13C_ind,k) = &
               sum(auto_graze_zoo(:,k) * R13C_autotroph(:,k),dim=1) &
-            + (zoo_graze_zoo(k) - zoo_graze(k) - zoo_loss(k)) &
+            + (zootot_graze_zoo(k) - zootot_graze(k) - zootot_loss(k)) &
             * R13C_zooC(k)
 
        column_dtracer(zootot14C_ind,k) = &
               sum(auto_graze_zoo(:,k) * R14C_autotroph(:,k),dim=1) &
-            + (zoo_graze_zoo(k) - zoo_graze(k) - zoo_loss(k)) &
+            + (zootot_graze_zoo(k) - zootot_graze(k) - zootot_loss(k)) &
             * R14C_zooC(k) - c14_lambda_inv_sec * zootot14C_loc(k)
 
        decay_14Ctot(k) = decay_14Ctot(k) + c14_lambda_inv_sec * zootot14C_loc(k)
@@ -833,14 +833,14 @@ contains
             sum((auto_loss_dic(:,k) + auto_graze_dic(:,k))*R13C_autotroph(:,k),dim=1) &
           - sum(photo13C(:,k),dim=1) &
           + DO13Ctot_remin(k) + PO13C%remin(k) &
-          + (zoo_loss_dic(k) + zoo_graze_dic(k)) * R13C_zooC(k) &
+          + (zootot_loss_dic(k) + zootot_graze_dic(k)) * R13C_zooC(k) &
           + P_Ca13CO3%remin(k)
 
        column_dtracer(di14c_ind,k) = &
             sum((auto_loss_dic(:,k) + auto_graze_dic(:,k))*R14C_autotroph(:,k),dim=1) &
           - sum(photo14C(:,k),dim=1) &
           + DO14Ctot_remin(k) + PO14C%remin(k) &
-          + (zoo_loss_dic(k) + zoo_graze_dic(k)) * R14C_zooC(k) &
+          + (zootot_loss_dic(k) + zootot_graze_dic(k)) * R14C_zooC(k) &
           + P_Ca14CO3%remin(k) &
           - c14_lambda_inv_sec * DI14C_loc(k)
 
@@ -894,8 +894,8 @@ contains
        DIC_d14C,            &
        DOCtot_d13C,         &
        DOCtot_d14C,         &
-       zooC_d13C,           &
-       zooC_d14C,           &
+       zoototC_d13C,        &
+       zoototC_d14C,        &
        DO13Ctot_prod,       &
        DO14Ctot_prod,       &
        DO13Ctot_remin,      &

--- a/src/marbl_ciso_mod.F90
+++ b/src/marbl_ciso_mod.F90
@@ -53,6 +53,7 @@ module marbl_ciso_mod
   use marbl_pft_mod, only : autotroph_type
   use marbl_pft_mod, only : marbl_zooplankton_share_type
   use marbl_pft_mod, only : marbl_autotroph_share_type
+  use marbl_pft_mod, only : autotroph_secondary_species_type
 
   implicit none
   private
@@ -217,6 +218,7 @@ contains
        marbl_zooplankton_share,               &
        marbl_autotroph_share,                 &
        marbl_particulate_share,               &
+       autotroph_secondary_species,           &
        temperature,                           &
        column_tracer,                         &
        column_dtracer,                        &
@@ -239,17 +241,18 @@ contains
 
     implicit none
 
-    type(marbl_domain_type)           , intent(in)    :: marbl_domain
-    type(marbl_interior_share_type)   , intent(in)    :: marbl_interior_share(:)
-    type(marbl_zooplankton_share_type), intent(in)    :: marbl_zooplankton_share(:)
-    type(marbl_autotroph_share_type)  , intent(in)    :: marbl_autotroph_share(:, :)
-    type(marbl_particulate_share_type), intent(in)    :: marbl_particulate_share
-    real (r8)                         , intent(in)    :: temperature(:)
-    real (r8)                         , intent(in)    :: column_tracer(:,:)
-    real (r8)                         , intent(inout) :: column_dtracer(:,:)  ! computed source/sink terms (inout because we don't touch non-ciso tracers)
-    type(marbl_tracer_index_type)     , intent(in)    :: marbl_tracer_indices
-    type(marbl_diagnostics_type)      , intent(inout) :: marbl_interior_diags
-    type(marbl_log_type)              , intent(inout) :: marbl_status_log
+    type(marbl_domain_type)               , intent(in)    :: marbl_domain
+    type(marbl_interior_share_type)       , intent(in)    :: marbl_interior_share(:)
+    type(marbl_zooplankton_share_type)    , intent(in)    :: marbl_zooplankton_share(:)
+    type(marbl_autotroph_share_type)      , intent(in)    :: marbl_autotroph_share(:, :)
+    type(marbl_particulate_share_type)    , intent(in)    :: marbl_particulate_share
+    type(autotroph_secondary_species_type), intent(in)    :: autotroph_secondary_species(:,:)
+    real (r8)                             , intent(in)    :: temperature(:)
+    real (r8)                             , intent(in)    :: column_tracer(:,:)
+    real (r8)                             , intent(inout) :: column_dtracer(:,:)  ! computed source/sink terms (inout because we don't touch non-ciso tracers)
+    type(marbl_tracer_index_type)         , intent(in)    :: marbl_tracer_indices
+    type(marbl_diagnostics_type)          , intent(inout) :: marbl_interior_diags
+    type(marbl_log_type)                  , intent(inout) :: marbl_status_log
 
     !-----------------------------------------------------------------------
     !  local variables
@@ -370,15 +373,15 @@ contains
          autotrophCaCO3_loc => marbl_autotroph_share%autotrophCaCO3_loc_fields , & ! INPUT local copy of model autotroph CaCO3
          autotrophC_loc     => marbl_autotroph_share%autotrophC_loc_fields     , & ! INPUT local copy of model autotroph C
          QCaCO3             => marbl_autotroph_share%QCaCO3_fields             , & ! INPUT small phyto CaCO3/C ratio (mmol CaCO3/mmol C)
-         auto_graze         => marbl_autotroph_share%auto_graze_fields         , & ! INPUT autotroph grazing rate (mmol C/m^3/sec)
-         auto_graze_zoo     => marbl_autotroph_share%auto_graze_zoo_fields     , & ! INPUT auto_graze routed to zoo (mmol C/m^3/sec)
-         auto_graze_poc     => marbl_autotroph_share%auto_graze_poc_fields     , & ! INPUT auto_graze routed to poc (mmol C/m^3/sec)
-         auto_graze_doc     => marbl_autotroph_share%auto_graze_doc_fields     , & ! INPUT auto_graze routed to doc (mmol C/m^3/sec)
-         auto_graze_dic     => marbl_autotroph_share%auto_graze_dic_fields     , & ! INPUT auto_graze routed to dic (mmol C/m^3/sec)
-         auto_loss          => marbl_autotroph_share%auto_loss_fields          , & ! INPUT autotroph non-grazing mort (mmol C/m^3/sec)
-         auto_loss_poc      => marbl_autotroph_share%auto_loss_poc_fields      , & ! INPUT auto_loss routed to poc (mmol C/m^3/sec)
-         auto_loss_doc      => marbl_autotroph_share%auto_loss_doc_fields      , & ! INPUT auto_loss routed to doc (mmol C/m^3/sec)
-         auto_loss_dic      => marbl_autotroph_share%auto_loss_dic_fields      , & ! INPUT auto_loss routed to dic (mmol C/m^3/sec)
+         auto_graze         => autotroph_secondary_species%auto_graze          , & ! INPUT autotroph grazing rate (mmol C/m^3/sec)
+         auto_graze_zoo     => autotroph_secondary_species%auto_graze_zoo      , & ! INPUT auto_graze routed to zoo (mmol C/m^3/sec)
+         auto_graze_poc     => autotroph_secondary_species%auto_graze_poc      , & ! INPUT auto_graze routed to poc (mmol C/m^3/sec)
+         auto_graze_doc     => autotroph_secondary_species%auto_graze_doc      , & ! INPUT auto_graze routed to doc (mmol C/m^3/sec)
+         auto_graze_dic     => autotroph_secondary_species%auto_graze_dic      , & ! INPUT auto_graze routed to dic (mmol C/m^3/sec)
+         auto_loss          => autotroph_secondary_species%auto_loss           , & ! INPUT autotroph non-grazing mort (mmol C/m^3/sec)
+         auto_loss_poc      => autotroph_secondary_species%auto_loss_poc       , & ! INPUT auto_loss routed to poc (mmol C/m^3/sec)
+         auto_loss_doc      => autotroph_secondary_species%auto_loss_doc       , & ! INPUT auto_loss routed to doc (mmol C/m^3/sec)
+         auto_loss_dic      => autotroph_secondary_species%auto_loss_dic       , & ! INPUT auto_loss routed to dic (mmol C/m^3/sec)
          auto_agg           => marbl_autotroph_share%auto_agg_fields           , & ! INPUT autotroph aggregation (mmol C/m^3/sec)
          photoC             => marbl_autotroph_share%photoC_fields             , & ! INPUT C-fixation (mmol C/m^3/sec)
          CaCO3_form         => marbl_autotroph_share%CaCO3_form_fields         , & ! INPUT prod. of CaCO3 by small phyto (mmol CaCO3/m^3/sec)

--- a/src/marbl_diagnostics_mod.F90
+++ b/src/marbl_diagnostics_mod.F90
@@ -320,8 +320,8 @@ module marbl_diagnostics_mod
      integer (int_kind) :: CISO_DO14Ctot_remin                                ! do14ctot remineralization
      integer (int_kind) :: CISO_Jint_13Ctot                                   ! vertically integrated source sink term, 13Ctot
      integer (int_kind) :: CISO_Jint_14Ctot                                   ! vertically integrated source sink term, 14Ctot
-     integer (int_kind) :: CISO_zooC_d13C                                     ! if for d13C of zooC
-     integer (int_kind) :: CISO_zooC_d14C                                     ! if for d14C of zooC
+     integer (int_kind) :: CISO_zoototC_d13C                                  ! if for d13C of zooC
+     integer (int_kind) :: CISO_zoototC_d14C                                  ! if for d14C of zooC
      integer (int_kind) :: CISO_DOCtot_d13C                                   ! if for d13C of DOCtot
      integer (int_kind) :: CISO_DOCtot_d14C                                   ! if for d14C of DOCtot
      integer (int_kind) :: CISO_DIC_d13C                                      ! if for d13C of DIC
@@ -3465,13 +3465,13 @@ contains
           return
         end if
 
-        lname    = 'd13C of zooC'
-        sname    = 'CISO_zooC_d13C'
+        lname    = 'd13C of total zooC'
+        sname    = 'CISO_zoototC_d13C'
         units    = 'permil'
         vgrid    = 'layer_avg'
         truncate = .false.
         call diags%add_diagnostic(lname, sname, units, vgrid, truncate,  &
-             ind%CISO_zooC_d13C, marbl_status_log)
+             ind%CISO_zoototC_d13C, marbl_status_log)
         if (marbl_status_log%labort_marbl) then
           call log_add_diagnostics_error(marbl_status_log, sname, subname)
           return
@@ -3609,13 +3609,13 @@ contains
           return
         end if
 
-        lname    = 'd14C of zooC'
-        sname    = 'CISO_zooC_d14C'
+        lname    = 'd14C of total zooC'
+        sname    = 'CISO_zoototC_d14C'
         units    = 'permil'
         vgrid    = 'layer_avg'
         truncate = .false.
         call diags%add_diagnostic(lname, sname, units, vgrid, truncate,  &
-             ind%CISO_zooC_d14C, marbl_status_log)
+             ind%CISO_zoototC_d14C, marbl_status_log)
         if (marbl_status_log%labort_marbl) then
           call log_add_diagnostics_error(marbl_status_log, sname, subname)
           return
@@ -5359,8 +5359,8 @@ contains
        DIC_d14C,            &
        DOCtot_d13C,         &
        DOCtot_d14C,         &
-       zooC_d13C,           &
-       zooC_d14C,           &
+       zoototC_d13C,        &
+       zoototC_d14C,        &
        DO13Ctot_prod,       &
        DO14Ctot_prod,       &
        DO13Ctot_remin,      &
@@ -5404,8 +5404,8 @@ contains
          DIC_d14C       , & ! d14C of DIC
          DOCtot_d13C    , & ! d13C of DOCtot
          DOCtot_d14C    , & ! d14C of DOCtot
-         zooC_d13C      , & ! d13C of zooC
-         zooC_d14C      , & ! d14C of zooC
+         zoototC_d13C   , & ! d13C of zooC
+         zoototC_d14C   , & ! d14C of zooC
          DO13Ctot_prod  , & ! production of 13C DOCtot (mmol C/m^3/sec)
          DO14Ctot_prod  , & ! production of 14C DOCtot (mmol C/m^3/sec)
          DO13Ctot_remin , & ! remineralization of 13C DOCtot (mmol C/m^3/sec)
@@ -5565,8 +5565,8 @@ contains
        diags(ind%CISO_DO13Ctot_remin)%field_3d(k, 1)  = DO13Ctot_remin(k)
        diags(ind%CISO_DO14Ctot_remin)%field_3d(k, 1)  = DO14Ctot_remin(k)
 
-       diags(ind%CISO_zooC_d13C)%field_3d(k, 1)       = zooC_d13C(k)
-       diags(ind%CISO_zooC_d14C)%field_3d(k, 1)       = zooC_d14C(k)
+       diags(ind%CISO_zoototC_d13C)%field_3d(k, 1)    = zoototC_d13C(k)
+       diags(ind%CISO_zoototC_d14C)%field_3d(k, 1)    = zoototC_d14C(k)
 
        diags(ind%CISO_eps_aq_g)%field_3d(k, 1)        = eps_aq_g(k)
        diags(ind%CISO_eps_dic_g)%field_3d(k, 1)       = eps_dic_g(k)

--- a/src/marbl_diagnostics_mod.F90
+++ b/src/marbl_diagnostics_mod.F90
@@ -5448,10 +5448,10 @@ contains
          ind     => marbl_interior_diag_ind, &
          di13c_ind     => marbl_tracer_indices%di13c_ind,    &
          do13ctot_ind  => marbl_tracer_indices%do13ctot_ind, &
-         zoo13Ctot_ind    => marbl_tracer_indices%zoo13Ctot_ind,   &
+         zootot13C_ind    => marbl_tracer_indices%zootot13C_ind,   &
          di14c_ind     => marbl_tracer_indices%di14c_ind,    &
          do14ctot_ind  => marbl_tracer_indices%do14ctot_ind, &
-         zoo14Ctot_ind    => marbl_tracer_indices%zoo14Ctot_ind    &
+         zootot14C_ind    => marbl_tracer_indices%zootot14C_ind    &
          )
 
     diags(ind%calcToSed_13C)%field_2d(1) = sum(P_Ca13CO3%sed_loss)
@@ -5468,7 +5468,7 @@ contains
 
     ! Vertical integrals - CISO_Jint_13Ctot
 
-    work(:) = dtracers(di13c_ind,:) + dtracers(do13ctot_ind,:) + dtracers(zoo13Ctot_ind,:) &
+    work(:) = dtracers(di13c_ind,:) + dtracers(do13ctot_ind,:) + dtracers(zootot13C_ind,:) &
          + sum(dtracers(marbl_tracer_indices%auto_inds(:)%C13_ind,:), dim=1)
     do auto_ind = 1, autotroph_cnt
        n = marbl_tracer_indices%auto_inds(auto_ind)%Ca13CO3_ind
@@ -5490,7 +5490,7 @@ contains
 
     ! Vertical integral - CISO_Jint_14Ctot
 
-    work(:) = dtracers(di14c_ind,:) + dtracers(do14ctot_ind,:) + dtracers(zoo14Ctot_ind,:) &
+    work(:) = dtracers(di14c_ind,:) + dtracers(do14ctot_ind,:) + dtracers(zootot14C_ind,:) &
          + sum(dtracers(marbl_tracer_indices%auto_inds(:)%C14_ind,:), dim=1) + decay_14Ctot
     do auto_ind = 1, autotroph_cnt
        n = marbl_tracer_indices%auto_inds(auto_ind)%Ca14CO3_ind

--- a/src/marbl_diagnostics_mod.F90
+++ b/src/marbl_diagnostics_mod.F90
@@ -307,10 +307,10 @@ module marbl_diagnostics_mod
      integer (int_kind), allocatable :: CISO_photo14C(:)            ! 14C fixation
      integer (int_kind), allocatable :: CISO_photo13C_zint(:)       ! 13C fixation vertical integral
      integer (int_kind), allocatable :: CISO_photo14C_zint(:)       ! 14C fixation vertical integral
-     integer (int_kind), allocatable :: CISO_d13C(:)                ! if for d13C of autotroph carbon
-     integer (int_kind), allocatable :: CISO_d14C(:)                ! if for d14C of autotroph carbon
-     integer (int_kind), allocatable :: CISO_autotrophCaCO3_d14C(:) ! if for d14C of autotrophCaCO3
-     integer (int_kind), allocatable :: CISO_autotrophCaCO3_d13C(:) ! if for d13C of autotrophCaCO3
+     integer (int_kind), allocatable :: CISO_d13C(:)                ! d13C of autotroph carbon
+     integer (int_kind), allocatable :: CISO_d14C(:)                ! d14C of autotroph carbon
+     integer (int_kind), allocatable :: CISO_autotrophCaCO3_d14C(:) ! d14C of autotrophCaCO3
+     integer (int_kind), allocatable :: CISO_autotrophCaCO3_d13C(:) ! d13C of autotrophCaCO3
 
      integer (int_kind) :: CISO_eps_aq_g                                      ! eps_aq_g
      integer (int_kind) :: CISO_eps_dic_g                                     ! eps_dic_g
@@ -320,12 +320,12 @@ module marbl_diagnostics_mod
      integer (int_kind) :: CISO_DO14Ctot_remin                                ! do14ctot remineralization
      integer (int_kind) :: CISO_Jint_13Ctot                                   ! vertically integrated source sink term, 13Ctot
      integer (int_kind) :: CISO_Jint_14Ctot                                   ! vertically integrated source sink term, 14Ctot
-     integer (int_kind) :: CISO_zoototC_d13C                                  ! if for d13C of zooC
-     integer (int_kind) :: CISO_zoototC_d14C                                  ! if for d14C of zooC
-     integer (int_kind) :: CISO_DOCtot_d13C                                   ! if for d13C of DOCtot
-     integer (int_kind) :: CISO_DOCtot_d14C                                   ! if for d14C of DOCtot
-     integer (int_kind) :: CISO_DIC_d13C                                      ! if for d13C of DIC
-     integer (int_kind) :: CISO_DIC_d14C                                      ! if for d14C of DIC
+     integer (int_kind) :: CISO_zoototC_d13C                                  ! d13C of total zooC
+     integer (int_kind) :: CISO_zoototC_d14C                                  ! d14C of total zooC
+     integer (int_kind) :: CISO_DOCtot_d13C                                   ! d13C of DOCtot
+     integer (int_kind) :: CISO_DOCtot_d14C                                   ! d14C of DOCtot
+     integer (int_kind) :: CISO_DIC_d13C                                      ! d13C of DIC
+     integer (int_kind) :: CISO_DIC_d14C                                      ! d14C of DIC
      integer (int_kind) :: calcToSed_13C                                      ! calcite flux sedimentary burial
      integer (int_kind) :: calcToSed_14C                                      ! calcite flux sedimentary burial
      integer (int_kind) :: pocToSed_13C                                       ! poc burial flux to sediments
@@ -5404,8 +5404,8 @@ contains
          DIC_d14C       , & ! d14C of DIC
          DOCtot_d13C    , & ! d13C of DOCtot
          DOCtot_d14C    , & ! d14C of DOCtot
-         zoototC_d13C   , & ! d13C of zooC
-         zoototC_d14C   , & ! d14C of zooC
+         zoototC_d13C   , & ! d13C of total zooC
+         zoototC_d14C   , & ! d14C of total zooC
          DO13Ctot_prod  , & ! production of 13C DOCtot (mmol C/m^3/sec)
          DO14Ctot_prod  , & ! production of 14C DOCtot (mmol C/m^3/sec)
          DO13Ctot_remin , & ! remineralization of 13C DOCtot (mmol C/m^3/sec)

--- a/src/marbl_interface_private_types.F90
+++ b/src/marbl_interface_private_types.F90
@@ -232,8 +232,8 @@ module marbl_interface_private_types
     ! For CISO, don't want individual C13 and C14 tracers for each zooplankton
     ! Instead we collect them into one tracer for each isotope, regardless of
     ! zooplankton_cnt
-    integer (int_kind) :: zoo13Ctot_ind   = 0 ! zooplankton carbon 13
-    integer (int_kind) :: zoo14Ctot_ind   = 0 ! zooplankton carbon 14
+    integer (int_kind) :: zootot13C_ind   = 0 ! zooplankton carbon 13
+    integer (int_kind) :: zootot14C_ind   = 0 ! zooplankton carbon 14
 
   contains
     procedure, public :: add_tracer_index
@@ -627,8 +627,8 @@ contains
       call this%add_tracer_index('do13ctot', 'ciso', this%do13ctot_ind, marbl_status_log)
       call this%add_tracer_index('di14c',    'ciso', this%di14c_ind,    marbl_status_log)
       call this%add_tracer_index('do14ctot', 'ciso', this%do14ctot_ind, marbl_status_log)
-      call this%add_tracer_index('zoo13Ctot',   'ciso', this%zoo13Ctot_ind,   marbl_status_log)
-      call this%add_tracer_index('zoo14Ctot',   'ciso', this%zoo14Ctot_ind,   marbl_status_log)
+      call this%add_tracer_index('zootot13C',   'ciso', this%zootot13C_ind,   marbl_status_log)
+      call this%add_tracer_index('zootot14C',   'ciso', this%zootot14C_ind,   marbl_status_log)
 
       do n=1,autotroph_cnt
         write(ind_name, "(2A)") trim(autotrophs(n)%sname), "C13"

--- a/src/marbl_interface_private_types.F90
+++ b/src/marbl_interface_private_types.F90
@@ -229,8 +229,8 @@ module marbl_interface_private_types
     ! For CISO, don't want individual C13 and C14 tracers for each zooplankton
     ! Instead we collect them into one tracer for each isotope, regardless of
     ! zooplankton_cnt
-    integer (int_kind) :: zootot13C_ind   = 0 ! zooplankton carbon 13
-    integer (int_kind) :: zootot14C_ind   = 0 ! zooplankton carbon 14
+    integer (int_kind) :: zootot13C_ind   = 0 ! total zooplankton carbon 13
+    integer (int_kind) :: zootot14C_ind   = 0 ! total zooplankton carbon 14
 
   contains
     procedure, public :: add_tracer_index

--- a/src/marbl_interface_private_types.F90
+++ b/src/marbl_interface_private_types.F90
@@ -85,14 +85,11 @@ module marbl_interface_private_types
 
   type, public :: marbl_interior_share_type
      real(r8) :: QA_dust_def         ! incoming deficit in the QA(dust) POC flux
-     real(r8) :: DIC_loc_fields      ! local copy of model DIC
-     real(r8) :: DOCtot_loc_fields   ! local copy of model DOC+DOCr
-     real(r8) :: O2_loc_fields       ! local copy of model O2
-     real(r8) :: NO3_loc_fields      ! local copy of model NO3
      real(r8) :: CO3_fields
      real(r8) :: HCO3_fields         ! bicarbonate ion
      real(r8) :: H2CO3_fields        ! carbonic acid
      real(r8) :: CO3_sat_calcite
+     real(r8) :: DOCtot_loc_fields   ! local copy of model DOC+DOCr
      real(r8) :: DOCtot_remin_fields ! remineralization of DOC+DOCr (mmol C/m^3/sec)
   end type marbl_interior_share_type
 

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -496,7 +496,7 @@ contains
 
     type(marbl_interior_share_type)    :: marbl_interior_share(domain%km)
     type(marbl_autotroph_share_type)   :: marbl_autotroph_share(autotroph_cnt, domain%km)
-    type(marbl_zooplankton_share_type) :: marbl_zooplankton_share(zooplankton_cnt, domain%km)
+    type(marbl_zooplankton_share_type) :: marbl_zooplankton_share(domain%km)
 
     integer (int_kind) :: n         ! tracer index
     integer (int_kind) :: k         ! vertical level index
@@ -766,10 +766,9 @@ contains
                marbl_tracer_indices, carbonate(k), dissolved_organic_matter(k), &
                QA_dust_def(k), marbl_interior_share(k))
 
-          call marbl_export_zooplankton_shared_variables(zooplankton_cnt, &
-               zooplankton_local(:, k), &
+          call marbl_export_zooplankton_shared_variables(zooplankton_local(:, k), &
                zooplankton_secondary_species(:, k), &
-               marbl_zooplankton_share(:, k))
+               marbl_zooplankton_share(k))
 
           call marbl_export_autotroph_shared_variables(autotroph_cnt, &
                autotroph_local(:, k), &
@@ -4531,35 +4530,28 @@ contains
   !-----------------------------------------------------------------------
 
   subroutine marbl_export_zooplankton_shared_variables (&
-       zoo_cnt, &
        zooplankton_local, &
        zooplankton_secondary_species, &
        marbl_zooplankton_share)
 
-    integer(int_kind)                        , intent(in)    :: zoo_cnt
-    type(zooplankton_local_type)             , intent(in)    :: zooplankton_local(zoo_cnt)
-    type(zooplankton_secondary_species_type) , intent(in)    :: zooplankton_secondary_species(zoo_cnt)
-    type(marbl_zooplankton_share_type)       , intent(inout) :: marbl_zooplankton_share(zoo_cnt)
-
-    integer(int_kind) :: n
+    type(zooplankton_local_type)             , intent(in)    :: zooplankton_local(:)
+    type(zooplankton_secondary_species_type) , intent(in)    :: zooplankton_secondary_species(:)
+    type(marbl_zooplankton_share_type)       , intent(inout) :: marbl_zooplankton_share
 
     associate( &
-         share => marbl_zooplankton_share(:) &
+         share => marbl_zooplankton_share &
          )
 
-    do n = 1, zoo_cnt
-       share(n)%zooC_loc_fields      = zooplankton_local(n)%C
-       share(n)%zoo_loss_fields      = zooplankton_secondary_species(n)%zoo_loss
-       share(n)%zoo_loss_poc_fields  = zooplankton_secondary_species(n)%zoo_loss_poc
-       share(n)%zoo_loss_doc_fields  = zooplankton_secondary_species(n)%zoo_loss_doc
-       share(n)%zoo_loss_dic_fields  = zooplankton_secondary_species(n)%zoo_loss_dic
-       share(n)%x_graze_zoo_fields   = zooplankton_secondary_species(n)%x_graze_zoo
-       share(n)%zoo_graze_fields     = zooplankton_secondary_species(n)%zoo_graze
-       share(n)%zoo_graze_zoo_fields = zooplankton_secondary_species(n)%zoo_graze_zoo
-       share(n)%zoo_graze_poc_fields = zooplankton_secondary_species(n)%zoo_graze_poc
-       share(n)%zoo_graze_doc_fields = zooplankton_secondary_species(n)%zoo_graze_doc
-       share(n)%zoo_graze_dic_fields = zooplankton_secondary_species(n)%zoo_graze_dic
-    end do
+       share%zooC_loc_fields      = sum(zooplankton_local(:)%C)
+       share%zoo_loss_fields      = sum(zooplankton_secondary_species(:)%zoo_loss)
+       share%zoo_loss_poc_fields  = sum(zooplankton_secondary_species(:)%zoo_loss_poc)
+       share%zoo_loss_doc_fields  = sum(zooplankton_secondary_species(:)%zoo_loss_doc)
+       share%zoo_loss_dic_fields  = sum(zooplankton_secondary_species(:)%zoo_loss_dic)
+       share%zoo_graze_fields     = sum(zooplankton_secondary_species(:)%zoo_graze)
+       share%zoo_graze_zoo_fields = sum(zooplankton_secondary_species(:)%zoo_graze_zoo)
+       share%zoo_graze_poc_fields = sum(zooplankton_secondary_species(:)%zoo_graze_poc)
+       share%zoo_graze_doc_fields = sum(zooplankton_secondary_species(:)%zoo_graze_doc)
+       share%zoo_graze_dic_fields = sum(zooplankton_secondary_species(:)%zoo_graze_dic)
 
     end associate
   end subroutine marbl_export_zooplankton_shared_variables

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -4543,16 +4543,16 @@ contains
          share => marbl_zooplankton_share &
          )
 
-       share%zooC_loc_fields      = sum(zooplankton_local(:)%C)
-       share%zoo_loss_fields      = sum(zooplankton_secondary_species(:)%zoo_loss)
-       share%zoo_loss_poc_fields  = sum(zooplankton_secondary_species(:)%zoo_loss_poc)
-       share%zoo_loss_doc_fields  = sum(zooplankton_secondary_species(:)%zoo_loss_doc)
-       share%zoo_loss_dic_fields  = sum(zooplankton_secondary_species(:)%zoo_loss_dic)
-       share%zoo_graze_fields     = sum(zooplankton_secondary_species(:)%zoo_graze)
-       share%zoo_graze_zoo_fields = sum(zooplankton_secondary_species(:)%zoo_graze_zoo)
-       share%zoo_graze_poc_fields = sum(zooplankton_secondary_species(:)%zoo_graze_poc)
-       share%zoo_graze_doc_fields = sum(zooplankton_secondary_species(:)%zoo_graze_doc)
-       share%zoo_graze_dic_fields = sum(zooplankton_secondary_species(:)%zoo_graze_dic)
+       share%zoototC_loc_fields      = sum(zooplankton_local(:)%C)
+       share%zootot_loss_fields      = sum(zooplankton_secondary_species(:)%zoo_loss)
+       share%zootot_loss_poc_fields  = sum(zooplankton_secondary_species(:)%zoo_loss_poc)
+       share%zootot_loss_doc_fields  = sum(zooplankton_secondary_species(:)%zoo_loss_doc)
+       share%zootot_loss_dic_fields  = sum(zooplankton_secondary_species(:)%zoo_loss_dic)
+       share%zootot_graze_fields     = sum(zooplankton_secondary_species(:)%zoo_graze)
+       share%zootot_graze_zoo_fields = sum(zooplankton_secondary_species(:)%zoo_graze_zoo)
+       share%zootot_graze_poc_fields = sum(zooplankton_secondary_species(:)%zoo_graze_poc)
+       share%zootot_graze_doc_fields = sum(zooplankton_secondary_species(:)%zoo_graze_doc)
+       share%zootot_graze_dic_fields = sum(zooplankton_secondary_species(:)%zoo_graze_dic)
 
     end associate
   end subroutine marbl_export_zooplankton_shared_variables

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -492,6 +492,7 @@ contains
     character(len=*), parameter :: subname = 'marbl_mod:marbl_set_interior_forcing'
 
     real(r8), dimension(size(tracers,1), domain%km) :: interior_restore
+    real(r8), dimension(size(tracers,1), domain%km) :: tracer_local
 
     type(marbl_interior_share_type)    :: marbl_interior_share(domain%km)
     type(marbl_zooplankton_share_type) :: marbl_zooplankton_share(domain%km)
@@ -522,7 +523,6 @@ contains
     real (r8) :: Lig_deg(domain%km)          ! loss of Fe-binding Ligand from bacterial degradation
     real (r8) :: Lig_loss(domain%km)         ! loss of Fe-binding Ligand
     real (r8) :: totalChl_local(domain%km)   ! local value of totalChl
-    real (r8) :: tracer_local(marbl_tracer_indices%ecosys_base%cnt, domain%km)
 
     type(zooplankton_local_type)             :: zooplankton_local(zooplankton_cnt, domain%km)
     type(autotroph_local_type)               :: autotroph_local(autotroph_cnt, domain%km)
@@ -2269,6 +2269,8 @@ contains
        n = marbl_tracer_indices%auto_inds(auto_ind)%CaCO3_ind
        if (n > 0) then
           autotroph_local(auto_ind,:)%CaCO3 = tracer_local(n,:)
+       else
+          autotroph_local(auto_ind,:)%CaCO3 = c0
        endif
 
        ! Carbon isotope elements of autotroph_local

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -4548,11 +4548,17 @@ contains
          )
 
     do n = 1, zoo_cnt
-       share(n)%zooC_loc_fields     = zooplankton_local(n)%C
-       share(n)%zoo_loss_fields     = zooplankton_secondary_species(n)%zoo_loss
-       share(n)%zoo_loss_poc_fields = zooplankton_secondary_species(n)%zoo_loss_poc
-       share(n)%zoo_loss_doc_fields = zooplankton_secondary_species(n)%zoo_loss_doc
-       share(n)%zoo_loss_dic_fields = zooplankton_secondary_species(n)%zoo_loss_dic
+       share(n)%zooC_loc_fields      = zooplankton_local(n)%C
+       share(n)%zoo_loss_fields      = zooplankton_secondary_species(n)%zoo_loss
+       share(n)%zoo_loss_poc_fields  = zooplankton_secondary_species(n)%zoo_loss_poc
+       share(n)%zoo_loss_doc_fields  = zooplankton_secondary_species(n)%zoo_loss_doc
+       share(n)%zoo_loss_dic_fields  = zooplankton_secondary_species(n)%zoo_loss_dic
+       share(n)%x_graze_zoo_fields   = zooplankton_secondary_species(n)%x_graze_zoo
+       share(n)%zoo_graze_fields     = zooplankton_secondary_species(n)%zoo_graze
+       share(n)%zoo_graze_zoo_fields = zooplankton_secondary_species(n)%zoo_graze_zoo
+       share(n)%zoo_graze_poc_fields = zooplankton_secondary_species(n)%zoo_graze_poc
+       share(n)%zoo_graze_doc_fields = zooplankton_secondary_species(n)%zoo_graze_doc
+       share(n)%zoo_graze_dic_fields = zooplankton_secondary_species(n)%zoo_graze_dic
     end do
 
     end associate

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -816,17 +816,18 @@ contains
 
     !  Compute time derivatives for ecosystem carbon isotope state variables
     if (ciso_on) then
-       call marbl_ciso_set_interior_forcing(                        &
-            marbl_domain                 = domain,                  &
-            marbl_interior_share         = marbl_interior_share,    &
-            marbl_zooplankton_share      = marbl_zooplankton_share, &
-            marbl_autotroph_share        = marbl_autotroph_share,   &
-            marbl_particulate_share      = marbl_particulate_share, &
-            temperature                  = temperature,             &
-            column_tracer                = tracers,                 &
-            column_dtracer               = dtracers,                &
-            marbl_tracer_indices         = marbl_tracer_indices,    &
-            marbl_interior_diags         = interior_forcing_diags,  &
+       call marbl_ciso_set_interior_forcing(                            &
+            marbl_domain                 = domain,                      &
+            marbl_interior_share         = marbl_interior_share,        &
+            marbl_zooplankton_share      = marbl_zooplankton_share,     &
+            marbl_autotroph_share        = marbl_autotroph_share,       &
+            marbl_particulate_share      = marbl_particulate_share,     &
+            autotroph_secondary_species  = autotroph_secondary_species, &
+            temperature                  = temperature,                 &
+            column_tracer                = tracers,                     &
+            column_dtracer               = dtracers,                    &
+            marbl_tracer_indices         = marbl_tracer_indices,        &
+            marbl_interior_diags         = interior_forcing_diags,      &
             marbl_status_log             = marbl_status_log)
 
        if (marbl_status_log%labort_marbl) then
@@ -4596,15 +4597,6 @@ contains
        end if
 
        share(n)%QCaCO3_fields         = autotroph_secondary_species(n)%QCaCO3
-       share(n)%auto_graze_fields     = autotroph_secondary_species(n)%auto_graze
-       share(n)%auto_graze_zoo_fields = autotroph_secondary_species(n)%auto_graze_zoo
-       share(n)%auto_graze_poc_fields = autotroph_secondary_species(n)%auto_graze_poc
-       share(n)%auto_graze_doc_fields = autotroph_secondary_species(n)%auto_graze_doc
-       share(n)%auto_graze_dic_fields = autotroph_secondary_species(n)%auto_graze_dic
-       share(n)%auto_loss_fields      = autotroph_secondary_species(n)%auto_loss
-       share(n)%auto_loss_poc_fields  = autotroph_secondary_species(n)%auto_loss_poc
-       share(n)%auto_loss_doc_fields  = autotroph_secondary_species(n)%auto_loss_doc
-       share(n)%auto_loss_dic_fields  = autotroph_secondary_species(n)%auto_loss_dic
        share(n)%auto_agg_fields       = autotroph_secondary_species(n)%auto_agg
        share(n)%photoC_fields         = autotroph_secondary_species(n)%photoC
        share(n)%CaCO3_form_fields     = autotroph_secondary_species(n)%CaCO3_form

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -4596,11 +4596,6 @@ contains
           share(n)%autotrophCaCO3_loc_fields = c0
        end if
 
-       share(n)%QCaCO3_fields         = autotroph_secondary_species(n)%QCaCO3
-       share(n)%auto_agg_fields       = autotroph_secondary_species(n)%auto_agg
-       share(n)%photoC_fields         = autotroph_secondary_species(n)%photoC
-       share(n)%CaCO3_form_fields     = autotroph_secondary_species(n)%CaCO3_form
-       share(n)%PCphoto_fields        = autotroph_secondary_species(n)%PCphoto
     end do
     end associate
 

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -2269,8 +2269,6 @@ contains
        n = marbl_tracer_indices%auto_inds(auto_ind)%CaCO3_ind
        if (n > 0) then
           autotroph_local(auto_ind,:)%CaCO3 = tracer_local(n,:)
-       else
-          autotroph_local(auto_ind,:)%CaCO3 = c0
        endif
 
        ! Carbon isotope elements of autotroph_local

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -814,9 +814,9 @@ contains
             marbl_zooplankton_share      = marbl_zooplankton_share,     &
             marbl_particulate_share      = marbl_particulate_share,     &
             autotroph_secondary_species  = autotroph_secondary_species, &
+            tracer_local                 = tracer_local,                &
             autotroph_local              = autotroph_local,             &
             temperature                  = temperature,                 &
-            column_tracer                = tracers,                     &
             column_dtracer               = dtracers,                    &
             marbl_tracer_indices         = marbl_tracer_indices,        &
             marbl_interior_diags         = interior_forcing_diags,      &
@@ -4531,18 +4531,14 @@ contains
     type(marbl_interior_share_type)     , intent(inout) :: marbl_interior_share
 
     marbl_interior_share%QA_dust_def    = QA_dust_def
-    marbl_interior_share%DIC_loc_fields = tracer_local(marbl_tracer_indices%DIC_ind)
-    marbl_interior_share%DOCtot_loc_fields = &
-         tracer_local(marbl_tracer_indices%DOC_ind) + tracer_local(marbl_tracer_indices%DOCr_ind)
-    marbl_interior_share%O2_loc_fields  = tracer_local(marbl_tracer_indices%O2_ind)
-    marbl_interior_share%NO3_loc_fields = tracer_local(marbl_tracer_indices%NO3_ind)
-
 
     marbl_interior_share%CO3_fields   = carbonate%CO3
     marbl_interior_share%HCO3_fields  = carbonate%HCO3
     marbl_interior_share%H2CO3_fields = carbonate%H2CO3
     marbl_interior_share%CO3_sat_calcite = carbonate%CO3_sat_calcite
 
+    marbl_interior_share%DOCtot_loc_fields = &
+         tracer_local(marbl_tracer_indices%DOC_ind) + tracer_local(marbl_tracer_indices%DOCr_ind)
     marbl_interior_share%DOCtot_remin_fields = &
          dissolved_organic_matter%DOC_remin + dissolved_organic_matter%DOCr_remin
 

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -817,14 +817,14 @@ contains
             tracer_local                 = tracer_local,                &
             autotroph_local              = autotroph_local,             &
             temperature                  = temperature,                 &
-            column_dtracer               = dtracers,                    &
             marbl_tracer_indices         = marbl_tracer_indices,        &
+            column_dtracer               = dtracers,                    &
             marbl_interior_diags         = interior_forcing_diags,      &
             marbl_status_log             = marbl_status_log)
 
        if (marbl_status_log%labort_marbl) then
           call marbl_status_log%log_error_trace(&
-               'marbl_ciso_set_interior_foricng()', subname)
+               'marbl_ciso_set_interior_forcing()', subname)
           return
        end if
     end if
@@ -2347,17 +2347,16 @@ contains
              end if
 
              ! carbon isotope components of autotroph_local_type
-             if (marbl_tracer_indices%auto_inds(auto_ind)%C13_ind > 0) then
+             if (ciso_on) then
                 autotroph_local(auto_ind,k)%C13 = c0
-             end if
-             if (marbl_tracer_indices%auto_inds(auto_ind)%C14_ind > 0) then
                 autotroph_local(auto_ind,k)%C14 = c0
-             end if
-             if (marbl_tracer_indices%auto_inds(auto_ind)%Ca13CO3_ind > 0) then
-                autotroph_local(auto_ind,k)%Ca13CO3 = c0
-             end if
-             if (marbl_tracer_indices%auto_inds(auto_ind)%Ca14CO3_ind > 0) then
-                autotroph_local(auto_ind,k)%Ca14CO3 = c0
+
+                if (marbl_tracer_indices%auto_inds(auto_ind)%Ca13CO3_ind > 0) then
+                   autotroph_local(auto_ind,k)%Ca13CO3 = c0
+                end if
+                if (marbl_tracer_indices%auto_inds(auto_ind)%Ca14CO3_ind > 0) then
+                   autotroph_local(auto_ind,k)%Ca14CO3 = c0
+                end if
              end if
           end if
 

--- a/src/marbl_pft_mod.F90
+++ b/src/marbl_pft_mod.F90
@@ -124,7 +124,6 @@ module marbl_pft_mod
      real(r8) :: zoo_loss_poc_fields  ! zoo_loss routed to large detrital (mmol C/m^3/sec)
      real(r8) :: zoo_loss_doc_fields  ! zoo_loss routed to doc (mmol C/m^3/sec)
      real(r8) :: zoo_loss_dic_fields  ! zoo_loss routed to dic (mmol C/m^3/sec)
-     real(r8) :: x_graze_zoo_fields   ! {auto, zoo}_graze routed to zoo (mmol C/m^3/sec)
      real(r8) :: zoo_graze_fields     ! zooplankton losses due to grazing (mmol C/m^3/sec)
      real(r8) :: zoo_graze_zoo_fields ! grazing of zooplankton routed to zoo (mmol C/m^3/sec)
      real(r8) :: zoo_graze_poc_fields ! grazing of zooplankton routed to poc (mmol C/m^3/sec)

--- a/src/marbl_pft_mod.F90
+++ b/src/marbl_pft_mod.F90
@@ -119,11 +119,17 @@ module marbl_pft_mod
   !***********************************************************************
 
   type, public :: marbl_zooplankton_share_type
-     real(r8) :: zooC_loc_fields     ! local copy of model zooC
-     real(r8) :: zoo_loss_fields     ! mortality & higher trophic grazing on zooplankton (mmol C/m^3/sec)
-     real(r8) :: zoo_loss_poc_fields ! zoo_loss routed to large detrital (mmol C/m^3/sec)
-     real(r8) :: zoo_loss_doc_fields ! zoo_loss routed to doc (mmol C/m^3/sec)
-     real(r8) :: zoo_loss_dic_fields ! zoo_loss routed to dic (mmol C/m^3/sec)
+     real(r8) :: zooC_loc_fields      ! local copy of model zooC
+     real(r8) :: zoo_loss_fields      ! mortality & higher trophic grazing on zooplankton (mmol C/m^3/sec)
+     real(r8) :: zoo_loss_poc_fields  ! zoo_loss routed to large detrital (mmol C/m^3/sec)
+     real(r8) :: zoo_loss_doc_fields  ! zoo_loss routed to doc (mmol C/m^3/sec)
+     real(r8) :: zoo_loss_dic_fields  ! zoo_loss routed to dic (mmol C/m^3/sec)
+     real(r8) :: x_graze_zoo_fields   ! {auto, zoo}_graze routed to zoo (mmol C/m^3/sec)
+     real(r8) :: zoo_graze_fields     ! zooplankton losses due to grazing (mmol C/m^3/sec)
+     real(r8) :: zoo_graze_zoo_fields ! grazing of zooplankton routed to zoo (mmol C/m^3/sec)
+     real(r8) :: zoo_graze_poc_fields ! grazing of zooplankton routed to poc (mmol C/m^3/sec)
+     real(r8) :: zoo_graze_doc_fields ! grazing of zooplankton routed to doc (mmol C/m^3/sec)
+     real(r8) :: zoo_graze_dic_fields ! grazing of zooplankton routed to dic (mmol C/m^3/sec)
   end type marbl_zooplankton_share_type
 
   !*****************************************************************************

--- a/src/marbl_pft_mod.F90
+++ b/src/marbl_pft_mod.F90
@@ -105,16 +105,16 @@ module marbl_pft_mod
   !***********************************************************************
 
   type, public :: marbl_zooplankton_share_type
-     real(r8) :: zooC_loc_fields      ! local copy of model zooC
-     real(r8) :: zoo_loss_fields      ! mortality & higher trophic grazing on zooplankton (mmol C/m^3/sec)
-     real(r8) :: zoo_loss_poc_fields  ! zoo_loss routed to large detrital (mmol C/m^3/sec)
-     real(r8) :: zoo_loss_doc_fields  ! zoo_loss routed to doc (mmol C/m^3/sec)
-     real(r8) :: zoo_loss_dic_fields  ! zoo_loss routed to dic (mmol C/m^3/sec)
-     real(r8) :: zoo_graze_fields     ! zooplankton losses due to grazing (mmol C/m^3/sec)
-     real(r8) :: zoo_graze_zoo_fields ! grazing of zooplankton routed to zoo (mmol C/m^3/sec)
-     real(r8) :: zoo_graze_poc_fields ! grazing of zooplankton routed to poc (mmol C/m^3/sec)
-     real(r8) :: zoo_graze_doc_fields ! grazing of zooplankton routed to doc (mmol C/m^3/sec)
-     real(r8) :: zoo_graze_dic_fields ! grazing of zooplankton routed to dic (mmol C/m^3/sec)
+     real(r8) :: zoototC_loc_fields      ! local copy of model zooC
+     real(r8) :: zootot_loss_fields      ! mortality & higher trophic grazing on zooplankton (mmol C/m^3/sec)
+     real(r8) :: zootot_loss_poc_fields  ! zoo_loss routed to large detrital (mmol C/m^3/sec)
+     real(r8) :: zootot_loss_doc_fields  ! zoo_loss routed to doc (mmol C/m^3/sec)
+     real(r8) :: zootot_loss_dic_fields  ! zoo_loss routed to dic (mmol C/m^3/sec)
+     real(r8) :: zootot_graze_fields     ! zooplankton losses due to grazing (mmol C/m^3/sec)
+     real(r8) :: zootot_graze_zoo_fields ! grazing of zooplankton routed to zoo (mmol C/m^3/sec)
+     real(r8) :: zootot_graze_poc_fields ! grazing of zooplankton routed to poc (mmol C/m^3/sec)
+     real(r8) :: zootot_graze_doc_fields ! grazing of zooplankton routed to doc (mmol C/m^3/sec)
+     real(r8) :: zootot_graze_dic_fields ! grazing of zooplankton routed to dic (mmol C/m^3/sec)
   end type marbl_zooplankton_share_type
 
   !*****************************************************************************

--- a/src/marbl_pft_mod.F90
+++ b/src/marbl_pft_mod.F90
@@ -101,15 +101,6 @@ module marbl_pft_mod
      real(r8) :: autotrophSi_loc_fields    ! local copy of model autotroph Si
      real(r8) :: autotrophCaCO3_loc_fields ! local copy of model autotroph CaCO3
      real(r8) :: QCaCO3_fields             ! small phyto CaCO3/C ratio (mmol CaCO3/mmol C)
-     real(r8) :: auto_graze_fields         ! autotroph grazing rate (mmol C/m^3/sec)
-     real(r8) :: auto_graze_zoo_fields     ! auto_graze routed to zoo (mmol C/m^3/sec)
-     real(r8) :: auto_graze_poc_fields     ! auto_graze routed to poc (mmol C/m^3/sec)
-     real(r8) :: auto_graze_doc_fields     ! auto_graze routed to doc (mmol C/m^3/sec)
-     real(r8) :: auto_graze_dic_fields     ! auto_graze routed to dic (mmol C/m^3/sec)
-     real(r8) :: auto_loss_fields          ! autotroph non-grazing mort (mmol C/m^3/sec)
-     real(r8) :: auto_loss_poc_fields      ! auto_loss routed to poc (mmol C/m^3/sec)
-     real(r8) :: auto_loss_doc_fields      ! auto_loss routed to doc (mmol C/m^3/sec)
-     real(r8) :: auto_loss_dic_fields      ! auto_loss routed to dic (mmol C/m^3/sec)
      real(r8) :: auto_agg_fields           ! autotroph aggregation (mmol C/m^3/sec)
      real(r8) :: photoC_fields             ! C-fixation (mmol C/m^3/sec)
      real(r8) :: CaCO3_form_fields         ! calcification of CaCO3 by small phyto (mmol CaCO3/m^3/sec)

--- a/src/marbl_pft_mod.F90
+++ b/src/marbl_pft_mod.F90
@@ -100,11 +100,6 @@ module marbl_pft_mod
      real(r8) :: autotrophFe_loc_fields    ! local copy of model autotroph Fe
      real(r8) :: autotrophSi_loc_fields    ! local copy of model autotroph Si
      real(r8) :: autotrophCaCO3_loc_fields ! local copy of model autotroph CaCO3
-     real(r8) :: QCaCO3_fields             ! small phyto CaCO3/C ratio (mmol CaCO3/mmol C)
-     real(r8) :: auto_agg_fields           ! autotroph aggregation (mmol C/m^3/sec)
-     real(r8) :: photoC_fields             ! C-fixation (mmol C/m^3/sec)
-     real(r8) :: CaCO3_form_fields         ! calcification of CaCO3 by small phyto (mmol CaCO3/m^3/sec)
-     real(r8) :: PCphoto_fields            ! C-specific rate of photosynth. (1/sec)
   end type marbl_autotroph_share_type
 
   !***********************************************************************

--- a/src/marbl_pft_mod.F90
+++ b/src/marbl_pft_mod.F90
@@ -52,6 +52,10 @@ module marbl_pft_mod
      real (r8) :: Fe    ! local copy of model autotroph Fe
      real (r8) :: Si    ! local copy of model autotroph Si
      real (r8) :: CaCO3 ! local copy of model autotroph CaCO3
+     real (r8) :: C13     ! local copy of model autotroph C13
+     real (r8) :: C14     ! local copy of model autotroph C14
+     real (r8) :: Ca13CO3 ! local copy of model autotroph Ca13CO3
+     real (r8) :: Ca14CO3 ! local copy of model autotroph Ca14CO3
   end type autotroph_local_type
 
   !****************************************************************************
@@ -91,16 +95,6 @@ module marbl_pft_mod
     procedure, public :: set_to_default => grazing_set_to_default
     procedure, public :: construct => grazing_constructor
   end type grazing_type
-
-  !***********************************************************************
-
-  type, public :: marbl_autotroph_share_type
-     real(r8) :: autotrophChl_loc_fields   ! local copy of model autotroph Chl
-     real(r8) :: autotrophC_loc_fields     ! local copy of model autotroph C
-     real(r8) :: autotrophFe_loc_fields    ! local copy of model autotroph Fe
-     real(r8) :: autotrophSi_loc_fields    ! local copy of model autotroph Si
-     real(r8) :: autotrophCaCO3_loc_fields ! local copy of model autotroph CaCO3
-  end type marbl_autotroph_share_type
 
   !***********************************************************************
 


### PR DESCRIPTION
Added additional terms to `zooplankton_share_type` so that `marbl_ciso_mod.F90` could include `zoo_graze` terms when computing tracer tendencies. This fixes #240 in the "quick fix" sense, but @klindsay28 and I talked about how it makes sense for me to take a little extra time to clean up the way some of this data is passed from `marbl_mod.F90` to `marbl_ciso_mod.F90`. Namely:

1. Most (all?) of `autotroph_share_type` is a direct copy of `autotroph_secondary_species_type`; why don't we pass that instead of doing unnecessary memory copies?
1. `marbl_ciso_mod.F90` is only concerned with the sum over all zooplankton species, so this summation should be done as part of building `zooplankton_share_type` rather than done internal to `marbl_ciso_mod.F90`. That would be consistent with how `DOCtot` is handled (summed in `marbl_mod.F90`, treated as a single quantity throughout `marbl_ciso_mod.F90`)

I'll add another comment when this is actually ready for review.