### PR TITLE
add caco3_bury_thres_omega_calc setting, fix for #264

### DIFF
--- a/autogenerated_src/default_settings.json
+++ b/autogenerated_src/default_settings.json
@@ -801,6 +801,13 @@
          "subcategory": "4. general parameters",
          "units": "cm"
       },
+      "caco3_bury_thres_omega_calc": {
+         "datatype": "real",
+         "default_value": 1.0,
+         "longname": "omega calcite threshold for CaCO3 burial when opt = 'omega_calc'",
+         "subcategory": "4. general parameters",
+         "units": 1
+      },
       "caco3_bury_thres_opt": {
          "datatype": "string",
          "default_value": "omega_calc",

--- a/src/default_settings.yaml
+++ b/src/default_settings.yaml
@@ -460,6 +460,12 @@ general_parms :
       units : cm
       datatype : real
       default_value : 3000e2
+   caco3_bury_thres_omega_calc :
+      longname : omega calcite threshold for CaCO3 burial when opt = 'omega_calc'
+      subcategory : 4. general parameters
+      units : 1
+      datatype : real
+      default_value : 1.0
    PON_bury_coeff :
       longname : Scale factor for burial of PON
       subcategory : 4. general parameters (bury coeffs)

--- a/src/marbl_ciso_mod.F90
+++ b/src/marbl_ciso_mod.F90
@@ -33,9 +33,6 @@ module marbl_ciso_mod
   use marbl_settings_mod, only : autotrophs
   use marbl_settings_mod, only : zooplankton
   use marbl_settings_mod, only : grazing
-  use marbl_settings_mod, only : caco3_bury_thres_iopt
-  use marbl_settings_mod, only : caco3_bury_thres_iopt_fixed_depth
-  use marbl_settings_mod, only : caco3_bury_thres_depth
 
   use marbl_logging, only : marbl_log_type
 
@@ -1368,8 +1365,12 @@ contains
     !  For other comments, see compute_particulate_terms in marbl_mod
     !----------------------------------------------------------------------------------------
 
-    use marbl_settings_mod , only : denitrif_C_N
     use marbl_constants_mod, only : spd
+    use marbl_settings_mod , only : denitrif_C_N
+    use marbl_settings_mod , only : caco3_bury_thres_iopt
+    use marbl_settings_mod , only : caco3_bury_thres_iopt_fixed_depth
+    use marbl_settings_mod , only : caco3_bury_thres_depth
+    use marbl_settings_mod , only : caco3_bury_thres_omega_calc
 
     implicit none
 
@@ -1600,7 +1601,7 @@ contains
             P_CaCO3_ciso%sed_loss(k) = P_CaCO3_ciso%to_floor
          endif
        else ! caco3_bury_thres_iopt = caco3_bury_thres_iopt_omega_calc
-         if (CO3 > CO3_sat_calcite) then
+         if (CO3 > caco3_bury_thres_omega_calc * CO3_sat_calcite) then
             P_CaCO3_ciso%sed_loss(k) = P_CaCO3_ciso%to_floor
          endif
        end if

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -147,9 +147,6 @@ module marbl_mod
   use marbl_settings_mod, only : r_Nfix_photo
   use marbl_settings_mod, only : spc_poc_fac
   use marbl_settings_mod, only : grazing
-  use marbl_settings_mod, only : caco3_bury_thres_iopt
-  use marbl_settings_mod, only : caco3_bury_thres_iopt_fixed_depth
-  use marbl_settings_mod, only : caco3_bury_thres_depth
   use marbl_settings_mod, only : PON_bury_coeff
 
   use marbl_interface_private_types, only : carbonate_type
@@ -1074,6 +1071,10 @@ contains
     use marbl_settings_mod , only : parm_Fe_desorption_rate0
     use marbl_settings_mod , only : parm_sed_denitrif_coeff
     use marbl_settings_mod , only : particulate_flux_ref_depth
+    use marbl_settings_mod , only : caco3_bury_thres_iopt
+    use marbl_settings_mod , only : caco3_bury_thres_iopt_fixed_depth
+    use marbl_settings_mod , only : caco3_bury_thres_depth
+    use marbl_settings_mod , only : caco3_bury_thres_omega_calc
 
     integer (int_kind)                , intent(in)    :: k                   ! vertical model level
     type(marbl_domain_type)           , intent(in)    :: domain
@@ -1614,10 +1615,10 @@ contains
              P_CaCO3_ALT_CO2%sed_loss(k) = P_CaCO3_ALT_CO2%to_floor
           endif
        else ! caco3_bury_thres_iopt = caco3_bury_thres_iopt_omega_calc
-          if (carbonate%CO3 > carbonate%CO3_sat_calcite) then
+          if (carbonate%CO3 > caco3_bury_thres_omega_calc * carbonate%CO3_sat_calcite) then
              P_CaCO3%sed_loss(k) = P_CaCO3%to_floor
           endif
-          if (carbonate%CO3_ALT_CO2 > carbonate%CO3_sat_calcite) then
+          if (carbonate%CO3_ALT_CO2 > caco3_bury_thres_omega_calc * carbonate%CO3_sat_calcite) then
              P_CaCO3_ALT_CO2%sed_loss(k) = P_CaCO3_ALT_CO2%to_floor
           endif
        endif

--- a/src/marbl_settings_mod.F90
+++ b/src/marbl_settings_mod.F90
@@ -266,6 +266,7 @@ module marbl_settings_mod
 
   character(len=char_len), target :: caco3_bury_thres_opt         ! option of threshold of caco3 burial ['fixed_depth', 'omega_calc']
   real(r8),                target :: caco3_bury_thres_depth       ! threshold depth for caco3_bury_thres_opt='fixed_depth'
+  real(r8),                target :: caco3_bury_thres_omega_calc  ! omega calcite threshold for caco3_bury_thres_opt='omega_calc'
   ! -----------
   ! PON_sed_loss = PON_bury_coeff * Q * POC_sed_loss
   ! factor is used to avoid overburying PON like POC
@@ -378,11 +379,11 @@ contains
     bury_coeff_rmean_timescale_years = 10.0_r8      ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
     parm_scalelen_z    = (/ 100.0e2_r8, 250.0e2_r8, 500.0e2_r8, 1000.0e2_r8 /)  ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
     parm_scalelen_vals = (/     1.0_r8,     3.0_r8,     4.5_r8,      5.5_r8 /)  ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
-
-    caco3_bury_thres_opt   = 'omega_calc'           ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
-    caco3_bury_thres_depth = 3000.0e2               ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
-    PON_bury_coeff         = 0.5_r8                 ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
-    ciso_fract_factors     = 'Laws'                 ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
+    caco3_bury_thres_opt          = 'omega_calc'    ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
+    caco3_bury_thres_depth        = 3000.0e2_r8     ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
+    caco3_bury_thres_omega_calc   = 1.0_r8          ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
+    PON_bury_coeff                = 0.5_r8          ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
+    ciso_fract_factors            = 'Laws'          ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
 
   end subroutine marbl_settings_set_defaults_general_parms
 
@@ -861,6 +862,15 @@ contains
     units     = 'cm'
     datatype  = 'real'
     rptr      => caco3_bury_thres_depth
+    call this%add_var(sname, lname, units, datatype, category,       &
+                        marbl_status_log, rptr=rptr)
+    call check_and_log_add_var_error(marbl_status_log, sname, subname, labort_marbl_loc)
+
+    sname     = 'caco3_bury_thres_omega_calc'
+    lname     = 'omega calcite threshold for CaCO3 burial (if using omega_calc option)'
+    units     = '1'
+    datatype  = 'real'
+    rptr      => caco3_bury_thres_omega_calc
     call this%add_var(sname, lname, units, datatype, category,       &
                         marbl_status_log, rptr=rptr)
     call check_and_log_add_var_error(marbl_status_log, sname, subname, labort_marbl_loc)


### PR DESCRIPTION
fix for #264 (comment added so that issue link is in pull request)

Testing:
marbl_dev_klindsay_n118_marbl_dev_n85_cesm_pop_2_1_20180419

aux_pop_MARBL cheyenne/{intel,gnu}: (baseline comparison to MARBL master)
   except for tests mentioned below, all tests pass
      NLCOMP failed for all tests because of new settings variable

Files Modified:
	modified:   autogenerated_src/default_settings.json
	modified:   src/default_settings.yaml
	modified:   src/marbl_ciso_mod.F90
	modified:   src/marbl_mod.F90
	modified:   src/marbl_settings_mod.F90