### PR TITLE
Lower Jint_Ctot_thres_molpm2pyr

### DIFF
--- a/autogenerated_src/default_settings.json
+++ b/autogenerated_src/default_settings.json
@@ -748,7 +748,7 @@
    "general_parms": {
       "Jint_Ctot_thres_molpm2pyr": {
          "datatype": "real",
-         "default_value": 1e-10,
+         "default_value": 1e-09,
          "longname": "MARBL will abort if abs(Jint_Ctot) exceeds this threshold",
          "subcategory": "4. general parameters",
          "units": "mol m-2 yr-1"

--- a/src/default_settings.yaml
+++ b/src/default_settings.yaml
@@ -280,7 +280,7 @@ general_parms :
       subcategory : 4. general parameters
       units : mol m-2 yr-1
       datatype : real
-      default_value : 1.0e-10
+      default_value : 1.0e-9
    parm_Fe_bioavail :
       longname : Fraction of Fe flux that is bioavailable
       subcategory : 4. general parameters

--- a/src/marbl_settings_mod.F90
+++ b/src/marbl_settings_mod.F90
@@ -355,7 +355,7 @@ contains
     init_bury_coeff_opt           = 'settings_file' ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
     ladjust_bury_coeff            = .false.         ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
     particulate_flux_ref_depth    = 100             ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
-    Jint_Ctot_thres_molpm2pyr     = 1.0e-10_r8      ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
+    Jint_Ctot_thres_molpm2pyr     = 1.0e-9_r8       ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
     parm_Fe_bioavail              = 1.0_r8          ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
     parm_o2_min                   = 5.0_r8          ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
     parm_o2_min_delta             = 5.0_r8          ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above


### PR DESCRIPTION
The CESM control run (using marbl0.28.5) and the aux_pop test list (using
marbl0.28.8) show a need to lower this threshold by an order of magnitude.