### PR TITLE
maintain P balance by taking P from DOP when setting negative POP%prod to 0

### DIFF
--- a/autogenerated_src/default_diagnostics.json
+++ b/autogenerated_src/default_diagnostics.json
@@ -1185,6 +1185,13 @@
       "units": "mmol/m^3/s",
       "vertical_grid": "layer_avg"
    },
+   "DOP_loss_P_bal": {
+      "frequency": "never",
+      "longname": "DOP loss, due to P budget balancing",
+      "operator": "average",
+      "units": "mmol/m^3/s",
+      "vertical_grid": "layer_avg"
+   },
    "DOP_prod": {
       "frequency": "medium",
       "longname": "DOP Production",

--- a/src/default_diagnostics.yaml
+++ b/src/default_diagnostics.yaml
@@ -694,6 +694,12 @@ DOPr_remin :
    vertical_grid : layer_avg
    frequency : low
    operator : average
+DOP_loss_P_bal :
+   longname : DOP loss, due to P budget balancing
+   units : mmol/m^3/s
+   vertical_grid : layer_avg
+   frequency : never
+   operator : average
 Fe_scavenge :
    longname : Iron Scavenging
    units : mmol/m^3/s

--- a/src/marbl_diagnostics_mod.F90
+++ b/src/marbl_diagnostics_mod.F90
@@ -190,6 +190,7 @@ module marbl_diagnostics_mod
     integer(int_kind) :: DOP_prod
     integer(int_kind) :: DOP_remin
     integer(int_kind) :: DOPr_remin
+    integer(int_kind) :: DOP_loss_P_bal
     integer(int_kind) :: Fe_scavenge
     integer(int_kind) :: Fe_scavenge_rate
     integer(int_kind) :: Lig_prod
@@ -2329,6 +2330,18 @@ contains
       truncate = .false.
       call diags%add_diagnostic(lname, sname, units, vgrid, truncate,     &
            ind%DOPr_remin, marbl_status_log)
+      if (marbl_status_log%labort_marbl) then
+        call log_add_diagnostics_error(marbl_status_log, sname, subname)
+        return
+      end if
+
+      lname = 'DOP loss, due to P budget balancing'
+      sname = 'DOP_loss_P_bal'
+      units = 'mmol/m^3/s'
+      vgrid = 'layer_avg'
+      truncate = .false.
+      call diags%add_diagnostic(lname, sname, units, vgrid, truncate,     &
+           ind%DOP_loss_P_bal, marbl_status_log)
       if (marbl_status_log%labort_marbl) then
         call log_add_diagnostics_error(marbl_status_log, sname, subname)
         return
@@ -4944,6 +4957,7 @@ contains
        diags(ind%DOP_prod)%field_3d(k, 1)         = dissolved_organic_matter(k)%DOP_prod
        diags(ind%DOP_remin)%field_3d(k, 1)        = dissolved_organic_matter(k)%DOP_remin
        diags(ind%DOPr_remin)%field_3d(k, 1)       = dissolved_organic_matter(k)%DOPr_remin
+       diags(ind%DOP_loss_P_bal)%field_3d(k, 1)   = dissolved_organic_matter(k)%DOP_loss_P_bal
     end do
 
     call compute_vertical_integrals(diags(ind%DOC_prod)%field_3d(:,1), &

--- a/src/marbl_interface_private_types.F90
+++ b/src/marbl_interface_private_types.F90
@@ -147,6 +147,7 @@ module marbl_interface_private_types
      real (r8) :: DOP_prod         ! production of DOP
      real (r8) :: DOP_remin        ! remineralization of DOP
      real (r8) :: DOPr_remin       ! remineralization of DOPr
+     real (r8) :: DOP_loss_P_bal   ! DOP loss, due to P budget balancing
   end type dissolved_organic_matter_type
 
   !***********************************************************************

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -4480,9 +4480,9 @@ contains
 
     dtracers(donr_ind) = (DON_prod * DONprod_refract) - DONr_remin + (PON_remin * PONremin_refract)
 
-    dtracers(dop_ind) = (DOP_prod * (c1 - DOPprod_refract)) - DOP_remin - sum(DOP_V(:))
+    dtracers(dop_ind) = (DOP_prod * (c1 - DOPprod_refract)) - DOP_remin - sum(DOP_V(:)) - DOP_loss_P_bal
 
-    dtracers(dopr_ind) = (DOP_prod * DOPprod_refract) - DOPr_remin + (POP_remin * POPremin_refract) - DOP_loss_P_bal
+    dtracers(dopr_ind) = (DOP_prod * DOPprod_refract) - DOPr_remin + (POP_remin * POPremin_refract)
 
     !-----------------------------------------------------------------------
     !  dissolved inorganic Carbon


### PR DESCRIPTION
fix for #268

write warning to log if omitting this term would have led to a Jint_Ptot based abort

term is written to new diagnostic, DOP_loss_P_bal
default frequency of DOP_loss_P_bal is 'never'

Testing:
marbl_dev_n86_cesm_pop_2_1_20180419

aux_pop_MARBL cheyenne/{intel,gnu}: (baseline comparison to MARBL master)
   except for tests mentioned below, all tests pass
      BASELINE failure for ERI tests (missing baseline, this test failed to run
         to completion with previous tag because of a Jint_Ptot based abort)
      other BASELINE failures, because of roundoff changes

Files Modified:
	modified:   autogenerated_src/default_diagnostics.json
	modified:   src/default_diagnostics.yaml
	modified:   src/marbl_diagnostics_mod.F90
	modified:   src/marbl_interface_private_types.F90
	modified:   src/marbl_mod.F90
