### PR TITLE
Use sphinx_rtd_theme in a manner to allow hosting on gh-pages

### DIFF
--- a/docs/src/_static/pop_ver.js
+++ b/docs/src/_static/pop_ver.js
@@ -1,0 +1,17 @@
+$(document).ready(function() {
+    var proj_end = document.baseURI.indexOf("versions") + 9;
+    var end = document.baseURI.indexOf("/", proj_end);
+    var cur_ver = document.baseURI.substring(proj_end, end);
+    var name = cur_ver.startsWith('cesm') ? cur_ver.substring(0) : cur_ver;
+    var mylist = $("#version-list");
+    mylist.empty();
+    mylist.append($("<option>", {value: "../" + cur_ver, text: name}));
+    $.getJSON(version_json_loc, function(obj) {
+        $.each(obj.versions, function() {
+            if (this != cur_ver) {
+                name = this.startsWith('cesm') ? this.substring(0) : this;
+                mylist.append($("<option>", {value: DOCUMENTATION_OPTIONS.URL_ROOT + '../' + this, text: name}));
+            }
+        });
+    });
+});

--- a/docs/src/_templates/footer.html
+++ b/docs/src/_templates/footer.html
@@ -1,0 +1,5 @@
+{% extends "!footer.html" %}
+{% block extrafooter %}
+    {{ super() }}
+<script>var version_json_loc = "{{ pathto('../versions.json', 1) }}";</script>
+{% endblock %}

--- a/docs/src/_templates/layout.html
+++ b/docs/src/_templates/layout.html
@@ -1,0 +1,3 @@
+{% extends "!layout.html" %}
+
+{% set script_files = script_files + ["_static/pop_ver.js"] %}

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -85,15 +85,18 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-#html_theme = 'bizstyle'
-#html_theme = 'sphinxdoc'
+import sphinx_rtd_theme
+html_theme = 'sphinx_rtd_theme'
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+
 html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {}
+html_theme_options['versions'] = {'latest': '../latest', 'cesm2.0': '../cesm2.0'}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
The Unidata development team provided a modified version of the `sphinx_rtd_theme` 0.2.5b1 `.whl` file, which adds flexibility to the `conf.py` options to allow a drop-down menu. There is also a javascript file to make sure old versions of the documentation have the latest contents of the dropdown menu.