### PR TITLE
Change sphinx theme

### DIFF
--- a/docs/sphinx-requirements.txt
+++ b/docs/sphinx-requirements.txt
@@ -28,8 +28,10 @@ requests==2.18.4
 six==1.11.0
 snowballstemmer==1.2.1
 Sphinx==1.7.5
-sphinx-rtd-theme==0.1.9
+sphinx-better-theme==0.1.5
+sphinx-rtd-theme==0.3.1
 sphinxcontrib-bibtex==0.4.0
+sphinxcontrib-fulltoc==1.2.0
 sphinxcontrib-websupport==1.1.0
 typing==3.6.4
 urllib3==1.22

--- a/docs/sphinx-requirements.txt
+++ b/docs/sphinx-requirements.txt
@@ -28,7 +28,7 @@ requests==2.18.4
 six==1.11.0
 snowballstemmer==1.2.1
 Sphinx==1.7.5
-sphinx-rtd-theme==0.3.1
+sphinx-rtd-theme==0.1.9
 sphinxcontrib-bibtex==0.4.0
 sphinxcontrib-websupport==1.1.0
 typing==3.6.4

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -30,7 +30,7 @@
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.mathjax','sphinxcontrib.bibtex']
+extensions = ['sphinx.ext.mathjax','sphinxcontrib.bibtex','sphinxcontrib.fulltoc']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -87,7 +87,11 @@ todo_include_todos = False
 #
 #html_theme = 'bizstyle'
 #html_theme = 'sphinxdoc'
-html_theme = 'sphinx_rtd_theme'
+#html_theme = 'sphinx_rtd_theme'
+
+from better import better_theme_path
+html_theme_path = [better_theme_path]
+html_theme = 'better'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
UCAR lawyers have pointed out that we can not have ads appearing on our documentation pages. If we want to continue to host documentation on [readthedocs.io](https://marbl.readthedocs.io/), then we can not use the `sphinx_rtd_theme` because it allows RTD to push ads. Instead, we switch to the `better` theme and also use `sphinxcontrib-fulltoc` to continue to get the full table of contents in the sidebar.