### PR TITLE
Streamline how we set up python environment

### DIFF
--- a/README
+++ b/README
@@ -10,10 +10,10 @@ https://groups.google.com/forum/#!forum/marbl-dev
 | MARBL Documentation |
 -----------------------
 
-MARBL documentation is compiled by sphinx and hosted by readthedocs.io.
+MARBL documentation is compiled by sphinx and hosted by github pages.
 It can be found on the web at
 
-https://marbl.readthedocs.io/en/latest/
+https://marbl-ecosys.github.io
 
 ---------------
 | About MARBL |

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,1 +1,2 @@
 doctrees
+html

--- a/docs/html/.gitignore
+++ b/docs/html/.gitignore
@@ -1,2 +1,0 @@
-*
-.buildinfo

--- a/docs/py_requirements.txt
+++ b/docs/py_requirements.txt
@@ -1,3 +1,3 @@
 Sphinx==1.7.5
 sphinxcontrib-bibtex==0.4.0
-git+https://github.com/marbl-ecosys/sphinx_rtd_theme.git#egg=version-dropdown
+git+https://github.com/marbl-ecosys/sphinx_rtd_theme.git@version-dropdown

--- a/docs/py_requirements.txt
+++ b/docs/py_requirements.txt
@@ -1,3 +1,3 @@
 Sphinx==1.7.5
-sphinx-rtd-theme==0.2.5b1
 sphinxcontrib-bibtex==0.4.0
+git+https://github.com/marbl-ecosys/sphinx_rtd_theme.git#egg=version-dropdown

--- a/docs/src/dev-guide/repo-access/working-on-docs.rst
+++ b/docs/src/dev-guide/repo-access/working-on-docs.rst
@@ -28,17 +28,21 @@ It's helpful to setup an environment. See `here
 <https://conda.io/docs/using/envs.html>`_
 for more on conda environments.
 
-With conda installed, do the following ::
+With conda installed, do the following (the last command assumes you are in the root of your MARBL repository):
+
+.. code-block:: none
 
   $ conda create --name marbl-docs pip
-  $ source activate marbl-docs
-  $ pip install -r $MARBL/docs/
+  $ conda activate marbl-docs
+  [MARBL]$ pip install -r docs/py_requirements.txt
 
 This creates an environment call "marbl-docs" and ensures that ``pip install`` commands are local to the environment rather than global.
 
-To deactivate the "marbl-docs" environment ::
+To deactivate the "marbl-docs" environment run
 
-  $ source deactivate marbl-docs
+.. code-block:: none
+
+  $ conda deactivate
 
 ----------------------
 Documentation workflow
@@ -51,7 +55,9 @@ Here's some notes on how to modify the documentation.
 Do all development work on a branch
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Checkout a new local branch using ::
+Checkout a new local branch using
+
+.. code-block:: none
 
   [MARBL]$ git checkout -b my_branch
 
@@ -75,12 +81,16 @@ The documentation has three major sections
 
 The file ``index.html`` in each of these directories includes the table of contents for each section; this file must be modified when new pages are added.
 
-Begin each ``rst`` file with a label that is the same as the file name::
+Begin each ``rst`` file with a label that is the same as the file name
+
+.. code-block:: none
 
   .. _myfilename:
 
 Note the position of the underscore and ending colon.
-This enables referencing this page from elsewhere in the project using::
+This enables referencing this page from elsewhere in the project using
+
+.. code-block:: none
 
   :ref:`Name of link<myfilename>`
 
@@ -88,9 +98,11 @@ This enables referencing this page from elsewhere in the project using::
 Build the documentation
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Once changes are complete, build from `src` using ::
+Once changes are complete, build from `src` using
 
-  [MARBL/src]$ make clean html
+.. code-block:: none
+
+  [MARBL/docs/src]$ make clean html
 
 The compiled documentation ends up in ``MARBL/docs/html``.
 You can view the files there in a browser locally as you work.
@@ -99,11 +111,15 @@ You can view the files there in a browser locally as you work.
 Commit changes
 ~~~~~~~~~~~~~~
 
-You can check the status of your modification using ::
+You can check the status of your modification using
+
+.. code-block:: none
 
   [MARBL]$ git status
 
-When you are ready to commit ::
+When you are ready to commit
+
+.. code-block:: none
 
   [MARBL/docs]$ git add .
   [MARBL/docs]$ git commit -m 'message describing changes'
@@ -116,7 +132,9 @@ reStructuredText parses special characters to create titles, subtitles, and othe
 Any non-alphanumeric [7-bit] character repeated for the entire length of the line above it will turn the line above it into a header.
 If you desire, you can also overline the header text with the same string.
 The order you use the special characters must be consistent within a file (the first character choice produces a title, the second character choice produces a subtitle, and so on).
-For example, the following two blocks of code translate into the same page::
+For example, the following two blocks of code translate into the same page:
+
+.. code-block:: none
 
   Title
   -----
@@ -127,7 +145,9 @@ For example, the following two blocks of code translate into the same page::
   Subsubtitle
   ===========
 
-and ::
+and
+
+.. code-block:: none
 
   Title
   +++++
@@ -141,7 +161,9 @@ and ::
 
 For consistency, MARBL documentation should use the same pattern across all files.
 (Again, this is not a requirement of reStructuredText.)
-The preferred pattern is::
+The preferred pattern is
+
+.. code-block:: none
 
   =====
   Title
@@ -157,9 +179,6 @@ The preferred pattern is::
 
 Note that this convention is entirely arbitrary, but should make reading ``.rst`` files a little easier.
 If you find a need for a Subsubsubtitle, choose your favorite special character that is not already in use and then edit this page accordingly.
-
-|
-|
 
 .. admonition:: reStructuredText resource
 

--- a/docs/src/dev-guide/repo-access/working-on-docs.rst
+++ b/docs/src/dev-guide/repo-access/working-on-docs.rst
@@ -30,9 +30,9 @@ for more on conda environments.
 
 With conda installed, do the following ::
 
-  $ conda create --name marbl-docs sphinx sphinx_rtd_theme
+  $ conda create --name marbl-docs
   $ source activate marbl-docs
-  $ pip install sphinxcontrib-bibtex
+  $ pip install -r $MARBL/docs/
 
 This creates an environment call "marbl-docs" and installs the required extensions.
 

--- a/docs/src/dev-guide/repo-access/working-on-docs.rst
+++ b/docs/src/dev-guide/repo-access/working-on-docs.rst
@@ -30,11 +30,11 @@ for more on conda environments.
 
 With conda installed, do the following ::
 
-  $ conda create --name marbl-docs
+  $ conda create --name marbl-docs pip
   $ source activate marbl-docs
   $ pip install -r $MARBL/docs/
 
-This creates an environment call "marbl-docs" and installs the required extensions.
+This creates an environment call "marbl-docs" and ensures that ``pip install`` commands are local to the environment rather than global.
 
 To deactivate the "marbl-docs" environment ::
 

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -44,6 +44,11 @@ Table of contents
 -----------------
 
 .. toctree::
+   :hidden:
+
+   self
+
+.. toctree::
    :maxdepth: 1
    :caption: Contents:
 


### PR DESCRIPTION
I forked the `rtfd/sphinx_rtd_theme` repository into the marbl-ecosys organization and made `version-dropdown` the default branch; `py_requirements.txt` now points to this branch on github. This makes it easier for users to create the same sphinx environment that we use to generate the docs, and also lets travis CI use the same theme version.