### PR TITLE
Clean up all gfortran warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 sudo: required
 before_install:
-  - sudo apt-get install gfortran
+  - sudo apt-get install gfortran mpich
 install:
   - pip install pyyaml
   - pip install -r docs/py_requirements.txt

--- a/MARBL_tools/run_test_suite.sh
+++ b/MARBL_tools/run_test_suite.sh
@@ -170,6 +170,13 @@ if [ "${STATUS}" == "PASS" ]; then
   ./requested_tracers.py
   STATUS=$(check_return $?)
   print_status "requested_tracers.py" >> $OUTFILE
+
+  # Initialize MARBL (with MPI)
+  cd ${MARBL_ROOT}/tests/regression_tests/init
+  echo "$ ./init.py --mpitasks 2"
+  ./init.py --mpitasks 2
+  STATUS=$(check_return $?)
+  print_status "init.py --mpitasks 2" >> $OUTFILE
 fi
 
 echo "----"

--- a/src/Makefile
+++ b/src/Makefile
@@ -108,7 +108,7 @@ all : gnu
 
 .PHONY: gnu
 gnu:
-	$(MAKE) -f $(MAKE_DIR)/Makefile $(LIB_DIR)/libmarbl-gnu$(MPISUF).a USE_DEPS=TRUE FC=gfortran FCFLAGS="-O2 -ffree-form -J $(OBJ_DIR)/gnu$(MPISUF) -cpp" OBJ_DIR=$(OBJ_DIR)/gnu$(MPISUF) INC_DIR=$(INC_DIR)/gnu$(MPISUF)
+	$(MAKE) -f $(MAKE_DIR)/Makefile $(LIB_DIR)/libmarbl-gnu$(MPISUF).a USE_DEPS=TRUE FC=gfortran FCFLAGS="-Wall -O2 -ffree-form -J $(OBJ_DIR)/gnu$(MPISUF) -cpp" OBJ_DIR=$(OBJ_DIR)/gnu$(MPISUF) INC_DIR=$(INC_DIR)/gnu$(MPISUF)
 
 .PHONY: intel
 intel:

--- a/src/Makefile
+++ b/src/Makefile
@@ -120,7 +120,7 @@ pgi:
 
 .PHONY: nag
 nag:
-	$(MAKE) -f $(MAKE_DIR)/Makefile $(LIB_DIR)/libmarbl-nag$(MPISUF).a USE_DEPS=TRUE FC=nagfor FCFLAGS="-O2 -free -I $(OBJ_DIR)/nag$(MPISUF) -mdir $(OBJ_DIR)/nag$(MPISUF) -kind=byte" OBJ_DIR=$(OBJ_DIR)/nag$(MPISUF) INC_DIR=$(INC_DIR)/nag$(MPISUF)
+	$(MAKE) -f $(MAKE_DIR)/Makefile $(LIB_DIR)/libmarbl-nag$(MPISUF).a USE_DEPS=TRUE FC=nagfor FCFLAGS="-colour -O2 -free -I $(OBJ_DIR)/nag$(MPISUF) -mdir $(OBJ_DIR)/nag$(MPISUF) -kind=byte" OBJ_DIR=$(OBJ_DIR)/nag$(MPISUF) INC_DIR=$(INC_DIR)/nag$(MPISUF)
 
 .PHONY: cray
 cray:

--- a/src/Makefile
+++ b/src/Makefile
@@ -108,7 +108,7 @@ all : gnu
 
 .PHONY: gnu
 gnu:
-	$(MAKE) -f $(MAKE_DIR)/Makefile $(LIB_DIR)/libmarbl-gnu$(MPISUF).a USE_DEPS=TRUE FC=gfortran FCFLAGS="-Wall -O2 -ffree-form -J $(OBJ_DIR)/gnu$(MPISUF) -cpp" OBJ_DIR=$(OBJ_DIR)/gnu$(MPISUF) INC_DIR=$(INC_DIR)/gnu$(MPISUF)
+	$(MAKE) -f $(MAKE_DIR)/Makefile $(LIB_DIR)/libmarbl-gnu$(MPISUF).a USE_DEPS=TRUE FC=gfortran FCFLAGS="-Wall -Werror -O2 -ffree-form -J $(OBJ_DIR)/gnu$(MPISUF) -cpp" OBJ_DIR=$(OBJ_DIR)/gnu$(MPISUF) INC_DIR=$(INC_DIR)/gnu$(MPISUF)
 
 .PHONY: intel
 intel:

--- a/src/marbl_ciso_mod.F90
+++ b/src/marbl_ciso_mod.F90
@@ -20,7 +20,6 @@ module marbl_ciso_mod
 
   use marbl_kinds_mod, only : r8
   use marbl_kinds_mod, only : int_kind
-  use marbl_kinds_mod, only : log_kind
   use marbl_kinds_mod, only : char_len
 
   use marbl_constants_mod, only : c0
@@ -31,8 +30,6 @@ module marbl_ciso_mod
 
   use marbl_settings_mod, only : autotroph_cnt
   use marbl_settings_mod, only : autotrophs
-  use marbl_settings_mod, only : zooplankton
-  use marbl_settings_mod, only : grazing
 
   use marbl_logging, only : marbl_log_type
 
@@ -45,9 +42,7 @@ module marbl_ciso_mod
   use marbl_interface_private_types, only : marbl_particulate_share_type
   use marbl_interface_private_types, only : marbl_surface_forcing_share_type
   use marbl_interface_private_types, only : marbl_tracer_index_type
-  use marbl_interface_private_types, only : carbonate_type
 
-  use marbl_pft_mod, only : autotroph_type
   use marbl_pft_mod, only : autotroph_local_type
   use marbl_pft_mod, only : marbl_zooplankton_share_type
   use marbl_pft_mod, only : autotroph_secondary_species_type
@@ -1439,7 +1434,6 @@ contains
 
     use marbl_constants_mod    , only : R13C_std
     use marbl_constants_mod    , only : R14C_std
-    use marbl_constants_mod    , only : p5
     use marbl_diagnostics_mod  , only : store_diagnostics_ciso_surface_forcing
 
     implicit none

--- a/src/marbl_ciso_mod.F90
+++ b/src/marbl_ciso_mod.F90
@@ -241,8 +241,8 @@ contains
     real (r8) :: work1      ! temporaries
 
     integer (int_kind) :: &
-         n,               & ! tracer index
-         auto_ind,        & ! autotroph functional group index
+         n,              & ! tracer index
+         auto_ind,       & ! autotroph functional group index
          k                 ! index for looping over k levels
 
     real (r8), dimension(autotroph_cnt) :: &

--- a/src/marbl_co2calc_mod.F90
+++ b/src/marbl_co2calc_mod.F90
@@ -402,8 +402,6 @@ contains
     !---------------------------------------------------------------------------
     !   local variable declarations
     !---------------------------------------------------------------------------
-    integer(kind=int_kind) :: c
-
     real(kind=r8), dimension(num_elements) :: salt_lim ! bounded salt
     real(kind=r8), dimension(num_elements) :: tk       ! temperature (K)
     real(kind=r8), dimension(num_elements) :: is       ! ionic strength
@@ -416,13 +414,8 @@ contains
     real(kind=r8), dimension(num_elements) :: sqrtis
     real(kind=r8), dimension(num_elements) :: s2
     real(kind=r8), dimension(num_elements) :: sqrts
-    real(kind=r8), dimension(num_elements) :: s15
     real(kind=r8), dimension(num_elements) :: invRtk
     real(kind=r8), dimension(num_elements) :: arg
-    real(kind=r8), dimension(num_elements) :: deltaV   ! pressure correction terms
-    real(kind=r8), dimension(num_elements) :: Kappa    ! pressure correction terms
-    real(kind=r8), dimension(num_elements) :: lnKfac   ! pressure correction terms
-    real(kind=r8), dimension(num_elements) :: Kfac     ! pressure correction terms
     real(kind=r8), dimension(num_elements) :: log_1_m_1p005em3_s
     real(kind=r8), dimension(num_elements) :: log_1_p_tot_sulfate_div_ks
     !---------------------------------------------------------------------------

--- a/src/marbl_diagnostics_mod.F90
+++ b/src/marbl_diagnostics_mod.F90
@@ -4577,8 +4577,6 @@ contains
     real(r8) :: autotrophC_weight(marbl_domain%km)
     real(r8) :: autotrophC_zint_100m
     real(r8) :: limterm(marbl_domain%km)
-    real(r8) :: limterm_zint_100m
-    !-----------------------------------------------------------------------
 
     associate(                                     &
          diags   => marbl_interior_diags%diags,    &
@@ -5726,10 +5724,8 @@ contains
        FLUX,           &
        FLUX13,         &
        FLUX14,         &
-       FLUX_as,        &
        FLUX13_as,      &
        FLUX14_as,      &
-       FLUX_sa,        &
        FLUX13_sa,      &
        FLUX14_sa,      &
        R13C_DIC,       &
@@ -5751,10 +5747,8 @@ contains
     real (r8), dimension(num_elements) , intent(in)    :: FLUX           ! gas flux of CO2 (nmol/cm^2/s)
     real (r8), dimension(num_elements) , intent(in)    :: FLUX13         ! gas flux of 13CO2 (nmol/cm^2/s)
     real (r8), dimension(num_elements) , intent(in)    :: FLUX14         ! gas flux of 14CO2 (nmol/cm^2/s)
-    real (r8), dimension(num_elements) , intent(in)    :: FLUX_as        ! air-to-sea gas flux of CO2 (nmol/cm^2/s)
     real (r8), dimension(num_elements) , intent(in)    :: FLUX13_as      ! air-to-sea gas flux of 13CO2 (nmol/cm^2/s)
     real (r8), dimension(num_elements) , intent(in)    :: FLUX14_as      ! air-to-sea gas flux of 14CO2 (nmol/cm^2/s)
-    real (r8), dimension(num_elements) , intent(in)    :: FLUX_sa        ! sea-to-air gas flux of CO2 (nmol/cm^2/s)
     real (r8), dimension(num_elements) , intent(in)    :: FLUX13_sa      ! sea-to-air gas flux of 13CO2 (nmol/cm^2/s)
     real (r8), dimension(num_elements) , intent(in)    :: FLUX14_sa      ! sea-to-air gas flux of 14CO2 (nmol/cm^2/s)
     real (r8), dimension(num_elements) , intent(in)    :: R13C_DIC       ! 13C/12C ratio in DIC

--- a/src/marbl_init_mod.F90
+++ b/src/marbl_init_mod.F90
@@ -64,7 +64,6 @@ contains
   subroutine marbl_init_parameters_pre_tracers(marbl_settings, marbl_status_log)
 
     use marbl_settings_mod, only : marbl_settings_type
-    use marbl_settings_mod, only : ladjust_bury_coeff
     use marbl_settings_mod, only : marbl_settings_set_defaults_general_parms
     use marbl_settings_mod, only : marbl_settings_define_general_parms
     use marbl_settings_mod, only : marbl_settings_set_defaults_PFT_counts
@@ -77,7 +76,6 @@ contains
 
     ! local variables
     character(len=*), parameter :: subname = 'marbl_init_mod:marbl_init_parameters_pre_tracers'
-    character(len=char_len) :: log_message
 
     !---------------------------------------------------------------------------
     ! set default values for basic settings
@@ -182,11 +180,7 @@ contains
       allocate(tracer_restore_vars(tracer_indices%total_cnt))
 
     ! Set up tracer metadata
-    call marbl_init_tracer_metadata(tracer_metadata, tracer_indices, marbl_status_log)
-    if (marbl_status_log%labort_marbl) then
-      call marbl_status_log%log_error_trace("marbl_init_tracer_metadata()", subname)
-      return
-    end if
+    call marbl_init_tracer_metadata(tracer_metadata, tracer_indices)
     if (ciso_on) then
        call marbl_ciso_init_tracer_metadata(tracer_metadata, tracer_indices)
     end if
@@ -218,8 +212,7 @@ contains
 
   !***********************************************************************
 
-  subroutine marbl_init_tracer_metadata(marbl_tracer_metadata,                &
-             marbl_tracer_indices, marbl_status_log)
+  subroutine marbl_init_tracer_metadata(marbl_tracer_metadata, marbl_tracer_indices)
 
     !  Set tracer and forcing metadata
 
@@ -229,7 +222,6 @@ contains
 
     type (marbl_tracer_metadata_type), intent(out)   :: marbl_tracer_metadata(:)   ! descriptors for each tracer
     type(marbl_tracer_index_type)    , intent(in)    :: marbl_tracer_indices
-    type(marbl_log_type)             , intent(inout) :: marbl_status_log
 
     !-----------------------------------------------------------------------
     !  local variables
@@ -308,7 +300,6 @@ contains
 
     ! local variables
     character(len=*), parameter :: subname = 'marbl_init_mod:marbl_init_parameters_post_tracers'
-    character(len=char_len) :: log_message
 
     ! set default values for parameters
     call marbl_settings_set_defaults_tracer_dependent(marbl_status_log)

--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -725,15 +725,10 @@ contains
     end if
     if (present(id)) id = id_loc
     if (any((/present(lname), present(units), present(datatype)/))) then
-      call this%settings%inquire_metadata(id_loc, this%StatusLog,  &
+      call this%settings%inquire_metadata(id_loc,                  &
                                           lname    = lname,        &
                                           units    = units,        &
                                           datatype = datatype)
-      if (this%StatusLog%labort_marbl) then
-        call this%StatusLog%log_error_trace('settings%inquire_metadata', subname)
-        return
-      end if
-    end if
 
   end subroutine inquire_settings_metadata_by_name
 
@@ -748,15 +743,11 @@ contains
 
     character(len=*), parameter :: subname = 'marbl_interface:inquire_settings_metadata_by_id'
 
-    call this%settings%inquire_metadata(id, this%StatusLog,  &
+    call this%settings%inquire_metadata(id,                  &
                                         sname    = sname,    &
                                         lname    = lname,    &
                                         units    = units,    &
                                         datatype = datatype)
-    if (this%StatusLog%labort_marbl) then
-      call this%StatusLog%log_error_trace('settings%inquire_metadata', subname)
-      return
-    end if
 
   end subroutine inquire_settings_metadata_by_id
 
@@ -948,7 +939,6 @@ contains
             glo_avg_rmean_interior    = this%glo_avg_rmean_interior,    &
             glo_avg_rmean_surface     = this%glo_avg_rmean_surface,     &
             glo_scalar_rmean_interior = this%glo_scalar_rmean_interior, &
-            glo_scalar_rmean_surface  = this%glo_scalar_rmean_surface,  &
             glo_scalar_interior       = this%glo_scalar_interior)
     end if
 

--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -19,7 +19,6 @@ module marbl_interface
 
   use marbl_kinds_mod, only : r8, log_kind, int_kind, log_kind, char_len
 
-  use marbl_settings_mod, only : autotroph_cnt
   use marbl_settings_mod, only : zooplankton_cnt
   use marbl_settings_mod, only : marbl_settings_type
 

--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -389,7 +389,6 @@ contains
     real(r8),                      intent(in)    :: val
 
     character(len=*), parameter :: subname = 'marbl_interface:put_real'
-    character(len=char_len) :: log_message
 
     call this%settings%put(varname, this%StatusLog, rval=val)
     if (this%StatusLog%labort_marbl) then
@@ -408,7 +407,6 @@ contains
     integer(int_kind),             intent(in)    :: val
 
     character(len=*), parameter :: subname = 'marbl_interface:put_integer'
-    character(len=char_len) :: log_message
 
     call this%settings%put(varname, this%StatusLog, ival=val)
     if (this%StatusLog%labort_marbl) then
@@ -427,7 +425,6 @@ contains
     logical,                       intent(in)    :: val
 
     character(len=*), parameter :: subname = 'marbl_interface:put_logical'
-    character(len=char_len) :: log_message
 
     call this%settings%put(varname, this%StatusLog, lval=val)
     if (this%StatusLog%labort_marbl) then
@@ -446,7 +443,6 @@ contains
     character(len=*),              intent(in)    :: val
 
     character(len=*), parameter :: subname = 'marbl_interface:put_string'
-    character(len=char_len) :: log_message
 
     call this%settings%put(varname, this%StatusLog, sval=val)
     if (this%StatusLog%labort_marbl) then
@@ -542,6 +538,8 @@ contains
     integer(int_kind)       :: n, char_ind
 
     line_loc = ''
+    ! The included PGI bugfix variable triggers a warning from gfortran unless it's used
+    if (present(pgi_bugfix_var)) line_loc=''
     ! Strip out comments (denoted by '!'); line_loc_arr(1) is the line to be processed
     call marbl_utils_str_to_substrs(line, '!', line_loc_arr)
     line_loc = line_loc_arr(1)
@@ -585,7 +583,6 @@ contains
     real(r8),                      intent(out)   :: val
 
     character(len=*), parameter :: subname = 'marbl_interface:get_real'
-    character(len=char_len) :: log_message
 
     call this%settings%get(varname, this%StatusLog, rval=val)
     if (this%StatusLog%labort_marbl) then
@@ -604,7 +601,6 @@ contains
     integer(int_kind),             intent(out)   :: val
 
     character(len=*), parameter :: subname = 'marbl_interface:get_integer'
-    character(len=char_len) :: log_message
 
     call this%settings%get(varname, this%StatusLog, ival=val)
     if (this%StatusLog%labort_marbl) then
@@ -623,7 +619,6 @@ contains
     logical,                       intent(out)   :: val
 
     character(len=*), parameter :: subname = 'marbl_interface:get_logical'
-    character(len=char_len) :: log_message
 
     call this%settings%get(varname, this%StatusLog, lval=val)
     if (this%StatusLog%labort_marbl) then
@@ -729,6 +724,7 @@ contains
                                           lname    = lname,        &
                                           units    = units,        &
                                           datatype = datatype)
+    end if
 
   end subroutine inquire_settings_metadata_by_name
 

--- a/src/marbl_interface_private_types.F90
+++ b/src/marbl_interface_private_types.F90
@@ -3,7 +3,6 @@ module marbl_interface_private_types
   ! module definitions of types that are internal to marbl
 
   use marbl_kinds_mod, only : r8
-  use marbl_kinds_mod, only : log_kind
   use marbl_kinds_mod, only : int_kind
   use marbl_kinds_mod, only : char_len
 
@@ -547,7 +546,6 @@ contains
     ! tracer_cnt by 1 for each tracer that is included. Note that this gives an
     ! accurate count whether the carbon isotope tracers are included or not.
 
-    use marbl_constants_mod, only : c0
     use marbl_pft_mod, only : autotroph_type
     use marbl_pft_mod, only : zooplankton_type
 

--- a/src/marbl_interface_private_types.F90
+++ b/src/marbl_interface_private_types.F90
@@ -338,8 +338,6 @@ contains
 
     class(column_sinking_particle_type), intent(inout) :: this
 
-    integer (int_kind) :: num_levels
-
     deallocate(this%sflux_in)
     deallocate(this%hflux_in)
     deallocate(this%prod)

--- a/src/marbl_interface_public_types.F90
+++ b/src/marbl_interface_public_types.F90
@@ -2,8 +2,7 @@ module marbl_interface_public_types
   ! module for definitions of types that are shared between marbl interior and the driver.
 
   use marbl_kinds_mod           , only : r8, log_kind, int_kind, char_len
-  use marbl_constants_mod       , only : c0, c1
-  use marbl_interface_constants , only : marbl_str_length
+  use marbl_constants_mod       , only : c0
   use marbl_logging             , only : marbl_log_type
 
   implicit none

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -1096,8 +1096,6 @@ contains
     character(len=*), parameter :: subname = 'marbl_mod:marbl_compute_particulate_terms'
     character(len=char_len)     :: log_message
 
-!   real (r8) :: TfuncS  ! temperature scaling from soft POM remin, not currently being applied
-
     real (r8) :: &
          DECAY_Hard,         & ! scaling factor for dissolution of Hard Ballast
          DECAY_HardDust        ! scaling factor for dissolution of Hard dust
@@ -1153,12 +1151,12 @@ contains
     !  compute scalelength and decay factors
     !-----------------------------------------------------------------------
 
+    scalelength = c1 ! avoid 'scalelength' may be used uninitialized warning from gfortran
     if (zw(k) < parm_scalelen_z(1)) then
        scalelength = parm_scalelen_vals(1)
     else if (zw(k) >= parm_scalelen_z(size(parm_scalelen_z))) then
        scalelength = parm_scalelen_vals(size(parm_scalelen_z))
     else
-       scalelength = c0
        do n = 2, size(parm_scalelen_z)
           if (zw(k) < parm_scalelen_z(n)) then
              scalelength = parm_scalelen_vals(n-1) &
@@ -1417,7 +1415,7 @@ contains
 
     else
 
-       dzr_loc = c0
+       dzr_loc = c0 ! avoid 'dzr_loc' may be used uninitialized warning from gfortran
        POC%remin(k) = c0
        POC%sflux_out(k) = c0
        POC%hflux_out(k) = c0

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -626,7 +626,6 @@ contains
 
     call marbl_restore_compute_interior_restore(            &
                tracers,                                     &
-               km,                                          &
                interior_forcings,                           &
                interior_forcing_indices,                    &
                interior_restore)

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -101,7 +101,6 @@ module marbl_mod
   use marbl_settings_mod, only : ladjust_bury_coeff
   use marbl_settings_mod, only : autotrophs
   use marbl_settings_mod, only : zooplankton
-  use marbl_settings_mod, only : parm_Fe_bioavail
   use marbl_settings_mod, only : dust_to_Fe
   use marbl_settings_mod, only : denitrif_C_N
   use marbl_settings_mod, only : parm_Red_Fe_C
@@ -109,18 +108,6 @@ module marbl_mod
   use marbl_settings_mod, only : parm_scalelen_z
   use marbl_settings_mod, only : parm_scalelen_vals
   use marbl_settings_mod, only : caco3_poc_min
-  use marbl_settings_mod, only : CaCO3_sp_thres
-  use marbl_settings_mod, only : CaCO3_temp_thres1
-  use marbl_settings_mod, only : CaCO3_temp_thres2
-  use marbl_settings_mod, only : DOC_reminR_light
-  use marbl_settings_mod, only : DON_reminR_light
-  use marbl_settings_mod, only : DOP_reminR_light
-  use marbl_settings_mod, only : DOC_reminR_dark
-  use marbl_settings_mod, only : DON_reminR_dark
-  use marbl_settings_mod, only : DOP_reminR_dark
-  use marbl_settings_mod, only : DOCr_reminR0
-  use marbl_settings_mod, only : DONr_reminR0
-  use marbl_settings_mod, only : DOPr_reminR0
   use marbl_settings_mod, only : DOCprod_refract
   use marbl_settings_mod, only : DONprod_refract
   use marbl_settings_mod, only : DOPprod_refract
@@ -131,12 +118,8 @@ module marbl_mod
   use marbl_settings_mod, only : f_graze_CaCO3_REMIN
   use marbl_settings_mod, only : f_graze_si_remin
   use marbl_settings_mod, only : f_graze_sp_poc_lim
-  use marbl_settings_mod, only : f_photosp_CaCO3
   use marbl_settings_mod, only : bury_coeff_rmean_timescale_years
-  use marbl_settings_mod, only : parm_f_prod_sp_CaCO3
-  use marbl_settings_mod, only : parm_kappa_nitrif
   use marbl_settings_mod, only : parm_labile_ratio
-  use marbl_settings_mod, only : parm_nitrif_par_lim
   use marbl_settings_mod, only : parm_o2_min
   use marbl_settings_mod, only : parm_o2_min_delta
   use marbl_settings_mod, only : parm_red_d_c_o2
@@ -144,7 +127,6 @@ module marbl_mod
   use marbl_settings_mod, only : parm_Remin_D_C_O2
   use marbl_settings_mod, only : QCaCO3_max
   use marbl_settings_mod, only : Qfe_zoo
-  use marbl_settings_mod, only : r_Nfix_photo
   use marbl_settings_mod, only : spc_poc_fac
   use marbl_settings_mod, only : grazing
   use marbl_settings_mod, only : PON_bury_coeff
@@ -1082,7 +1064,6 @@ contains
 
     ! !USES:
 
-    use marbl_constants_mod, only : Tref
     use marbl_constants_mod, only : cmperm
     use marbl_settings_mod , only : parm_Fe_desorption_rate0
     use marbl_settings_mod , only : parm_sed_denitrif_coeff
@@ -1208,12 +1189,6 @@ contains
 
     DECAY_Hard     = exp(-delta_z(k) * p_remin_scalef / 4.0e6_r8)
     DECAY_HardDust = exp(-delta_z(k) * p_remin_scalef / 1.2e8_r8)
-
-    !----------------------------------------------------------------------
-    !   Tref = 30.0 reference temperature (degC)
-    !   not currently being applied
-    !----------------------------------------------------------------------
-!   TfuncS = 1.5_r8**(((temperature + T0_Kelvin) - (Tref + T0_Kelvin)) / c10)
 
     poc_error = .false.
     dz_loc = delta_z(k)
@@ -1821,7 +1796,6 @@ contains
     use marbl_co2calc_mod, only : co2calc_coeffs_type
     use marbl_co2calc_mod, only : co2calc_state_type
     use marbl_oxygen, only : o2sat_surf
-    use marbl_constants_mod, only : molw_Fe
     use marbl_nhx_surface_emis_mod, only : marbl_comp_nhx_surface_emis
     use marbl_settings_mod, only : lcompute_nhx_surface_emis
     use marbl_settings_mod, only : xkw_coeff
@@ -3631,7 +3605,6 @@ contains
              autotroph_secondary_species, PAR_col_frac, PAR_in, PAR_avg, &
              dz1, tracer_local, marbl_tracer_indices, dissolved_organic_matter)
 
-    use marbl_settings_mod, only : Qfe_zoo
     use marbl_settings_mod, only : Q
     use marbl_settings_mod, only : DOC_reminR_light
     use marbl_settings_mod, only : DON_reminR_light
@@ -3760,7 +3733,7 @@ contains
        Fefree, Fe_scavenge_rate, Fe_scavenge, Lig_scavenge, &
        marbl_status_log)
 
-    use marbl_constants_mod, only : c1, c2, c3, c4
+    use marbl_constants_mod, only : c3, c4
     use marbl_settings_mod , only : Lig_cnt
     use marbl_settings_mod , only : parm_Fe_scavenge_rate0
     use marbl_settings_mod , only : parm_Lig_scavenge_rate0
@@ -4102,7 +4075,6 @@ contains
         Lig_loc, Lig_scavenge, auto_cnt, photoFe,            &
         Lig_prod, Lig_photochem, Lig_deg, Lig_loss)
 
-    use marbl_constants_mod , only : c2, yps, ypd, dps
     use marbl_settings_mod  , only : remin_to_Lig
     use marbl_settings_mod  , only : parm_Lig_degrade_rate0
 

--- a/src/marbl_mod.F90
+++ b/src/marbl_mod.F90
@@ -150,9 +150,7 @@ module marbl_mod
   use marbl_interface_public_types, only : marbl_diagnostics_type
   use marbl_interface_public_types, only : marbl_running_mean_0d_type
 
-  use marbl_pft_mod, only : autotroph_type
   use marbl_pft_mod, only : autotroph_local_type
-  use marbl_pft_mod, only : zooplankton_type
   use marbl_pft_mod, only : autotroph_secondary_species_type
   use marbl_pft_mod, only : zooplankton_secondary_species_type
   use marbl_pft_mod, only : marbl_zooplankton_share_type

--- a/src/marbl_nhx_surface_emis_mod.F90
+++ b/src/marbl_nhx_surface_emis_mod.F90
@@ -84,7 +84,6 @@ contains
        kw_nh3)
 
     use marbl_schmidt_number_mod, only : schmidt_nh3_surf
-    use marbl_constants_mod     , only : c0
     use marbl_constants_mod     , only : hrps
 
     integer(int_kind)  , intent(in)  :: num_elements
@@ -121,7 +120,6 @@ contains
        kg_nh3)
 
     use marbl_schmidt_number_mod, only : schmidt_nh3_air
-    use marbl_constants_mod     , only : c0
     use marbl_constants_mod     , only : c1
     use marbl_constants_mod     , only : c2
     use marbl_constants_mod     , only : vonkar
@@ -172,7 +170,6 @@ contains
        sss,                        &
        Hstar_nhx)
 
-    use marbl_constants_mod, only : c0
     use marbl_constants_mod, only : c1
     use marbl_constants_mod, only : T0_Kelvin
 

--- a/src/marbl_oxygen.F90
+++ b/src/marbl_oxygen.F90
@@ -2,11 +2,8 @@
 
 module marbl_oxygen
 
-  use marbl_kinds_mod, only : log_kind
   use marbl_kinds_mod, only : int_kind
   use marbl_kinds_mod, only : r8
-
-  use marbl_constants_mod, only : c0
 
   implicit none
 

--- a/src/marbl_pft_mod.F90
+++ b/src/marbl_pft_mod.F90
@@ -5,7 +5,7 @@ module marbl_pft_mod
   use marbl_kinds_mod, only : int_kind
   use marbl_kinds_mod, only : char_len
 
-  use marbl_constants_mod, only : c0, c1
+  use marbl_constants_mod, only : c1
 
   use marbl_logging, only : marbl_log_type
 

--- a/src/marbl_restore_mod.F90
+++ b/src/marbl_restore_mod.F90
@@ -22,7 +22,7 @@ contains
 
 !*****************************************************************************
 
-subroutine marbl_restore_compute_interior_restore(interior_tracers, km,       &
+subroutine marbl_restore_compute_interior_restore(interior_tracers,           &
                                                   interior_forcings,          &
                                                   interior_forcing_ind,       &
                                                   interior_restore)
@@ -37,7 +37,6 @@ subroutine marbl_restore_compute_interior_restore(interior_tracers, km,       &
   !-----------------------------------------------------------------------
 
   real(kind=r8), dimension(:,:),               intent(in) :: interior_tracers
-  integer,                                     intent(in) :: km
   type(marbl_forcing_fields_type),             intent(in) :: interior_forcings(:)
   type(marbl_interior_forcing_indexing_type),  intent(in) :: interior_forcing_ind
 

--- a/src/marbl_schmidt_number_mod.F90
+++ b/src/marbl_schmidt_number_mod.F90
@@ -26,7 +26,6 @@ contains
     !        doi:10.4319/lom.2014.12.351
 
     use marbl_kinds_mod     , only : r8, int_kind
-    use marbl_constants_mod , only : c0
 
     implicit none
 
@@ -69,7 +68,6 @@ contains
     !  following Wanninkhof 2014, a 4th order polynomial is used
 
     use marbl_kinds_mod     , only : r8, int_kind
-    use marbl_constants_mod , only : c0
 
     implicit none
 
@@ -114,7 +112,6 @@ contains
     !  schmidt_nh3_air scales quadratically with atmpres
 
     use marbl_kinds_mod     , only : r8, int_kind
-    use marbl_constants_mod , only : c0
 
     implicit none
 

--- a/src/marbl_settings_mod.F90
+++ b/src/marbl_settings_mod.F90
@@ -439,6 +439,7 @@ contains
         max_grazer_prey_cnt           = -1       ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
       case DEFAULT
         write(log_message, "(3A)") "'", trim(PFT_defaults), "'' is not a valid value for PFT_defaults"
+        call marbl_status_log%log_error(log_message, subname)
     end select
 
   end subroutine marbl_settings_set_defaults_PFT_counts
@@ -1169,7 +1170,6 @@ contains
     type(marbl_log_type),       intent(inout) :: marbl_status_log
 
     character(len=*), parameter :: subname = 'marbl_settings_mod:marbl_settings_define_PFT_derived_types'
-    character(len=char_len)     :: log_message
 
     character(len=char_len)          :: sname, lname, units, datatype, category
     real(r8),                pointer :: rptr => NULL()
@@ -1927,7 +1927,7 @@ contains
 
     type(marbl_single_setting_ll_type), pointer :: new_entry, ll_ptr, ll_prev
     character(len=char_len), dimension(:), pointer :: new_categories
-    integer :: cat_ind, n
+    integer :: cat_ind
     character(len=char_len) :: log_message, alternate_sname, tmp_sval
     logical :: put_success, datatype_match, nondefault_val
     logical :: allow_nondefault, require_nondefault, put_called
@@ -1967,6 +1967,7 @@ contains
 
     ! 2) Error checking
     ll_ptr => this%vars
+    nullify(ll_prev)
     do while (associated(ll_ptr))
       if (case_insensitive_eq(trim(sname), trim(ll_ptr%short_name))) then
         write(log_message, "(A,1X,A)") trim(sname), "has been added twice"
@@ -2412,7 +2413,7 @@ contains
     character(len=*), optional, intent(in)    :: sval
     character(len=*), optional, intent(in)    :: uval
 
-    type(marbl_single_setting_ll_type), pointer :: new_entry, ll_ptr
+    type(marbl_single_setting_ll_type), pointer :: new_entry
     character(len=*), parameter :: subname = 'marbl_settings_mod:put'
     character(len=char_len) :: log_message
 
@@ -2613,17 +2614,13 @@ contains
 
   !*****************************************************************************
 
-  subroutine inquire_metadata(this, id, marbl_status_log, sname, lname, units, &
+  subroutine inquire_metadata(this, id, sname, lname, units, &
                               datatype)
 
     class(marbl_settings_type), intent(in)    :: this
     integer(int_kind),          intent(in)    :: id
-    type(marbl_log_type),       intent(inout) :: marbl_status_log
     character(len=*), optional, intent(out)   :: sname, lname, units
     character(len=*), optional, intent(out)   :: datatype
-
-    character(len=*), parameter :: subname = 'marbl_settings_mod:inquire_metadata'
-    character(len=char_len)     :: log_message
 
     if (present(sname)) then
       sname = this%varArray(id)%ptr%short_name

--- a/src/marbl_settings_mod.F90
+++ b/src/marbl_settings_mod.F90
@@ -1967,7 +1967,7 @@ contains
 
     ! 2) Error checking
     ll_ptr => this%vars
-    nullify(ll_prev)
+    nullify(ll_prev) ! avoid 'll_prev' may be used uninitialized warning from gfortran
     do while (associated(ll_ptr))
       if (case_insensitive_eq(trim(sname), trim(ll_ptr%short_name))) then
         write(log_message, "(A,1X,A)") trim(sname), "has been added twice"

--- a/src/marbl_utils_mod.F90
+++ b/src/marbl_utils_mod.F90
@@ -32,12 +32,12 @@ contains
 
     if ((y(1).gt.c0).and.(y(2).gt.c0)) then
        ! If no linear root is found, function will return 0
-       linear_root = 0
+       linear_root = c0 ! avoid 'linear_root' may be used uninitialized warning from gfortran
        call marbl_status_log%log_error("can not find root, both y-values are positive!", subname)
        return
     else if ((y(1).lt.c0).and.(y(2).lt.c0)) then
        ! If no linear root is found, function will return 0
-       linear_root = 0
+       linear_root = c0 ! avoid 'linear_root' may be used uninitialized warning from gfortran
        call marbl_status_log%log_error("can not find root, both y-values are negative!", subname)
        return
     end if

--- a/src/marbl_utils_mod.F90
+++ b/src/marbl_utils_mod.F90
@@ -73,6 +73,7 @@ contains
     ! Initialize some local variables and intent(out)
     linit_new_substr = .true.
     linside_delim = .false.
+    cur_pos = 1
     if (len_trim(str) .eq. 0) then
       allocate(substrs(1))
       substrs(1) = ''

--- a/src/marbl_utils_mod.F90
+++ b/src/marbl_utils_mod.F90
@@ -31,9 +31,13 @@ contains
     real(kind=r8) :: m_inv
 
     if ((y(1).gt.c0).and.(y(2).gt.c0)) then
+       ! If no linear root is found, function will return 0
+       linear_root = 0
        call marbl_status_log%log_error("can not find root, both y-values are positive!", subname)
        return
     else if ((y(1).lt.c0).and.(y(2).lt.c0)) then
+       ! If no linear root is found, function will return 0
+       linear_root = 0
        call marbl_status_log%log_error("can not find root, both y-values are negative!", subname)
        return
     end if

--- a/tests/driver_src/Makefile
+++ b/tests/driver_src/Makefile
@@ -125,7 +125,7 @@ all: gnu
 
 .PHONY: gnu
 gnu:
-	$(MAKE) -f $(MAKE_DIR)/Makefile $(EXE) COMP_NAME=gnu$(MPISUF) FC=gfortran FCFLAGS="-O2 -ffree-form -cpp" INC="-J $(OBJ_ROOT)/gnu$(MPISUF)" INC2="-J $(OBJ_ROOT)/gnu$(MPISUF)/driver"
+	$(MAKE) -f $(MAKE_DIR)/Makefile $(EXE) COMP_NAME=gnu$(MPISUF) FC=gfortran FCFLAGS="-Wall -O2 -ffree-form -cpp" INC="-J $(OBJ_ROOT)/gnu$(MPISUF)" INC2="-J $(OBJ_ROOT)/gnu$(MPISUF)/driver"
 
 .PHONY: intel
 intel:

--- a/tests/driver_src/Makefile
+++ b/tests/driver_src/Makefile
@@ -125,7 +125,7 @@ all: gnu
 
 .PHONY: gnu
 gnu:
-	$(MAKE) -f $(MAKE_DIR)/Makefile $(EXE) COMP_NAME=gnu$(MPISUF) FC=gfortran FCFLAGS="-Wall -O2 -ffree-form -cpp" INC="-J $(OBJ_ROOT)/gnu$(MPISUF)" INC2="-J $(OBJ_ROOT)/gnu$(MPISUF)/driver"
+	$(MAKE) -f $(MAKE_DIR)/Makefile $(EXE) COMP_NAME=gnu$(MPISUF) FC=gfortran FCFLAGS="-Wall -Werror -O2 -ffree-form -cpp" INC="-J $(OBJ_ROOT)/gnu$(MPISUF)" INC2="-J $(OBJ_ROOT)/gnu$(MPISUF)/driver"
 
 .PHONY: intel
 intel:

--- a/tests/driver_src/Makefile
+++ b/tests/driver_src/Makefile
@@ -137,7 +137,7 @@ pgi:
 
 .PHONY: nag
 nag:
-	$(MAKE) -f $(MAKE_DIR)/Makefile $(EXE) COMP_NAME=nag$(MPISUF) FC=nagfor FCFLAGS="-O2 -free -kind=byte -wmismatch=mpi_bcast" INC="-mdir $(OBJ_ROOT)/nag$(MPISUF) -I$(OBJ_ROOT)/nag$(MPISUF)" INC2="-mdir $(OBJ_ROOT)/nag$(MPISUF)/driver -I$(OBJ_ROOT)/nag$(MPISUF)/driver"
+	$(MAKE) -f $(MAKE_DIR)/Makefile $(EXE) COMP_NAME=nag$(MPISUF) FC=nagfor FCFLAGS="-colour -O2 -free -kind=byte -wmismatch=mpi_bcast" INC="-mdir $(OBJ_ROOT)/nag$(MPISUF) -I$(OBJ_ROOT)/nag$(MPISUF)" INC2="-mdir $(OBJ_ROOT)/nag$(MPISUF)/driver -I$(OBJ_ROOT)/nag$(MPISUF)/driver"
 
 .PHONY: cray
 cray:

--- a/tests/driver_src/marbl.F90
+++ b/tests/driver_src/marbl.F90
@@ -530,10 +530,10 @@ Contains
       do n=1, timers%num_timers
         ind_runtime = timers%cumulative_runtimes(n)
         if (mpi_on) then
+          min_runtime = ind_runtime
+          max_runtime = ind_runtime
+          tot_runtime = ind_runtime
           if (my_task.eq.0) then
-            min_runtime = ind_runtime
-            max_runtime = ind_runtime
-            tot_runtime = ind_runtime
             write(log_message, 100) trim(timers%names(n)), ind_runtime,       &
                                     ' (Task 0)'
             call driver_status_log%log_noerror(log_message, subname)

--- a/tests/driver_src/marbl.F90
+++ b/tests/driver_src/marbl.F90
@@ -39,7 +39,7 @@ Program marbl
   ! Use from libmarbl.a
   use marbl_interface, only : marbl_interface_class
   use marbl_logging,   only : marbl_log_type
-  use marbl_kinds_mod, only : r8, char_len
+  use marbl_kinds_mod, only : char_len
 
   ! Driver modules for individual tests
   use marbl_init_drv,    only : marbl_init_test    => test

--- a/tests/driver_src/marbl.F90
+++ b/tests/driver_src/marbl.F90
@@ -68,7 +68,7 @@ Program marbl
 
   type(marbl_interface_class)   :: marbl_instance
   type(marbl_log_type)          :: driver_status_log
-  integer                       :: m, n, nt, cnt
+  integer                       :: n, nt, cnt
   character(len=char_len)       :: input_line, testname, varname, log_message, log_out_file
   logical                       :: lprint_marbl_log, lhas_namelist_file, lhas_input_file
   logical                       :: ldriver_log_to_file, lsummarize_timers
@@ -514,6 +514,7 @@ Contains
 
     real(r8) :: min_runtime, ind_runtime, max_runtime, tot_runtime
     character(len=15) :: int_to_str
+    integer :: m, n
 
 100 format(A, ': ', F11.3, ' seconds',A)
 

--- a/tests/driver_src/marbl.F90
+++ b/tests/driver_src/marbl.F90
@@ -39,7 +39,7 @@ Program marbl
   ! Use from libmarbl.a
   use marbl_interface, only : marbl_interface_class
   use marbl_logging,   only : marbl_log_type
-  use marbl_kinds_mod, only : r8
+  use marbl_kinds_mod, only : r8, char_len
 
   ! Driver modules for individual tests
   use marbl_init_drv,    only : marbl_init_test    => test
@@ -58,25 +58,23 @@ Program marbl
 
   Implicit None
 
-  character(len=256), parameter :: subname = 'Program Marbl'
+  character(len=char_len), parameter :: subname = 'Program Marbl'
 
   ! Variables for processing commandline arguments
-  character(256) :: progname, argstr
-  character(256) :: namelist_file, input_file
+  character(len=char_len) :: progname, argstr
+  character(len=char_len) :: namelist_file, input_file
   integer        :: argcnt
   logical        :: labort_after_argparse, lshow_usage, lfound_file
 
   type(marbl_interface_class)   :: marbl_instance
   type(marbl_log_type)          :: driver_status_log
   integer                       :: m, n, nt, cnt
-  character(len=256)            :: input_line, testname, varname, log_message, log_out_file
+  character(len=char_len)       :: input_line, testname, varname, log_message, log_out_file
   logical                       :: lprint_marbl_log, lhas_namelist_file, lhas_input_file
   logical                       :: ldriver_log_to_file, lsummarize_timers
 
   ! Processing input file for put calls
   integer  :: ioerr
-  integer  :: ival
-  real(r8) :: rval
 
   namelist /marbl_driver_nml/testname, log_out_file
 
@@ -416,8 +414,8 @@ Contains
     character(len=*),            intent(in)    :: input_file
     type(marbl_interface_class), intent(inout) :: marbl_instance
 
-    character(len=256), parameter :: subname = 'marbl::read_input_file'
-    character(len=256) :: input_line
+    character(len=char_len), parameter :: subname = 'marbl::read_input_file'
+    character(len=char_len) :: input_line
     integer :: ioerr
 
     if (my_task .eq. 0) open(97, file=trim(input_file), status="old", iostat=ioerr)

--- a/tests/driver_src/marbl_get_put_drv.F90
+++ b/tests/driver_src/marbl_get_put_drv.F90
@@ -109,8 +109,6 @@ Contains
 
   subroutine set_all_vals(local_instance, marbl_instance, driver_status_log)
 
-    use marbl_mpi_mod, only : marbl_mpi_abort
-
     type(marbl_interface_class),       intent(inout) :: local_instance ! inout because inquire_settings_metadata updates StatusLog
     type(marbl_interface_class),       intent(inout) :: marbl_instance
     type(marbl_log_type),              intent(inout) :: driver_status_log

--- a/tests/driver_src/marbl_init_drv.F90
+++ b/tests/driver_src/marbl_init_drv.F90
@@ -16,8 +16,6 @@ Contains
 
   subroutine test(marbl_instance, nt, lshutdown)
 
-    use marbl_mpi_mod, only : marbl_mpi_abort
-
     type(marbl_interface_class), intent(inout) :: marbl_instance
     integer, optional,           intent(inout) :: nt
     logical, optional,           intent(in)    :: lshutdown

--- a/tests/driver_src/marbl_mpi_mod.F90
+++ b/tests/driver_src/marbl_mpi_mod.F90
@@ -48,8 +48,11 @@ contains
     integer :: ierr
 
     call MPI_Init(ierr)
+    call check_mpi_err_code(ierr)
     call MPI_Comm_rank(MPI_COMM_WORLD, my_task, ierr)
+    call check_mpi_err_code(ierr)
     call MPI_Comm_size(MPI_COMM_WORLD, num_tasks, ierr)
+    call check_mpi_err_code(ierr)
 #else
     my_task = 0
     num_tasks = 1
@@ -59,122 +62,112 @@ contains
 
   !****************************************************************************
 
-  subroutine marbl_mpi_barrier()
-
-#ifdef MARBL_WITH_MPI
-    integer :: ierr
-
-    call MPI_Barrier(MPI_COMM_WORLD, ierr)
-#endif
-
-  end subroutine marbl_mpi_barrier
-  !****************************************************************************
-
   subroutine marbl_mpi_finalize()
 
 #ifdef MARBL_WITH_MPI
     integer :: ierr
 
     call MPI_Finalize(ierr)
+    call check_mpi_err_code(ierr)
 #endif
 
   end subroutine marbl_mpi_finalize
 
   !****************************************************************************
 
-  subroutine marbl_mpi_send_dbl(dbl_var, receiver)
+  subroutine marbl_mpi_send_dbl(dbl_var, dest)
 
     use marbl_kinds_mod, only : r8
 
     real(r8), intent(in) :: dbl_var
-    integer,  intent(in)  :: receiver
+    integer,  intent(in)  :: dest
 
     integer :: ierr
 
 #ifdef MARBL_WITH_MPI
-    call MPI_Send(dbl_var, 1, MPI_DOUBLE_PRECISION, 0, 2017, MPI_COMM_WORLD, ierr)
+    call MPI_Send(dbl_var, 1, MPI_DOUBLE_PRECISION, dest, 2017, MPI_COMM_WORLD, ierr)
+    call check_mpi_err_code(ierr)
 #else
-    ierr = receiver + floor(dbl_var)
+    ierr = dest + floor(dbl_var)
 #endif
 
   end subroutine marbl_mpi_send_dbl
 
   !****************************************************************************
 
-  subroutine marbl_mpi_recv_dbl(dbl_var, sender)
+  subroutine marbl_mpi_recv_dbl(dbl_var, source)
 
     use marbl_kinds_mod, only : r8
 
     real(r8), intent(out) :: dbl_var
-    integer,  intent(in)  :: sender
+    integer,  intent(in)  :: source
 
     integer :: ierr
 
 #ifdef MARBL_WITH_MPI
     integer :: status(MPI_STATUS_SIZE)
 
-    call MPI_Recv(dbl_var, 1, MPI_DOUBLE_PRECISION, sender, 2017,             &
-                  MPI_COMM_WORLD, status, ierr)
+    call MPI_Recv(dbl_var, 1, MPI_DOUBLE_PRECISION, source, 2017, MPI_COMM_WORLD, status, ierr)
+    call check_mpi_err_code(ierr)
 #else
     dbl_var = 0._r8
-    ierr = sender
+    ierr = source
 #endif
 
   end subroutine marbl_mpi_recv_dbl
 
   !****************************************************************************
 
-  subroutine marbl_mpi_bcast_str(str_to_bcast, root_task)
+  subroutine marbl_mpi_bcast_str(str_to_bcast, root)
 
     character(len=*), intent(inout) :: str_to_bcast
-    integer,          intent(in)    :: root_task
+    integer,          intent(in)    :: root
 
     integer :: ierr
 
 #ifdef MARBL_WITH_MPI
-    call MPI_Bcast(str_to_bcast, len(str_to_bcast), MPI_CHARACTER, root_task, &
-                   MPI_COMM_WORLD, ierr)
+    call MPI_Bcast(str_to_bcast, len(str_to_bcast), MPI_CHARACTER, root, MPI_COMM_WORLD, ierr)
+    call check_mpi_err_code(ierr)
 #else
     ! Avoid an empty subroutine when no MPI
-    ierr = root_task + len(str_to_bcast)
+    ierr = root + len(str_to_bcast)
 #endif
 
   end subroutine marbl_mpi_bcast_str
 
   !****************************************************************************
 
-  subroutine marbl_mpi_bcast_logical(logical_to_bcast, root_task)
+  subroutine marbl_mpi_bcast_logical(logical_to_bcast, root)
 
     logical, intent(inout) :: logical_to_bcast
-    integer, intent(in)    :: root_task
+    integer, intent(in)    :: root
 
     integer :: ierr
 
 #ifdef MARBL_WITH_MPI
-    call MPI_Bcast(logical_to_bcast, 1, MPI_LOGICAL, root_task, &
-                   MPI_COMM_WORLD, ierr)
+    call MPI_Bcast(logical_to_bcast, 1, MPI_LOGICAL, root, MPI_COMM_WORLD, ierr)
 #else
     ! Avoid an empty subroutine when no MPI
-    if (logical_to_bcast) ierr = root_task
+    if (logical_to_bcast) ierr = root
 #endif
 
   end subroutine marbl_mpi_bcast_logical
 
   !****************************************************************************
 
-  subroutine marbl_mpi_bcast_integer(int_to_bcast, root_task)
+  subroutine marbl_mpi_bcast_integer(int_to_bcast, root)
 
     integer, intent(inout) :: int_to_bcast
-    integer, intent(in)    :: root_task
+    integer, intent(in)    :: root
 
     integer :: ierr
 
 #ifdef MARBL_WITH_MPI
-    call MPI_Bcast(int_to_bcast, 1, MPI_INTEGER, root_task, &
-                   MPI_COMM_WORLD, ierr)
+    call MPI_Bcast(int_to_bcast, 1, MPI_INTEGER, root, MPI_COMM_WORLD, ierr)
+    call check_mpi_err_code(ierr)
 #else
     ! Avoid an empty subroutine when no MPI
-    ierr = root_task + int_to_bcast
+    ierr = root + int_to_bcast
 #endif
 
   end subroutine marbl_mpi_bcast_integer
@@ -184,8 +177,6 @@ contains
   subroutine marbl_mpi_abort()
 
 #ifdef MARBL_WITH_MPI
-    integer :: ierr
-
     call marbl_mpi_barrier()
     call marbl_mpi_finalize()
 #endif
@@ -197,5 +188,32 @@ contains
   end subroutine marbl_mpi_abort
 
   !****************************************************************************
+
+#ifdef MARBL_WITH_MPI
+
+  subroutine marbl_mpi_barrier()
+
+    integer :: ierr
+
+    call MPI_Barrier(MPI_COMM_WORLD, ierr)
+    call check_mpi_err_code(ierr)
+
+  end subroutine marbl_mpi_barrier
+
+  !****************************************************************************
+
+  subroutine check_mpi_err_code(ierr)
+
+    integer, intent(in) :: ierr
+
+    if (ierr /= MPI_SUCCESS) then
+      call marbl_mpi_abort()
+    end if
+
+  end subroutine check_mpi_err_code
+
+#endif
+
+!****************************************************************************
 
 end module marbl_mpi_mod

--- a/tests/driver_src/marbl_mpi_mod.F90
+++ b/tests/driver_src/marbl_mpi_mod.F90
@@ -89,10 +89,12 @@ contains
     real(r8), intent(in) :: dbl_var
     integer,  intent(in)  :: receiver
 
-#ifdef MARBL_WITH_MPI
     integer :: ierr
 
+#ifdef MARBL_WITH_MPI
     call MPI_Send(dbl_var, 1, MPI_DOUBLE_PRECISION, 0, 2017, MPI_COMM_WORLD, ierr)
+#else
+    ierr = receiver + floor(dbl_var)
 #endif
 
   end subroutine marbl_mpi_send_dbl
@@ -106,14 +108,16 @@ contains
     real(r8), intent(out) :: dbl_var
     integer,  intent(in)  :: sender
 
+    integer :: ierr
+
 #ifdef MARBL_WITH_MPI
     integer :: status(MPI_STATUS_SIZE)
-    integer :: ierr
 
     call MPI_Recv(dbl_var, 1, MPI_DOUBLE_PRECISION, sender, 2017,             &
                   MPI_COMM_WORLD, status, ierr)
 #else
     dbl_var = 0._r8
+    ierr = sender
 #endif
 
   end subroutine marbl_mpi_recv_dbl
@@ -131,7 +135,7 @@ contains
     call MPI_Bcast(str_to_bcast, len(str_to_bcast), MPI_CHARACTER, root_task, &
                    MPI_COMM_WORLD, ierr)
 #else
-    ! Avoid an empty subroutien when no MPI
+    ! Avoid an empty subroutine when no MPI
     ierr = root_task + len(str_to_bcast)
 #endif
 
@@ -150,8 +154,8 @@ contains
     call MPI_Bcast(logical_to_bcast, 1, MPI_LOGICAL, root_task, &
                    MPI_COMM_WORLD, ierr)
 #else
-    ! Avoid an empty subroutien when no MPI
-    ierr = root_task
+    ! Avoid an empty subroutine when no MPI
+    if (logical_to_bcast) ierr = root_task
 #endif
 
   end subroutine marbl_mpi_bcast_logical
@@ -169,8 +173,8 @@ contains
     call MPI_Bcast(int_to_bcast, 1, MPI_INTEGER, root_task, &
                    MPI_COMM_WORLD, ierr)
 #else
-    ! Avoid an empty subroutien when no MPI
-    ierr = root_task
+    ! Avoid an empty subroutine when no MPI
+    ierr = root_task + int_to_bcast
 #endif
 
   end subroutine marbl_mpi_bcast_integer

--- a/tests/driver_src/marbl_utils_drv.F90
+++ b/tests/driver_src/marbl_utils_drv.F90
@@ -18,10 +18,10 @@ contains
 
     type(marbl_log_type),        intent(inout) :: driver_status_log
 
-    real(kind=r8)               :: linear_root, expected_root
+    real(kind=r8)               :: expected_root
     real(kind=r8), dimension(2) :: x, y
     character(len=char_len)     :: str, expected_str
-    character(len=char_len), allocatable :: substrs(:), expected_substrs(:)
+    character(len=char_len), allocatable :: expected_substrs(:)
     integer                     :: test_cnt, fail_cnt, tot_fail_cnt
     character(len=*), parameter :: subname = 'marbl_utils_drv:test'
     character(len=char_len)     :: log_message


### PR DESCRIPTION
Also elevate warnings -> errors to prevent future warnings from creeping in. Tested with gfortran 4.8.4 and 8.1.0