### PR TITLE
Add -Wextra -Wno-compare-reals gfortran flags

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -108,7 +108,7 @@ all : gnu
 
 .PHONY: gnu
 gnu:
-	$(MAKE) -f $(MAKE_DIR)/Makefile $(LIB_DIR)/libmarbl-gnu$(MPISUF).a USE_DEPS=TRUE FC=gfortran FCFLAGS="-Wall -Werror -O2 -ffree-form -J $(OBJ_DIR)/gnu$(MPISUF) -cpp" OBJ_DIR=$(OBJ_DIR)/gnu$(MPISUF) INC_DIR=$(INC_DIR)/gnu$(MPISUF)
+	$(MAKE) -f $(MAKE_DIR)/Makefile $(LIB_DIR)/libmarbl-gnu$(MPISUF).a USE_DEPS=TRUE FC=gfortran FCFLAGS="-Wall -Wextra -Wno-compare-reals -Werror -O2 -ffree-form -J $(OBJ_DIR)/gnu$(MPISUF) -cpp" OBJ_DIR=$(OBJ_DIR)/gnu$(MPISUF) INC_DIR=$(INC_DIR)/gnu$(MPISUF)
 
 .PHONY: intel
 intel:

--- a/src/marbl_diagnostics_mod.F90
+++ b/src/marbl_diagnostics_mod.F90
@@ -4293,14 +4293,6 @@ contains
     type(marbl_surface_forcing_internal_type) , intent(in)    :: surface_forcing_internal
     type(marbl_diagnostics_type)              , intent(inout) :: surface_forcing_diags
 
-    !-----------------------------------------------------------------------
-    !  local variables
-    !-----------------------------------------------------------------------
-
-    !-----------------------------------------------------------------------
-    !  calculate gas flux quantities if necessary
-    !-----------------------------------------------------------------------
-
     associate(                                                                                  &
          ind_diag          => marbl_surface_forcing_diag_ind,                                   &
          ind_forc          => surface_forcing_ind,                                              &
@@ -4352,6 +4344,10 @@ contains
          donr_ind          => marbl_tracer_indices%donr_ind,                                    &
          docr_ind          => marbl_tracer_indices%docr_ind                                     &
          )
+
+    !-----------------------------------------------------------------------
+    !  calculate gas flux quantities if necessary
+    !-----------------------------------------------------------------------
 
     if (lflux_gas_o2 .or. lflux_gas_co2) then
 
@@ -4575,6 +4571,7 @@ contains
     real(r8) :: autotrophC_weight(marbl_domain%km)
     real(r8) :: autotrophC_zint_100m
     real(r8) :: limterm(marbl_domain%km)
+    !-----------------------------------------------------------------------
 
     associate(                                     &
          diags   => marbl_interior_diags%diags,    &
@@ -5757,18 +5754,10 @@ contains
     real (r8), dimension(num_elements) , intent(in)    :: eps_dic_g_surf ! equilibrium fractionation between total DIC and gaseous CO2
     type(marbl_diagnostics_type)       , intent(inout) :: marbl_surface_forcing_diags
 
-    !-----------------------------------------------------------------------
-    !  local variables
-    !-----------------------------------------------------------------------
-
     associate(                                          &
          diags => marbl_surface_forcing_diags%diags,    &
          ind   => marbl_surface_forcing_diag_ind        &
          )
-
-    !-----------------------------------------------------------------------
-    !    Tavg variables
-    !-----------------------------------------------------------------------
 
     diags(ind%CISO_DI13C_GAS_FLUX)%field_2d(:) = FLUX13(:)
     diags(ind%CISO_DI14C_GAS_FLUX)%field_2d(:) = FLUX14(:)

--- a/src/marbl_diagnostics_mod.F90
+++ b/src/marbl_diagnostics_mod.F90
@@ -4296,8 +4296,6 @@ contains
     !-----------------------------------------------------------------------
     !  local variables
     !-----------------------------------------------------------------------
-    character(len=*), parameter :: subname = 'marbl_diagnostics_mod:marbl_diagnostics_set_surface_forcing'
-    !-----------------------------------------------------------------------
 
     !-----------------------------------------------------------------------
     !  calculate gas flux quantities if necessary
@@ -5761,8 +5759,6 @@ contains
 
     !-----------------------------------------------------------------------
     !  local variables
-    !-----------------------------------------------------------------------
-    character(len=*), parameter :: subname = 'marbl_diagnostics_mod:store_diagnostics_ciso_surface_forcing'
     !-----------------------------------------------------------------------
 
     associate(                                          &

--- a/src/marbl_init_mod.F90
+++ b/src/marbl_init_mod.F90
@@ -227,8 +227,6 @@ contains
     !  local variables
     !-----------------------------------------------------------------------
 
-    character(len=*), parameter :: subname = 'marbl_init_mod:marbl_init_tracer_metadata'
-
     integer (int_kind) :: n        ! index for looping over tracers
     integer (int_kind) :: zoo_ind  ! zooplankton functional group index
     integer (int_kind) :: auto_ind ! autotroph functional group index

--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -736,8 +736,6 @@ contains
     character(len=*), optional,    intent(out)   :: sname, lname, units
     character(len=*), optional,    intent(out)   :: datatype
 
-    character(len=*), parameter :: subname = 'marbl_interface:inquire_settings_metadata_by_id'
-
     call this%settings%inquire_metadata(id,                  &
                                         sname    = sname,    &
                                         lname    = lname,    &

--- a/tests/driver_src/Makefile
+++ b/tests/driver_src/Makefile
@@ -125,7 +125,7 @@ all: gnu
 
 .PHONY: gnu
 gnu:
-	$(MAKE) -f $(MAKE_DIR)/Makefile $(EXE) COMP_NAME=gnu$(MPISUF) FC=gfortran FCFLAGS="-Wall -Werror -O2 -ffree-form -cpp" INC="-J $(OBJ_ROOT)/gnu$(MPISUF)" INC2="-J $(OBJ_ROOT)/gnu$(MPISUF)/driver"
+	$(MAKE) -f $(MAKE_DIR)/Makefile $(EXE) COMP_NAME=gnu$(MPISUF) FC=gfortran FCFLAGS="-Wall -Wextra -Wno-compare-reals -Werror -O2 -ffree-form -cpp" INC="-J $(OBJ_ROOT)/gnu$(MPISUF)" INC2="-J $(OBJ_ROOT)/gnu$(MPISUF)/driver"
 
 .PHONY: intel
 intel:


### PR DESCRIPTION
`-Wall` does not actually turn on ALL warnings, so we include `-Wextra` as well.
However, `-Wextra` flags checking for equality between two reals with the warning

```
Equality comparison for REAL(8) at (1)
```

And we want to allow those checks, so we also include `-Wno-compare-reals`.

These extra checks picked up on a few unused parameters (mostly `subname` being
declared in a subroutine and then never used)