### PR TITLE
Clean up PFT-related data structures and migrate k-loop out of interior_tendency_compute()

### DIFF
--- a/MARBL_tools/MARBL_settings_file_class.py
+++ b/MARBL_tools/MARBL_settings_file_class.py
@@ -228,11 +228,7 @@ class MARBL_settings_class(object):
         append_to_keys = (('PFT_defaults == "CESM2"' in self._config_keyword) and
                           (category_name == "PFT_derived_types"))
         if append_to_keys:
-            PFT_name = variable_name[:-9] # drop '_settings' from 'autotroph_settings', 'zooplankton_settings', or 'grazer_settings'
-            if PFT_name == 'zooplankton':
-                PFT_keys = self._settings['general_parms']['PFT_defaults']['_CESM2_PFT_keys'][PFT_name]
-            else:
-                PFT_keys = self._settings['general_parms']['PFT_defaults']['_CESM2_PFT_keys'][PFT_name+'s']
+            PFT_keys = self._settings['general_parms']['PFT_defaults']['_CESM2_PFT_keys'][variable_name]
         # Is the derived type an array? If so, treat each entry separately
         if ("_array_shape" in this_var.keys()):
             for n, elem_index in enumerate(_get_array_info(this_var["_array_shape"], self.settings_dict, self.tracers_dict)):
@@ -241,7 +237,12 @@ class MARBL_settings_class(object):
 
                 if append_to_keys:
                     # Add key for specific PFT
-                    self._config_keyword.append('((%s_sname)) == "%s"' % (PFT_name, PFT_keys[n]))
+                    if variable_name == 'zooplankton_settings':
+                      self._config_keyword.append('((zooplankton_sname)) == "%s"' % PFT_keys[n])
+                    elif variable_name == 'autotroph_settings':
+                      self._config_keyword.append('((autotroph_sname)) == "%s"' % PFT_keys[n])
+                    elif variable_name == 'grazing_relationship_settings':
+                      self._config_keyword.append('((grazer_sname)) == "%s"' % PFT_keys[n])
 
                 for key in _sort_with_specific_suffix_first(this_var["datatype"].keys(),'_cnt'):
                     if key[0] != '_':

--- a/MARBL_tools/MARBL_settings_file_class.py
+++ b/MARBL_tools/MARBL_settings_file_class.py
@@ -228,11 +228,11 @@ class MARBL_settings_class(object):
         append_to_keys = (('PFT_defaults == "CESM2"' in self._config_keyword) and
                           (category_name == "PFT_derived_types"))
         if append_to_keys:
-            PFT_keys = self._settings['general_parms']['PFT_defaults']['_CESM2_PFT_keys'][variable_name]
-            if variable_name == "autotrophs":
-                PFT_name = "autotroph"
+            PFT_name = variable_name[:-9] # drop '_settings' from 'autotroph_settings', 'zooplankton_settings', or 'grazer_settings'
+            if PFT_name == 'zooplankton':
+                PFT_keys = self._settings['general_parms']['PFT_defaults']['_CESM2_PFT_keys'][PFT_name]
             else:
-                PFT_name = variable_name
+                PFT_keys = self._settings['general_parms']['PFT_defaults']['_CESM2_PFT_keys'][PFT_name+'s']
         # Is the derived type an array? If so, treat each entry separately
         if ("_array_shape" in this_var.keys()):
             for n, elem_index in enumerate(_get_array_info(this_var["_array_shape"], self.settings_dict, self.tracers_dict)):

--- a/MARBL_tools/MARBL_share.py
+++ b/MARBL_tools/MARBL_share.py
@@ -82,7 +82,7 @@ def expand_template_value(key_name, MARBL_settings, unprocessed_dict, check_freq
                     template_fill_dict['((restore_this_tracer))'] = True
                     break
         elif fill_source == 'autotrophs':
-            auto_prefix = "autotrophs(%d)%%" % item
+            auto_prefix = "autotroph_settings(%d)%%" % item
             key_fill_val = MARBL_settings.settings_dict[auto_prefix + "sname"].strip('"')
             # Autotroph properties
             imp_calcifier = (MARBL_settings.settings_dict[auto_prefix + "imp_calcifier"].strip('"'))
@@ -95,7 +95,7 @@ def expand_template_value(key_name, MARBL_settings, unprocessed_dict, check_freq
             template_fill_dict['((autotroph_silicifier))'] = (silicifier == ".true.")
             template_fill_dict['((autotroph_Nfixer))'] = (Nfixer == ".true.")
         elif fill_source == 'zooplankton':
-            zoo_prefix = "zooplankton(%d)%%" % item
+            zoo_prefix = "zooplankton_settings(%d)%%" % item
             key_fill_val = MARBL_settings.settings_dict[zoo_prefix + "sname"].strip('"')
             template_fill_dict['((zooplankton_lname))'] = MARBL_settings.settings_dict[zoo_prefix + "lname"].strip('"')
         elif fill_source == 'strings':

--- a/defaults/json/settings_cesm2.0.json
+++ b/defaults/json/settings_cesm2.0.json
@@ -344,14 +344,14 @@
             }
          }
       },
-      "grazer_settings": {
+      "grazing_relationship_settings": {
          "_array_shape": [
             "max_grazer_prey_cnt",
             "zooplankton_cnt"
          ],
          "_is_allocatable": true,
          "datatype": {
-            "_type_name": "grazer_settings_type",
+            "_type_name": "grazing_relationship_settings_type",
             "auto_ind": {
                "_array_len_to_print": "auto_ind_cnt",
                "_array_shape": "autotroph_cnt",
@@ -755,17 +755,17 @@
       },
       "PFT_defaults": {
          "_CESM2_PFT_keys": {
-            "autotrophs": [
+            "autotroph_settings": [
                "sp",
                "diat",
                "diaz"
             ],
-            "grazers": [
+            "grazing_relationship_settings": [
                "sp_zoo",
                "diat_zoo",
                "diaz_zoo"
             ],
-            "zooplankton": [
+            "zooplankton_settings": [
                "zoo"
             ]
          },

--- a/defaults/json/settings_cesm2.0.json
+++ b/defaults/json/settings_cesm2.0.json
@@ -755,17 +755,17 @@
       },
       "PFT_defaults": {
          "_CESM2_PFT_keys": {
-            "autotroph_settings": [
+            "autotrophs": [
                "sp",
                "diat",
                "diaz"
             ],
-            "grazer_settings": [
+            "grazers": [
                "sp_zoo",
                "diat_zoo",
                "diaz_zoo"
             ],
-            "zooplankton_settings": [
+            "zooplankton": [
                "zoo"
             ]
          },

--- a/defaults/json/settings_cesm2.0.json
+++ b/defaults/json/settings_cesm2.0.json
@@ -34,7 +34,7 @@
       }
    },
    "PFT_derived_types": {
-      "autotrophs": {
+      "autotroph_settings": {
          "_array_shape": "autotroph_cnt",
          "_is_allocatable": true,
          "datatype": {
@@ -72,7 +72,7 @@
                "subcategory": "10. autotrophs",
                "units": "unitless"
             },
-            "_type_name": "autotrophs_type",
+            "_type_name": "autotroph_settings_type",
             "agg_rate_max": {
                "datatype": "real",
                "default_value": {
@@ -344,23 +344,23 @@
             }
          }
       },
-      "grazing": {
+      "grazer_settings": {
          "_array_shape": [
             "max_grazer_prey_cnt",
             "zooplankton_cnt"
          ],
          "_is_allocatable": true,
          "datatype": {
-            "_type_name": "grazing_type",
+            "_type_name": "grazer_settings_type",
             "auto_ind": {
                "_array_len_to_print": "auto_ind_cnt",
                "_array_shape": "autotroph_cnt",
                "_is_allocatable": true,
                "datatype": "integer",
                "default_value": {
-                  "((grazing_sname)) == \"diat_zoo\"": 2,
-                  "((grazing_sname)) == \"diaz_zoo\"": 3,
-                  "((grazing_sname)) == \"sp_zoo\"": 1,
+                  "((grazer_sname)) == \"diat_zoo\"": 2,
+                  "((grazer_sname)) == \"diaz_zoo\"": 3,
+                  "((grazer_sname)) == \"sp_zoo\"": 1,
                   "default": 0
                },
                "longname": "Indices of autotrophs being grazed",
@@ -379,9 +379,9 @@
             "f_zoo_detr": {
                "datatype": "real",
                "default_value": {
-                  "((grazing_sname)) == \"diat_zoo\"": 0.24,
-                  "((grazing_sname)) == \"diaz_zoo\"": 0.12,
-                  "((grazing_sname)) == \"sp_zoo\"": 0.12,
+                  "((grazer_sname)) == \"diat_zoo\"": 0.24,
+                  "((grazer_sname)) == \"diaz_zoo\"": 0.12,
+                  "((grazer_sname)) == \"sp_zoo\"": 0.12,
                   "default": "1e34"
                },
                "longname": "Fraction of zoo losses to detrital",
@@ -391,9 +391,9 @@
             "graze_doc": {
                "datatype": "real",
                "default_value": {
-                  "((grazing_sname)) == \"diat_zoo\"": 0.06,
-                  "((grazing_sname)) == \"diaz_zoo\"": 0.06,
-                  "((grazing_sname)) == \"sp_zoo\"": 0.06,
+                  "((grazer_sname)) == \"diat_zoo\"": 0.06,
+                  "((grazer_sname)) == \"diaz_zoo\"": 0.06,
+                  "((grazer_sname)) == \"sp_zoo\"": 0.06,
                   "default": "1e34"
                },
                "longname": "Routing of grazed term, remainder goes to dic",
@@ -403,9 +403,9 @@
             "graze_poc": {
                "datatype": "real",
                "default_value": {
-                  "((grazing_sname)) == \"diat_zoo\"": 0.38,
-                  "((grazing_sname)) == \"diaz_zoo\"": 0.1,
-                  "((grazing_sname)) == \"sp_zoo\"": 0,
+                  "((grazer_sname)) == \"diat_zoo\"": 0.38,
+                  "((grazer_sname)) == \"diaz_zoo\"": 0.1,
+                  "((grazer_sname)) == \"sp_zoo\"": 0,
                   "default": "1e34"
                },
                "longname": "Routing of grazed term, remainder goes to dic",
@@ -415,9 +415,9 @@
             "graze_zoo": {
                "datatype": "real",
                "default_value": {
-                  "((grazing_sname)) == \"diat_zoo\"": 0.25,
-                  "((grazing_sname)) == \"diaz_zoo\"": 0.3,
-                  "((grazing_sname)) == \"sp_zoo\"": 0.3,
+                  "((grazer_sname)) == \"diat_zoo\"": 0.25,
+                  "((grazer_sname)) == \"diaz_zoo\"": 0.3,
+                  "((grazer_sname)) == \"sp_zoo\"": 0.3,
                   "default": "1e34"
                },
                "longname": "Routing of grazed term, remainder goes to dic",
@@ -435,9 +435,9 @@
             "lname": {
                "datatype": "string",
                "default_value": {
-                  "((grazing_sname)) == \"diat_zoo\"": "Grazing of diat by zoo",
-                  "((grazing_sname)) == \"diaz_zoo\"": "Grazing of diaz by zoo",
-                  "((grazing_sname)) == \"sp_zoo\"": "Grazing of sp by zoo",
+                  "((grazer_sname)) == \"diat_zoo\"": "Grazing of diat by zoo",
+                  "((grazer_sname)) == \"diaz_zoo\"": "Grazing of diaz by zoo",
+                  "((grazer_sname)) == \"sp_zoo\"": "Grazing of sp by zoo",
                   "default": "UNSET"
                },
                "longname": "Long name of the grazing relationship",
@@ -447,9 +447,9 @@
             "sname": {
                "datatype": "string",
                "default_value": {
-                  "((grazing_sname)) == \"diat_zoo\"": "grz_diat_zoo",
-                  "((grazing_sname)) == \"diaz_zoo\"": "grz_diaz_zoo",
-                  "((grazing_sname)) == \"sp_zoo\"": "grz_sp_zoo",
+                  "((grazer_sname)) == \"diat_zoo\"": "grz_diat_zoo",
+                  "((grazer_sname)) == \"diaz_zoo\"": "grz_diaz_zoo",
+                  "((grazer_sname)) == \"sp_zoo\"": "grz_sp_zoo",
                   "default": "UNSET"
                },
                "longname": "Short name of the grazing relationship",
@@ -459,9 +459,9 @@
             "z_grz": {
                "datatype": "real",
                "default_value": {
-                  "((grazing_sname)) == \"diat_zoo\"": 1.2,
-                  "((grazing_sname)) == \"diaz_zoo\"": 1.2,
-                  "((grazing_sname)) == \"sp_zoo\"": 1.2,
+                  "((grazer_sname)) == \"diat_zoo\"": 1.2,
+                  "((grazer_sname)) == \"diaz_zoo\"": 1.2,
+                  "((grazer_sname)) == \"sp_zoo\"": 1.2,
                   "default": "1e34"
                },
                "longname": "Grazing coefficient",
@@ -471,9 +471,9 @@
             "z_umax_0_per_day": {
                "datatype": "real",
                "default_value": {
-                  "((grazing_sname)) == \"diat_zoo\"": 3.1,
-                  "((grazing_sname)) == \"diaz_zoo\"": 3.25,
-                  "((grazing_sname)) == \"sp_zoo\"": 3.3,
+                  "((grazer_sname)) == \"diat_zoo\"": 3.1,
+                  "((grazer_sname)) == \"diaz_zoo\"": 3.25,
+                  "((grazer_sname)) == \"sp_zoo\"": 3.3,
                   "default": "1e34"
                },
                "longname": "Max zoo growth rate at tref",
@@ -501,7 +501,7 @@
             }
          }
       },
-      "zooplankton": {
+      "zooplankton_settings": {
          "_array_shape": "zooplankton_cnt",
          "_is_allocatable": true,
          "datatype": {
@@ -755,17 +755,17 @@
       },
       "PFT_defaults": {
          "_CESM2_PFT_keys": {
-            "autotrophs": [
+            "autotroph_settings": [
                "sp",
                "diat",
                "diaz"
             ],
-            "grazing": [
+            "grazer_settings": [
                "sp_zoo",
                "diat_zoo",
                "diaz_zoo"
             ],
-            "zooplankton": [
+            "zooplankton_settings": [
                "zoo"
             ]
          },

--- a/defaults/json/settings_latest.json
+++ b/defaults/json/settings_latest.json
@@ -344,14 +344,14 @@
             }
          }
       },
-      "grazer_settings": {
+      "grazing_relationship_settings": {
          "_array_shape": [
             "max_grazer_prey_cnt",
             "zooplankton_cnt"
          ],
          "_is_allocatable": true,
          "datatype": {
-            "_type_name": "grazer_settings_type",
+            "_type_name": "grazing_relationship_settings_type",
             "auto_ind": {
                "_array_len_to_print": "auto_ind_cnt",
                "_array_shape": "autotroph_cnt",
@@ -755,17 +755,17 @@
       },
       "PFT_defaults": {
          "_CESM2_PFT_keys": {
-            "autotrophs": [
+            "autotroph_settings": [
                "sp",
                "diat",
                "diaz"
             ],
-            "grazers": [
+            "grazing_relationship_settings": [
                "sp_zoo",
                "diat_zoo",
                "diaz_zoo"
             ],
-            "zooplankton": [
+            "zooplankton_settings": [
                "zoo"
             ]
          },

--- a/defaults/json/settings_latest.json
+++ b/defaults/json/settings_latest.json
@@ -34,7 +34,7 @@
       }
    },
    "PFT_derived_types": {
-      "autotrophs": {
+      "autotroph_settings": {
          "_array_shape": "autotroph_cnt",
          "_is_allocatable": true,
          "datatype": {
@@ -72,7 +72,7 @@
                "subcategory": "10. autotrophs",
                "units": "unitless"
             },
-            "_type_name": "autotrophs_type",
+            "_type_name": "autotroph_settings_type",
             "agg_rate_max": {
                "datatype": "real",
                "default_value": {
@@ -344,23 +344,23 @@
             }
          }
       },
-      "grazing": {
+      "grazer_settings": {
          "_array_shape": [
             "max_grazer_prey_cnt",
             "zooplankton_cnt"
          ],
          "_is_allocatable": true,
          "datatype": {
-            "_type_name": "grazing_type",
+            "_type_name": "grazer_settings_type",
             "auto_ind": {
                "_array_len_to_print": "auto_ind_cnt",
                "_array_shape": "autotroph_cnt",
                "_is_allocatable": true,
                "datatype": "integer",
                "default_value": {
-                  "((grazing_sname)) == \"diat_zoo\"": 2,
-                  "((grazing_sname)) == \"diaz_zoo\"": 3,
-                  "((grazing_sname)) == \"sp_zoo\"": 1,
+                  "((grazer_sname)) == \"diat_zoo\"": 2,
+                  "((grazer_sname)) == \"diaz_zoo\"": 3,
+                  "((grazer_sname)) == \"sp_zoo\"": 1,
                   "default": 0
                },
                "longname": "Indices of autotrophs being grazed",
@@ -379,9 +379,9 @@
             "f_zoo_detr": {
                "datatype": "real",
                "default_value": {
-                  "((grazing_sname)) == \"diat_zoo\"": 0.24,
-                  "((grazing_sname)) == \"diaz_zoo\"": 0.12,
-                  "((grazing_sname)) == \"sp_zoo\"": 0.12,
+                  "((grazer_sname)) == \"diat_zoo\"": 0.24,
+                  "((grazer_sname)) == \"diaz_zoo\"": 0.12,
+                  "((grazer_sname)) == \"sp_zoo\"": 0.12,
                   "default": "1e34"
                },
                "longname": "Fraction of zoo losses to detrital",
@@ -391,9 +391,9 @@
             "graze_doc": {
                "datatype": "real",
                "default_value": {
-                  "((grazing_sname)) == \"diat_zoo\"": 0.06,
-                  "((grazing_sname)) == \"diaz_zoo\"": 0.06,
-                  "((grazing_sname)) == \"sp_zoo\"": 0.06,
+                  "((grazer_sname)) == \"diat_zoo\"": 0.06,
+                  "((grazer_sname)) == \"diaz_zoo\"": 0.06,
+                  "((grazer_sname)) == \"sp_zoo\"": 0.06,
                   "default": "1e34"
                },
                "longname": "Routing of grazed term, remainder goes to dic",
@@ -403,9 +403,9 @@
             "graze_poc": {
                "datatype": "real",
                "default_value": {
-                  "((grazing_sname)) == \"diat_zoo\"": 0.39,
-                  "((grazing_sname)) == \"diaz_zoo\"": 0.1,
-                  "((grazing_sname)) == \"sp_zoo\"": 0,
+                  "((grazer_sname)) == \"diat_zoo\"": 0.39,
+                  "((grazer_sname)) == \"diaz_zoo\"": 0.1,
+                  "((grazer_sname)) == \"sp_zoo\"": 0,
                   "default": "1e34"
                },
                "longname": "Routing of grazed term, remainder goes to dic",
@@ -415,9 +415,9 @@
             "graze_zoo": {
                "datatype": "real",
                "default_value": {
-                  "((grazing_sname)) == \"diat_zoo\"": 0.25,
-                  "((grazing_sname)) == \"diaz_zoo\"": 0.3,
-                  "((grazing_sname)) == \"sp_zoo\"": 0.3,
+                  "((grazer_sname)) == \"diat_zoo\"": 0.25,
+                  "((grazer_sname)) == \"diaz_zoo\"": 0.3,
+                  "((grazer_sname)) == \"sp_zoo\"": 0.3,
                   "default": "1e34"
                },
                "longname": "Routing of grazed term, remainder goes to dic",
@@ -435,9 +435,9 @@
             "lname": {
                "datatype": "string",
                "default_value": {
-                  "((grazing_sname)) == \"diat_zoo\"": "Grazing of diat by zoo",
-                  "((grazing_sname)) == \"diaz_zoo\"": "Grazing of diaz by zoo",
-                  "((grazing_sname)) == \"sp_zoo\"": "Grazing of sp by zoo",
+                  "((grazer_sname)) == \"diat_zoo\"": "Grazing of diat by zoo",
+                  "((grazer_sname)) == \"diaz_zoo\"": "Grazing of diaz by zoo",
+                  "((grazer_sname)) == \"sp_zoo\"": "Grazing of sp by zoo",
                   "default": "UNSET"
                },
                "longname": "Long name of the grazing relationship",
@@ -447,9 +447,9 @@
             "sname": {
                "datatype": "string",
                "default_value": {
-                  "((grazing_sname)) == \"diat_zoo\"": "grz_diat_zoo",
-                  "((grazing_sname)) == \"diaz_zoo\"": "grz_diaz_zoo",
-                  "((grazing_sname)) == \"sp_zoo\"": "grz_sp_zoo",
+                  "((grazer_sname)) == \"diat_zoo\"": "grz_diat_zoo",
+                  "((grazer_sname)) == \"diaz_zoo\"": "grz_diaz_zoo",
+                  "((grazer_sname)) == \"sp_zoo\"": "grz_sp_zoo",
                   "default": "UNSET"
                },
                "longname": "Short name of the grazing relationship",
@@ -459,9 +459,9 @@
             "z_grz": {
                "datatype": "real",
                "default_value": {
-                  "((grazing_sname)) == \"diat_zoo\"": 1.2,
-                  "((grazing_sname)) == \"diaz_zoo\"": 1.2,
-                  "((grazing_sname)) == \"sp_zoo\"": 1.2,
+                  "((grazer_sname)) == \"diat_zoo\"": 1.2,
+                  "((grazer_sname)) == \"diaz_zoo\"": 1.2,
+                  "((grazer_sname)) == \"sp_zoo\"": 1.2,
                   "default": "1e34"
                },
                "longname": "Grazing coefficient",
@@ -471,9 +471,9 @@
             "z_umax_0_per_day": {
                "datatype": "real",
                "default_value": {
-                  "((grazing_sname)) == \"diat_zoo\"": 3.15,
-                  "((grazing_sname)) == \"diaz_zoo\"": 3.3,
-                  "((grazing_sname)) == \"sp_zoo\"": 3.3,
+                  "((grazer_sname)) == \"diat_zoo\"": 3.15,
+                  "((grazer_sname)) == \"diaz_zoo\"": 3.3,
+                  "((grazer_sname)) == \"sp_zoo\"": 3.3,
                   "default": "1e34"
                },
                "longname": "Max zoo growth rate at tref",
@@ -501,11 +501,11 @@
             }
          }
       },
-      "zooplankton": {
+      "zooplankton_settings": {
          "_array_shape": "zooplankton_cnt",
          "_is_allocatable": true,
          "datatype": {
-            "_type_name": "zooplankton_type",
+            "_type_name": "zooplankton_settings_type",
             "lname": {
                "datatype": "string",
                "default_value": {
@@ -760,7 +760,7 @@
                "diat",
                "diaz"
             ],
-            "grazing": [
+            "grazers": [
                "sp_zoo",
                "diat_zoo",
                "diaz_zoo"

--- a/defaults/settings_cesm2.0.yaml
+++ b/defaults/settings_cesm2.0.yaml
@@ -203,13 +203,13 @@ general_parms :
             - CESM2
             - user-specified
       _CESM2_PFT_keys :
-         autotrophs :
+         autotroph_settings :
             - sp
             - diat
             - diaz
-         zooplankton :
+         zooplankton_settings :
             - zoo
-         grazers :
+         grazing_relationship_settings :
             - sp_zoo
             - diat_zoo
             - diaz_zoo
@@ -944,13 +944,13 @@ PFT_derived_types :
             default_value :
                default : 1e34
                ((zooplankton_sname)) == "zoo" : 0.075
-   grazer_settings :
+   grazing_relationship_settings :
       _array_shape :
          - max_grazer_prey_cnt
          - zooplankton_cnt
       _is_allocatable : true
       datatype :
-         _type_name : grazer_settings_type
+         _type_name : grazing_relationship_settings_type
          sname :
             longname : Short name of the grazing relationship
             subcategory : 12. grazing

--- a/defaults/settings_cesm2.0.yaml
+++ b/defaults/settings_cesm2.0.yaml
@@ -203,13 +203,13 @@ general_parms :
             - CESM2
             - user-specified
       _CESM2_PFT_keys :
-         autotrophs :
+         autotroph_settings :
             - sp
             - diat
             - diaz
-         zooplankton :
+         zooplankton_settings :
             - zoo
-         grazing :
+         grazer_settings :
             - sp_zoo
             - diat_zoo
             - diaz_zoo
@@ -639,13 +639,13 @@ PFT_counts :
 ################################################################################
 
 PFT_derived_types :
-   autotrophs :
+   autotroph_settings :
       _array_shape : autotroph_cnt
       _is_allocatable : true
       datatype :
          # Components of the derived type
          # (_* are not part of the type)
-         _type_name : autotrophs_type
+         _type_name : autotroph_settings_type
          sname :
             longname : Short name of the autotroph
             subcategory : 10. autotrophs
@@ -897,7 +897,7 @@ PFT_derived_types :
                ((autotroph_sname)) == "sp" : 0
                ((autotroph_sname)) == "diat" : 0
                ((autotroph_sname)) == "diaz" : 0
-   zooplankton :
+   zooplankton_settings :
       _array_shape : zooplankton_cnt
       _is_allocatable : true
       datatype :
@@ -944,13 +944,13 @@ PFT_derived_types :
             default_value :
                default : 1e34
                ((zooplankton_sname)) == "zoo" : 0.075
-   grazing :
+   grazer_settings :
       _array_shape :
          - max_grazer_prey_cnt
          - zooplankton_cnt
       _is_allocatable : true
       datatype :
-         _type_name : grazing_type
+         _type_name : grazer_settings_type
          sname :
             longname : Short name of the grazing relationship
             subcategory : 12. grazing
@@ -958,9 +958,9 @@ PFT_derived_types :
             datatype : string
             default_value :
                default : UNSET
-               ((grazing_sname)) == "sp_zoo" : grz_sp_zoo
-               ((grazing_sname)) == "diat_zoo" : grz_diat_zoo
-               ((grazing_sname)) == "diaz_zoo" : grz_diaz_zoo
+               ((grazer_sname)) == "sp_zoo" : grz_sp_zoo
+               ((grazer_sname)) == "diat_zoo" : grz_diat_zoo
+               ((grazer_sname)) == "diaz_zoo" : grz_diaz_zoo
          lname :
             longname : Long name of the grazing relationship
             subcategory : 12. grazing
@@ -968,9 +968,9 @@ PFT_derived_types :
             datatype : string
             default_value :
                default : UNSET
-               ((grazing_sname)) == "sp_zoo" : Grazing of sp by zoo
-               ((grazing_sname)) == "diat_zoo" : Grazing of diat by zoo
-               ((grazing_sname)) == "diaz_zoo" : Grazing of diaz by zoo
+               ((grazer_sname)) == "sp_zoo" : Grazing of sp by zoo
+               ((grazer_sname)) == "diat_zoo" : Grazing of diat by zoo
+               ((grazer_sname)) == "diaz_zoo" : Grazing of diaz by zoo
          auto_ind_cnt :
             longname : Number of autotrophs being grazed
             subcategory : 12. grazing
@@ -999,9 +999,9 @@ PFT_derived_types :
             datatype : real
             default_value :
                default : 1e34
-               ((grazing_sname)) == "sp_zoo" : 3.3
-               ((grazing_sname)) == "diat_zoo" : 3.1
-               ((grazing_sname)) == "diaz_zoo" : 3.25
+               ((grazer_sname)) == "sp_zoo" : 3.3
+               ((grazer_sname)) == "diat_zoo" : 3.1
+               ((grazer_sname)) == "diaz_zoo" : 3.25
          z_grz :
             longname : Grazing coefficient
             subcategory : 12. grazing
@@ -1009,9 +1009,9 @@ PFT_derived_types :
             datatype : real
             default_value :
                default : 1e34
-               ((grazing_sname)) == "sp_zoo" : 1.2
-               ((grazing_sname)) == "diat_zoo" : 1.2
-               ((grazing_sname)) == "diaz_zoo" : 1.2
+               ((grazer_sname)) == "sp_zoo" : 1.2
+               ((grazer_sname)) == "diat_zoo" : 1.2
+               ((grazer_sname)) == "diaz_zoo" : 1.2
          graze_zoo :
             longname : Routing of grazed term, remainder goes to dic
             subcategory : 12. grazing
@@ -1019,9 +1019,9 @@ PFT_derived_types :
             datatype : real
             default_value :
                default : 1e34
-               ((grazing_sname)) == "sp_zoo" : 0.3
-               ((grazing_sname)) == "diat_zoo" : 0.25
-               ((grazing_sname)) == "diaz_zoo" : 0.3
+               ((grazer_sname)) == "sp_zoo" : 0.3
+               ((grazer_sname)) == "diat_zoo" : 0.25
+               ((grazer_sname)) == "diaz_zoo" : 0.3
          graze_poc :
             longname : Routing of grazed term, remainder goes to dic
             subcategory : 12. grazing
@@ -1029,9 +1029,9 @@ PFT_derived_types :
             datatype : real
             default_value :
                default : 1e34
-               ((grazing_sname)) == "sp_zoo" : 0
-               ((grazing_sname)) == "diat_zoo" : 0.38
-               ((grazing_sname)) == "diaz_zoo" : 0.1
+               ((grazer_sname)) == "sp_zoo" : 0
+               ((grazer_sname)) == "diat_zoo" : 0.38
+               ((grazer_sname)) == "diaz_zoo" : 0.1
          graze_doc :
             longname : Routing of grazed term, remainder goes to dic
             subcategory : 12. grazing
@@ -1039,9 +1039,9 @@ PFT_derived_types :
             datatype : real
             default_value :
                default : 1e34
-               ((grazing_sname)) == "sp_zoo" : 0.06
-               ((grazing_sname)) == "diat_zoo" : 0.06
-               ((grazing_sname)) == "diaz_zoo" : 0.06
+               ((grazer_sname)) == "sp_zoo" : 0.06
+               ((grazer_sname)) == "diat_zoo" : 0.06
+               ((grazer_sname)) == "diaz_zoo" : 0.06
          f_zoo_detr :
             longname : Fraction of zoo losses to detrital
             subcategory : 12. grazing
@@ -1049,9 +1049,9 @@ PFT_derived_types :
             datatype : real
             default_value :
                default : 1e34
-               ((grazing_sname)) == "sp_zoo" : 0.12
-               ((grazing_sname)) == "diat_zoo" : 0.24
-               ((grazing_sname)) == "diaz_zoo" : 0.12
+               ((grazer_sname)) == "sp_zoo" : 0.12
+               ((grazer_sname)) == "diat_zoo" : 0.24
+               ((grazer_sname)) == "diaz_zoo" : 0.12
          auto_ind :
             _array_shape : autotroph_cnt
             _array_len_to_print : auto_ind_cnt
@@ -1062,9 +1062,9 @@ PFT_derived_types :
             datatype : integer
             default_value :
                default : 0
-               ((grazing_sname)) == "sp_zoo" : 1 # index where autotroph_name = sp
-               ((grazing_sname)) == "diat_zoo" : 2 # index where autotroph_name = diat
-               ((grazing_sname)) == "diaz_zoo" : 3 # index where autotroph_name = diaz
+               ((grazer_sname)) == "sp_zoo" : 1 # index where autotroph_name = sp
+               ((grazer_sname)) == "diat_zoo" : 2 # index where autotroph_name = diat
+               ((grazer_sname)) == "diaz_zoo" : 3 # index where autotroph_name = diaz
          zoo_ind :
             _array_shape : zooplankton_cnt
             _array_len_to_print : zoo_ind_cnt

--- a/defaults/settings_cesm2.0.yaml
+++ b/defaults/settings_cesm2.0.yaml
@@ -203,13 +203,13 @@ general_parms :
             - CESM2
             - user-specified
       _CESM2_PFT_keys :
-         autotroph_settings :
+         autotrophs :
             - sp
             - diat
             - diaz
-         zooplankton_settings :
+         zooplankton :
             - zoo
-         grazer_settings :
+         grazers :
             - sp_zoo
             - diat_zoo
             - diaz_zoo

--- a/defaults/settings_latest.yaml
+++ b/defaults/settings_latest.yaml
@@ -209,7 +209,7 @@ general_parms :
             - diaz
          zooplankton :
             - zoo
-         grazing :
+         grazers :
             - sp_zoo
             - diat_zoo
             - diaz_zoo
@@ -641,13 +641,13 @@ PFT_counts :
 ################################################################################
 
 PFT_derived_types :
-   autotrophs :
+   autotroph_settings :
       _array_shape : autotroph_cnt
       _is_allocatable : true
       datatype :
          # Components of the derived type
          # (_* are not part of the type)
-         _type_name : autotrophs_type
+         _type_name : autotroph_settings_type
          sname :
             longname : Short name of the autotroph
             subcategory : 10. autotrophs
@@ -899,13 +899,13 @@ PFT_derived_types :
                ((autotroph_sname)) == "sp" : 0
                ((autotroph_sname)) == "diat" : 0
                ((autotroph_sname)) == "diaz" : 0
-   zooplankton :
+   zooplankton_settings :
       _array_shape : zooplankton_cnt
       _is_allocatable : true
       datatype :
          # Components of the derived type
          # (_* are not part of the type)
-         _type_name : zooplankton_type
+         _type_name : zooplankton_settings_type
          sname :
             longname : Short name of the zooplankton
             subcategory : 11. zooplankton
@@ -946,13 +946,13 @@ PFT_derived_types :
             default_value :
                default : 1e34
                ((zooplankton_sname)) == "zoo" : 0.075
-   grazing :
+   grazer_settings :
       _array_shape :
          - max_grazer_prey_cnt
          - zooplankton_cnt
       _is_allocatable : true
       datatype :
-         _type_name : grazing_type
+         _type_name : grazer_settings_type
          sname :
             longname : Short name of the grazing relationship
             subcategory : 12. grazing
@@ -960,9 +960,9 @@ PFT_derived_types :
             datatype : string
             default_value :
                default : UNSET
-               ((grazing_sname)) == "sp_zoo" : grz_sp_zoo
-               ((grazing_sname)) == "diat_zoo" : grz_diat_zoo
-               ((grazing_sname)) == "diaz_zoo" : grz_diaz_zoo
+               ((grazer_sname)) == "sp_zoo" : grz_sp_zoo
+               ((grazer_sname)) == "diat_zoo" : grz_diat_zoo
+               ((grazer_sname)) == "diaz_zoo" : grz_diaz_zoo
          lname :
             longname : Long name of the grazing relationship
             subcategory : 12. grazing
@@ -970,9 +970,9 @@ PFT_derived_types :
             datatype : string
             default_value :
                default : UNSET
-               ((grazing_sname)) == "sp_zoo" : Grazing of sp by zoo
-               ((grazing_sname)) == "diat_zoo" : Grazing of diat by zoo
-               ((grazing_sname)) == "diaz_zoo" : Grazing of diaz by zoo
+               ((grazer_sname)) == "sp_zoo" : Grazing of sp by zoo
+               ((grazer_sname)) == "diat_zoo" : Grazing of diat by zoo
+               ((grazer_sname)) == "diaz_zoo" : Grazing of diaz by zoo
          auto_ind_cnt :
             longname : Number of autotrophs being grazed
             subcategory : 12. grazing
@@ -1001,9 +1001,9 @@ PFT_derived_types :
             datatype : real
             default_value :
                default : 1e34
-               ((grazing_sname)) == "sp_zoo" : 3.3
-               ((grazing_sname)) == "diat_zoo" : 3.15
-               ((grazing_sname)) == "diaz_zoo" : 3.3
+               ((grazer_sname)) == "sp_zoo" : 3.3
+               ((grazer_sname)) == "diat_zoo" : 3.15
+               ((grazer_sname)) == "diaz_zoo" : 3.3
          z_grz :
             longname : Grazing coefficient
             subcategory : 12. grazing
@@ -1011,9 +1011,9 @@ PFT_derived_types :
             datatype : real
             default_value :
                default : 1e34
-               ((grazing_sname)) == "sp_zoo" : 1.2
-               ((grazing_sname)) == "diat_zoo" : 1.2
-               ((grazing_sname)) == "diaz_zoo" : 1.2
+               ((grazer_sname)) == "sp_zoo" : 1.2
+               ((grazer_sname)) == "diat_zoo" : 1.2
+               ((grazer_sname)) == "diaz_zoo" : 1.2
          graze_zoo :
             longname : Routing of grazed term, remainder goes to dic
             subcategory : 12. grazing
@@ -1021,9 +1021,9 @@ PFT_derived_types :
             datatype : real
             default_value :
                default : 1e34
-               ((grazing_sname)) == "sp_zoo" : 0.3
-               ((grazing_sname)) == "diat_zoo" : 0.25
-               ((grazing_sname)) == "diaz_zoo" : 0.3
+               ((grazer_sname)) == "sp_zoo" : 0.3
+               ((grazer_sname)) == "diat_zoo" : 0.25
+               ((grazer_sname)) == "diaz_zoo" : 0.3
          graze_poc :
             longname : Routing of grazed term, remainder goes to dic
             subcategory : 12. grazing
@@ -1031,9 +1031,9 @@ PFT_derived_types :
             datatype : real
             default_value :
                default : 1e34
-               ((grazing_sname)) == "sp_zoo" : 0
-               ((grazing_sname)) == "diat_zoo" : 0.39
-               ((grazing_sname)) == "diaz_zoo" : 0.1
+               ((grazer_sname)) == "sp_zoo" : 0
+               ((grazer_sname)) == "diat_zoo" : 0.39
+               ((grazer_sname)) == "diaz_zoo" : 0.1
          graze_doc :
             longname : Routing of grazed term, remainder goes to dic
             subcategory : 12. grazing
@@ -1041,9 +1041,9 @@ PFT_derived_types :
             datatype : real
             default_value :
                default : 1e34
-               ((grazing_sname)) == "sp_zoo" : 0.06
-               ((grazing_sname)) == "diat_zoo" : 0.06
-               ((grazing_sname)) == "diaz_zoo" : 0.06
+               ((grazer_sname)) == "sp_zoo" : 0.06
+               ((grazer_sname)) == "diat_zoo" : 0.06
+               ((grazer_sname)) == "diaz_zoo" : 0.06
          f_zoo_detr :
             longname : Fraction of zoo losses to detrital
             subcategory : 12. grazing
@@ -1051,9 +1051,9 @@ PFT_derived_types :
             datatype : real
             default_value :
                default : 1e34
-               ((grazing_sname)) == "sp_zoo" : 0.12
-               ((grazing_sname)) == "diat_zoo" : 0.24
-               ((grazing_sname)) == "diaz_zoo" : 0.12
+               ((grazer_sname)) == "sp_zoo" : 0.12
+               ((grazer_sname)) == "diat_zoo" : 0.24
+               ((grazer_sname)) == "diaz_zoo" : 0.12
          auto_ind :
             _array_shape : autotroph_cnt
             _array_len_to_print : auto_ind_cnt
@@ -1064,9 +1064,9 @@ PFT_derived_types :
             datatype : integer
             default_value :
                default : 0
-               ((grazing_sname)) == "sp_zoo" : 1 # index where autotroph_name = sp
-               ((grazing_sname)) == "diat_zoo" : 2 # index where autotroph_name = diat
-               ((grazing_sname)) == "diaz_zoo" : 3 # index where autotroph_name = diaz
+               ((grazer_sname)) == "sp_zoo" : 1 # index where autotroph_name = sp
+               ((grazer_sname)) == "diat_zoo" : 2 # index where autotroph_name = diat
+               ((grazer_sname)) == "diaz_zoo" : 3 # index where autotroph_name = diaz
          zoo_ind :
             _array_shape : zooplankton_cnt
             _array_len_to_print : zoo_ind_cnt

--- a/defaults/settings_latest.yaml
+++ b/defaults/settings_latest.yaml
@@ -203,13 +203,13 @@ general_parms :
             - CESM2
             - user-specified
       _CESM2_PFT_keys :
-         autotrophs :
+         autotroph_settings :
             - sp
             - diat
             - diaz
-         zooplankton :
+         zooplankton_settings :
             - zoo
-         grazers :
+         grazing_relationship_settings :
             - sp_zoo
             - diat_zoo
             - diaz_zoo
@@ -946,13 +946,13 @@ PFT_derived_types :
             default_value :
                default : 1e34
                ((zooplankton_sname)) == "zoo" : 0.075
-   grazer_settings :
+   grazing_relationship_settings :
       _array_shape :
          - max_grazer_prey_cnt
          - zooplankton_cnt
       _is_allocatable : true
       datatype :
-         _type_name : grazer_settings_type
+         _type_name : grazing_relationship_settings_type
          sname :
             longname : Short name of the grazing relationship
             subcategory : 12. grazing

--- a/src/marbl_ciso_diagnostics_mod.F90
+++ b/src/marbl_ciso_diagnostics_mod.F90
@@ -9,7 +9,7 @@ module marbl_ciso_diagnostics_mod
   use marbl_constants_mod, only : c1000
 
   use marbl_settings_mod, only : autotroph_cnt
-  use marbl_settings_mod, only : autotrophs
+  use marbl_settings_mod, only : autotroph_settings
 
   use marbl_interface_public_types, only : marbl_diagnostics_type
 
@@ -621,9 +621,9 @@ contains
        allocate(ind%CISO_autotrophCaCO3_d14C(autotroph_cnt))
       end if
       do n = 1, autotroph_cnt
-       if (autotrophs(n)%imp_calcifier .or. autotrophs(n)%exp_calcifier) then
-         lname    = trim(autotrophs(n)%lname) // ' Ca13CO3 Formation'
-         sname    = 'CISO_' // trim(autotrophs(n)%sname) // '_Ca13CO3_form'
+       if (autotroph_settings(n)%imp_calcifier .or. autotroph_settings(n)%exp_calcifier) then
+         lname    = trim(autotroph_settings(n)%lname) // ' Ca13CO3 Formation'
+         sname    = 'CISO_' // trim(autotroph_settings(n)%sname) // '_Ca13CO3_form'
          units    = 'mmol/m^3/s'
          vgrid    = 'layer_avg'
          truncate = .true.
@@ -634,8 +634,8 @@ contains
            return
          end if
 
-         lname    = trim(autotrophs(n)%lname) // ' Ca13CO3 Formation Vertical Integral'
-         sname    = 'CISO_' // trim(autotrophs(n)%sname) // '_Ca13CO3_form_zint'
+         lname    = trim(autotroph_settings(n)%lname) // ' Ca13CO3 Formation Vertical Integral'
+         sname    = 'CISO_' // trim(autotroph_settings(n)%sname) // '_Ca13CO3_form_zint'
          units    = 'mmol/m^3 cm/s'
          vgrid    = 'none'
          truncate = .false.
@@ -646,8 +646,8 @@ contains
            return
          end if
 
-         lname    = trim(autotrophs(n)%lname) // ' Ca14CO3 Formation'
-         sname    = 'CISO_' // trim(autotrophs(n)%sname) // '_Ca14CO3_form'
+         lname    = trim(autotroph_settings(n)%lname) // ' Ca14CO3 Formation'
+         sname    = 'CISO_' // trim(autotroph_settings(n)%sname) // '_Ca14CO3_form'
          units    = 'mmol/m^3/s'
          vgrid    = 'layer_avg'
          truncate = .true.
@@ -658,8 +658,8 @@ contains
            return
          end if
 
-         lname    = trim(autotrophs(n)%lname) // ' Ca14CO3 Formation Vertical Integral'
-         sname    = 'CISO_' // trim(autotrophs(n)%sname) // '_Ca14CO3_form_zint'
+         lname    = trim(autotroph_settings(n)%lname) // ' Ca14CO3 Formation Vertical Integral'
+         sname    = 'CISO_' // trim(autotroph_settings(n)%sname) // '_Ca14CO3_form_zint'
          units    = 'mmol/m^3 cm/s'
          vgrid    = 'none'
          truncate = .false.
@@ -670,8 +670,8 @@ contains
            return
          end if
 
-         lname    = trim(autotrophs(n)%lname) // ' d13C of CaCO3'
-         sname    = 'CISO_autotrophCaCO3_d13C_' // trim(autotrophs(n)%sname)
+         lname    = trim(autotroph_settings(n)%lname) // ' d13C of CaCO3'
+         sname    = 'CISO_autotrophCaCO3_d13C_' // trim(autotroph_settings(n)%sname)
          units    = 'mmol/m^3/s'
          vgrid    = 'layer_avg'
          truncate = .false.
@@ -682,8 +682,8 @@ contains
            return
          end if
 
-         lname    = trim(autotrophs(n)%lname) // ' d14C of CaCO3'
-         sname    = 'CISO_autotrophCaCO3_d14C_' // trim(autotrophs(n)%sname)
+         lname    = trim(autotroph_settings(n)%lname) // ' d14C of CaCO3'
+         sname    = 'CISO_autotrophCaCO3_d14C_' // trim(autotroph_settings(n)%sname)
          units    = 'mmol/m^3/s'
          vgrid    = 'layer_avg'
          truncate = .false.
@@ -702,8 +702,8 @@ contains
          ind%CISO_autotrophCaCO3_d14C(n) = 0
        end if ! calcifier
 
-       lname    = trim(autotrophs(n)%lname) // ' 13C Fixation'
-       sname    = 'CISO_photo13C_' // trim(autotrophs(n)%sname)
+       lname    = trim(autotroph_settings(n)%lname) // ' 13C Fixation'
+       sname    = 'CISO_photo13C_' // trim(autotroph_settings(n)%sname)
        units    = 'mmol/m^3/s'
        vgrid    = 'layer_avg'
        truncate = .true.
@@ -714,8 +714,8 @@ contains
          return
        end if
 
-       lname    = trim(autotrophs(n)%lname) // ' 14C Fixation'
-       sname    = 'CISO_photo14C_' // trim(autotrophs(n)%sname)
+       lname    = trim(autotroph_settings(n)%lname) // ' 14C Fixation'
+       sname    = 'CISO_photo14C_' // trim(autotroph_settings(n)%sname)
        units    = 'mmol/m^3/s'
        vgrid    = 'layer_avg'
        truncate = .true.
@@ -726,8 +726,8 @@ contains
          return
        end if
 
-       lname    = trim(autotrophs(n)%lname) // ' 13C Fixation Vertical Integral'
-       sname    = 'CISO_photo13C_' // trim(autotrophs(n)%sname) // '_zint'
+       lname    = trim(autotroph_settings(n)%lname) // ' 13C Fixation Vertical Integral'
+       sname    = 'CISO_photo13C_' // trim(autotroph_settings(n)%sname) // '_zint'
        units    = 'mmol/m^3 cm/s'
        vgrid    = 'none'
        truncate = .false.
@@ -738,8 +738,8 @@ contains
          return
        end if
 
-       lname    = trim(autotrophs(n)%lname) // ' 14C Fixation Vertical Integral'
-       sname    = 'CISO_photo14C_' // trim(autotrophs(n)%sname) // '_zint'
+       lname    = trim(autotroph_settings(n)%lname) // ' 14C Fixation Vertical Integral'
+       sname    = 'CISO_photo14C_' // trim(autotroph_settings(n)%sname) // '_zint'
        units    = 'mmol/m^3 cm/s'
        vgrid    = 'none'
        truncate = .false.
@@ -750,8 +750,8 @@ contains
          return
        end if
 
-       lname    = trim(autotrophs(n)%lname) // ' discrimination factor (eps)'
-       sname    = 'CISO_eps_autotroph_' // trim(autotrophs(n)%sname)
+       lname    = trim(autotroph_settings(n)%lname) // ' discrimination factor (eps)'
+       sname    = 'CISO_eps_autotroph_' // trim(autotroph_settings(n)%sname)
        units    = 'permil'
        vgrid    = 'layer_avg'
        truncate = .false.
@@ -762,8 +762,8 @@ contains
          return
        end if
 
-       lname    = trim(autotrophs(n)%lname) // ' d13C'
-       sname    = 'CISO_d13C_' // trim(autotrophs(n)%sname)
+       lname    = trim(autotroph_settings(n)%lname) // ' d13C'
+       sname    = 'CISO_d13C_' // trim(autotroph_settings(n)%sname)
        units    = 'permil'
        vgrid    = 'layer_avg'
        truncate = .false.
@@ -774,8 +774,8 @@ contains
          return
        end if
 
-       lname    = trim(autotrophs(n)%lname) // ' d14C'
-       sname    = 'CISO_d14C_' // trim(autotrophs(n)%sname)
+       lname    = trim(autotroph_settings(n)%lname) // ' d14C'
+       sname    = 'CISO_d14C_' // trim(autotroph_settings(n)%sname)
        units    = 'permil'
        vgrid    = 'layer_avg'
        truncate = .false.
@@ -786,8 +786,8 @@ contains
          return
        end if
 
-       lname    = trim(autotrophs(n)%lname) // ' instanteous growth rate over [CO2*]'
-       sname    = 'CISO_mui_to_co2star_' // trim(autotrophs(n)%sname)
+       lname    = trim(autotroph_settings(n)%lname) // ' instanteous growth rate over [CO2*]'
+       sname    = 'CISO_mui_to_co2star_' // trim(autotroph_settings(n)%sname)
        units    = 'm^3/mmol/s'
        vgrid    = 'layer_avg'
        truncate = .false.
@@ -1171,8 +1171,8 @@ contains
              diags(ind%CISO_Ca13CO3_form(n))%field_3d(k, 1)     = Ca13CO3_prod(n,k)
           if (ind%CISO_Ca14CO3_form(n) .gt. 0) &
              diags(ind%CISO_Ca14CO3_form(n))%field_3d(k, 1)     = Ca14CO3_prod(n,k)
-       end do  ! end loop over autotrophs
-    end do  ! end loop over k
+       end do  ! end loop over autotroph_cnt
+    end do  ! end loop over km
 
     do k = 1,km
        diags(ind%CISO_DIC_d13C)%field_3d(k, 1)        = DIC_d13C(k)

--- a/src/marbl_ciso_init_mod.F90
+++ b/src/marbl_ciso_init_mod.F90
@@ -20,7 +20,7 @@ contains
     !  Set tracer and forcing metadata
     use marbl_settings_mod, only : ciso_lecovars_full_depth_tavg
     use marbl_settings_mod, only : autotroph_cnt
-    use marbl_settings_mod, only : autotrophs
+    use marbl_settings_mod, only : autotroph_settings
 
     type (marbl_tracer_metadata_type) , intent(inout) :: marbl_tracer_metadata(:)   ! descriptors for each tracer
     type(marbl_tracer_index_type)     , intent(in)    :: marbl_tracer_indices
@@ -79,23 +79,23 @@ contains
 
     do auto_ind = 1, autotroph_cnt
        n = marbl_tracer_indices%auto_inds(auto_ind)%C13_ind
-       marbl_tracer_metadata(n)%short_name = trim(autotrophs(auto_ind)%sname) // '13C'
-       marbl_tracer_metadata(n)%long_name  = trim(autotrophs(auto_ind)%lname) // ' Carbon-13'
+       marbl_tracer_metadata(n)%short_name = trim(autotroph_settings(auto_ind)%sname) // '13C'
+       marbl_tracer_metadata(n)%long_name  = trim(autotroph_settings(auto_ind)%lname) // ' Carbon-13'
 
        n = marbl_tracer_indices%auto_inds(auto_ind)%C14_ind
-       marbl_tracer_metadata(n)%short_name = trim(autotrophs(auto_ind)%sname) // '14C'
-       marbl_tracer_metadata(n)%long_name  = trim(autotrophs(auto_ind)%lname) // ' Carbon-14'
+       marbl_tracer_metadata(n)%short_name = trim(autotroph_settings(auto_ind)%sname) // '14C'
+       marbl_tracer_metadata(n)%long_name  = trim(autotroph_settings(auto_ind)%lname) // ' Carbon-14'
 
        n = marbl_tracer_indices%auto_inds(auto_ind)%Ca13CO3_ind
        if (n .gt. 0) then
-          marbl_tracer_metadata(n)%short_name = trim(autotrophs(auto_ind)%sname) // 'Ca13CO3'
-          marbl_tracer_metadata(n)%long_name  = trim(autotrophs(auto_ind)%lname) // ' Ca13CO3'
+          marbl_tracer_metadata(n)%short_name = trim(autotroph_settings(auto_ind)%sname) // 'Ca13CO3'
+          marbl_tracer_metadata(n)%long_name  = trim(autotroph_settings(auto_ind)%lname) // ' Ca13CO3'
         end if
 
        n = marbl_tracer_indices%auto_inds(auto_ind)%Ca14CO3_ind
        if (n .gt. 0) then
-          marbl_tracer_metadata(n)%short_name = trim(autotrophs(auto_ind)%sname) // 'Ca14CO3'
-          marbl_tracer_metadata(n)%long_name  = trim(autotrophs(auto_ind)%lname) // ' Ca14CO3'
+          marbl_tracer_metadata(n)%short_name = trim(autotroph_settings(auto_ind)%sname) // 'Ca14CO3'
+          marbl_tracer_metadata(n)%long_name  = trim(autotroph_settings(auto_ind)%lname) // ' Ca14CO3'
        endif
     end do
 

--- a/src/marbl_ciso_interior_tendency_mod.F90
+++ b/src/marbl_ciso_interior_tendency_mod.F90
@@ -11,7 +11,7 @@ module marbl_ciso_interior_tendency_mod
   use marbl_constants_mod, only : mpercm
 
   use marbl_settings_mod, only : autotroph_cnt
-  use marbl_settings_mod, only : autotrophs
+  use marbl_settings_mod, only : autotroph_settings
   use marbl_settings_mod, only : ciso_on
 
   use marbl_logging, only : marbl_log_type
@@ -24,7 +24,7 @@ module marbl_ciso_interior_tendency_mod
   use marbl_interface_private_types, only : marbl_interior_tendency_share_type
   use marbl_interface_private_types, only : marbl_particulate_share_type
   use marbl_interface_private_types, only : marbl_tracer_index_type
-  use marbl_interface_private_types, only : autotroph_secondary_species_type
+  use marbl_interface_private_types, only : autotroph_derived_terms_type
 
   use marbl_pft_mod, only : marbl_zooplankton_share_type
 
@@ -46,17 +46,17 @@ contains
   !***********************************************************************
 
   subroutine marbl_ciso_interior_tendency_compute( &
-       marbl_domain,                          &
-       marbl_interior_tendency_share,         &
-       marbl_zooplankton_share,               &
-       marbl_particulate_share,               &
-       tracer_local,                          &
-       autotroph_local,                       &
-       autotroph_secondary_species,           &
-       temperature,                           &
-       marbl_tracer_indices,                  &
-       interior_tendencies,                   &
-       marbl_interior_diags,                  &
+       marbl_domain,                               &
+       marbl_interior_tendency_share,              &
+       marbl_zooplankton_share,                    &
+       marbl_particulate_share,                    &
+       tracer_local,                               &
+       autotroph_local,                            &
+       autotroph_derived_terms,                    &
+       temperature,                                &
+       marbl_tracer_indices,                       &
+       interior_tendencies,                        &
+       marbl_interior_diags,                       &
        marbl_status_log)
 
     !  Compute time derivatives for 13C and 14C state variables.
@@ -77,7 +77,7 @@ contains
     type(marbl_particulate_share_type),       intent(in)    :: marbl_particulate_share
     real (r8),                                intent(in)    :: tracer_local(:,:)
     type(autotroph_local_type),               intent(in)    :: autotroph_local
-    type(autotroph_secondary_species_type),   intent(in)    :: autotroph_secondary_species
+    type(autotroph_derived_terms_type),       intent(in)    :: autotroph_derived_terms
     real (r8),                                intent(in)    :: temperature(:)
     type(marbl_tracer_index_type),            intent(in)    :: marbl_tracer_indices
     real (r8),                                intent(inout) :: interior_tendencies(:,:)  ! computed source/sink terms (inout because we don't touch non-ciso tracers)
@@ -175,58 +175,58 @@ contains
     ! Return immediately if not running with carbon isotope tracer module
     if (.not. ciso_on) return
 
-    associate(                                                                   &
-         column_km          => marbl_domain%km                                 , &
-         column_kmt         => marbl_domain%kmt                                , &
+    associate(                                   &
+         column_km          => marbl_domain%km,  &
+         column_kmt         => marbl_domain%kmt, &
 
-         CO3                => marbl_interior_tendency_share%CO3_fields        , & ! INPUT carbonate ion
-         HCO3               => marbl_interior_tendency_share%HCO3_fields       , & ! INPUT bicarbonate ion
-         H2CO3              => marbl_interior_tendency_share%H2CO3_fields      , & ! INPUT carbonic acid
-         DOCtot_remin       => marbl_interior_tendency_share%DOCtot_remin_fields, & ! INPUT remineralization of DOCtot (mmol C/m^3/sec)
-         DOCtot_loc         => marbl_interior_tendency_share%DOCtot_loc_fields , & ! INPUT local copy of model DOCtot
-         DO13Ctot_loc       => tracer_local(marbl_tracer_indices%DO13Ctot_ind,:) , & ! local copy of model DO14Ctot
-         DO14Ctot_loc       => tracer_local(marbl_tracer_indices%DO14Ctot_ind,:) , & ! local copy of model DO14Ctot
-         DIC_loc            => tracer_local(marbl_tracer_indices%DIC_ind,:)    , & ! INPUT local copy of model DIC
-         DI13C_loc          => tracer_local(marbl_tracer_indices%DI13C_ind,:)    , & ! local copy of model DI13C
-         DI14C_loc          => tracer_local(marbl_tracer_indices%DI14C_ind,:)    , & ! local copy of model DI14C
+         CO3                => marbl_interior_tendency_share%CO3_fields,           & ! INPUT carbonate ion
+         HCO3               => marbl_interior_tendency_share%HCO3_fields,          & ! INPUT bicarbonate ion
+         H2CO3              => marbl_interior_tendency_share%H2CO3_fields,         & ! INPUT carbonic acid
+         DOCtot_remin       => marbl_interior_tendency_share%DOCtot_remin_fields,  & ! INPUT remineralization of DOCtot (mmol C/m^3/sec)
+         DOCtot_loc         => marbl_interior_tendency_share%DOCtot_loc_fields,    & ! INPUT local copy of model DOCtot
+         DO13Ctot_loc       => tracer_local(marbl_tracer_indices%DO13Ctot_ind,:),  & ! local copy of model DO14Ctot
+         DO14Ctot_loc       => tracer_local(marbl_tracer_indices%DO14Ctot_ind,:),  & ! local copy of model DO14Ctot
+         DIC_loc            => tracer_local(marbl_tracer_indices%DIC_ind,:),       & ! INPUT local copy of model DIC
+         DI13C_loc          => tracer_local(marbl_tracer_indices%DI13C_ind,:),     & ! local copy of model DI13C
+         DI14C_loc          => tracer_local(marbl_tracer_indices%DI14C_ind,:),     & ! local copy of model DI14C
          zootot13C_loc      => tracer_local(marbl_tracer_indices%zootot13C_ind,:), & ! local copy of model zootot13C
-         zootot14C_loc      => tracer_local(marbl_tracer_indices%zootot14C_ind,:), &  ! local copy of model zootot14C
+         zootot14C_loc      => tracer_local(marbl_tracer_indices%zootot14C_ind,:), & ! local copy of model zootot14C
 
-         QCaCO3             => autotroph_secondary_species%QCaCO3              , & ! INPUT small phyto CaCO3/C ratio (mmol CaCO3/mmol C)
-         auto_graze         => autotroph_secondary_species%auto_graze          , & ! INPUT autotroph grazing rate (mmol C/m^3/sec)
-         auto_graze_zoo     => autotroph_secondary_species%auto_graze_zoo      , & ! INPUT auto_graze routed to zoo (mmol C/m^3/sec)
-         auto_graze_poc     => autotroph_secondary_species%auto_graze_poc      , & ! INPUT auto_graze routed to poc (mmol C/m^3/sec)
-         auto_graze_doc     => autotroph_secondary_species%auto_graze_doc      , & ! INPUT auto_graze routed to doc (mmol C/m^3/sec)
-         auto_graze_dic     => autotroph_secondary_species%auto_graze_dic      , & ! INPUT auto_graze routed to dic (mmol C/m^3/sec)
-         auto_loss          => autotroph_secondary_species%auto_loss           , & ! INPUT autotroph non-grazing mort (mmol C/m^3/sec)
-         auto_loss_poc      => autotroph_secondary_species%auto_loss_poc       , & ! INPUT auto_loss routed to poc (mmol C/m^3/sec)
-         auto_loss_doc      => autotroph_secondary_species%auto_loss_doc       , & ! INPUT auto_loss routed to doc (mmol C/m^3/sec)
-         auto_loss_dic      => autotroph_secondary_species%auto_loss_dic       , & ! INPUT auto_loss routed to dic (mmol C/m^3/sec)
-         auto_agg           => autotroph_secondary_species%auto_agg            , & ! INPUT autotroph aggregation (mmol C/m^3/sec)
-         photoC             => autotroph_secondary_species%photoC              , & ! INPUT C-fixation (mmol C/m^3/sec)
-         CaCO3_form         => autotroph_secondary_species%CaCO3_form          , & ! INPUT prod. of CaCO3 by small phyto (mmol CaCO3/m^3/sec)
-         PCphoto            => autotroph_secondary_species%PCphoto             , & ! INPUT C-specific rate of photosynth. (1/sec)
+         QCaCO3             => autotroph_derived_terms%QCaCO3,         & ! INPUT small phyto CaCO3/C ratio (mmol CaCO3/mmol C)
+         auto_graze         => autotroph_derived_terms%auto_graze,     & ! INPUT autotroph grazing rate (mmol C/m^3/sec)
+         auto_graze_zoo     => autotroph_derived_terms%auto_graze_zoo, & ! INPUT auto_graze routed to zoo (mmol C/m^3/sec)
+         auto_graze_poc     => autotroph_derived_terms%auto_graze_poc, & ! INPUT auto_graze routed to poc (mmol C/m^3/sec)
+         auto_graze_doc     => autotroph_derived_terms%auto_graze_doc, & ! INPUT auto_graze routed to doc (mmol C/m^3/sec)
+         auto_graze_dic     => autotroph_derived_terms%auto_graze_dic, & ! INPUT auto_graze routed to dic (mmol C/m^3/sec)
+         auto_loss          => autotroph_derived_terms%auto_loss,      & ! INPUT autotroph non-grazing mort (mmol C/m^3/sec)
+         auto_loss_poc      => autotroph_derived_terms%auto_loss_poc,  & ! INPUT auto_loss routed to poc (mmol C/m^3/sec)
+         auto_loss_doc      => autotroph_derived_terms%auto_loss_doc,  & ! INPUT auto_loss routed to doc (mmol C/m^3/sec)
+         auto_loss_dic      => autotroph_derived_terms%auto_loss_dic,  & ! INPUT auto_loss routed to dic (mmol C/m^3/sec)
+         auto_agg           => autotroph_derived_terms%auto_agg,       & ! INPUT autotroph aggregation (mmol C/m^3/sec)
+         photoC             => autotroph_derived_terms%photoC,         & ! INPUT C-fixation (mmol C/m^3/sec)
+         CaCO3_form         => autotroph_derived_terms%CaCO3_form,     & ! INPUT prod. of CaCO3 by small phyto (mmol CaCO3/m^3/sec)
+         PCphoto            => autotroph_derived_terms%PCphoto,        & ! INPUT C-specific rate of photosynth. (1/sec)
 
-         zoototC_loc        => marbl_zooplankton_share%zoototC_loc_fields      , & ! INPUT local copy of model zoototC
-         zootot_loss        => marbl_zooplankton_share%zootot_loss_fields      , & ! INPUT mortality & higher trophic grazing on zooplankton (mmol C/m^3/sec)
-         zootot_loss_poc    => marbl_zooplankton_share%zootot_loss_poc_fields  , & ! INPUT zootot_loss routed to large detrital pool (mmol C/m^3/sec)
-         zootot_loss_doc    => marbl_zooplankton_share%zootot_loss_doc_fields  , & ! INPUT zootot_loss routed to doc (mmol C/m^3/sec)
-         zootot_loss_dic    => marbl_zooplankton_share%zootot_loss_dic_fields  , & ! INPUT zootot_loss routed to dic (mmol C/m^3/sec)
-         zootot_graze       => marbl_zooplankton_share%zootot_graze_fields     , & ! INPUT zooplankton losses due to grazing (mmol C/m^3/sec)
-         zootot_graze_zoo   => marbl_zooplankton_share%zootot_graze_zoo_fields , & ! INPUT grazing of zooplankton routed to zoo (mmol C/m^3/sec)
-         zootot_graze_poc   => marbl_zooplankton_share%zootot_graze_poc_fields , & ! INPUT grazing of zooplankton routed to poc (mmol C/m^3/sec)
-         zootot_graze_doc   => marbl_zooplankton_share%zootot_graze_doc_fields , & ! INPUT grazing of zooplankton routed to doc (mmol C/m^3/sec)
-         zootot_graze_dic   => marbl_zooplankton_share%zootot_graze_dic_fields , & ! INPUT grazing of zooplankton routed to dic (mmol C/m^3/sec)
+         zoototC_loc        => marbl_zooplankton_share%zoototC_loc_fields,      & ! INPUT local copy of model zoototC
+         zootot_loss        => marbl_zooplankton_share%zootot_loss_fields,      & ! INPUT mortality & higher trophic grazing on zooplankton (mmol C/m^3/sec)
+         zootot_loss_poc    => marbl_zooplankton_share%zootot_loss_poc_fields,  & ! INPUT zootot_loss routed to large detrital pool (mmol C/m^3/sec)
+         zootot_loss_doc    => marbl_zooplankton_share%zootot_loss_doc_fields,  & ! INPUT zootot_loss routed to doc (mmol C/m^3/sec)
+         zootot_loss_dic    => marbl_zooplankton_share%zootot_loss_dic_fields,  & ! INPUT zootot_loss routed to dic (mmol C/m^3/sec)
+         zootot_graze       => marbl_zooplankton_share%zootot_graze_fields,     & ! INPUT zooplankton losses due to grazing (mmol C/m^3/sec)
+         zootot_graze_zoo   => marbl_zooplankton_share%zootot_graze_zoo_fields, & ! INPUT grazing of zooplankton routed to zoo (mmol C/m^3/sec)
+         zootot_graze_poc   => marbl_zooplankton_share%zootot_graze_poc_fields, & ! INPUT grazing of zooplankton routed to poc (mmol C/m^3/sec)
+         zootot_graze_doc   => marbl_zooplankton_share%zootot_graze_doc_fields, & ! INPUT grazing of zooplankton routed to doc (mmol C/m^3/sec)
+         zootot_graze_dic   => marbl_zooplankton_share%zootot_graze_dic_fields, & ! INPUT grazing of zooplankton routed to dic (mmol C/m^3/sec)
 
-         POC                => marbl_particulate_share%POC                     , & ! INPUT
-         P_CaCO3            => marbl_particulate_share%P_CaCO3                 , & ! INPUT
+         POC                => marbl_particulate_share%POC,     & ! INPUT
+         P_CaCO3            => marbl_particulate_share%P_CaCO3, & ! INPUT
 
-         di13c_ind          => marbl_tracer_indices%di13c_ind                  , &
-         do13ctot_ind       => marbl_tracer_indices%do13ctot_ind               , &
-         zootot13C_ind      => marbl_tracer_indices%zootot13C_ind              , &
-         di14c_ind          => marbl_tracer_indices%di14c_ind                  , &
-         do14ctot_ind       => marbl_tracer_indices%do14ctot_ind               , &
-         zootot14C_ind      => marbl_tracer_indices%zootot14C_ind                &
+         di13c_ind          => marbl_tracer_indices%di13c_ind,     &
+         do13ctot_ind       => marbl_tracer_indices%do13ctot_ind,  &
+         zootot13C_ind      => marbl_tracer_indices%zootot13C_ind, &
+         di14c_ind          => marbl_tracer_indices%di14c_ind,     &
+         do14ctot_ind       => marbl_tracer_indices%do14ctot_ind,  &
+         zootot14C_ind      => marbl_tracer_indices%zootot14C_ind  &
          )
 
     !-----------------------------------------------------------------------
@@ -475,7 +475,7 @@ contains
           ! C13 & C14 CaCO3 production
           !-----------------------------------------------------------------------
 
-          if (autotrophs(auto_ind)%imp_calcifier) then
+          if (autotroph_settings(auto_ind)%imp_calcifier) then
 
              R13C_CaCO3_form(k) = R13C_DIC(k) + R13C_std * eps_carb / c1000
              R14C_CaCO3_form(k) = R14C_DIC(k) + R14C_std * eps_carb * 2.0_r8 / c1000
@@ -785,7 +785,7 @@ contains
     case ('KellerMorel')
        do auto_ind = 1, autotroph_cnt
 
-          if (autotrophs(auto_ind)%silicifier) then
+          if (autotroph_settings(auto_ind)%silicifier) then
              !----------------------------------------------------------------------------------------
              ! Diatom based on P. tricornumtum ( Keller and morel, 1999; Popp et al., 1998 )
              !----------------------------------------------------------------------------------------
@@ -796,7 +796,7 @@ contains
              cell_permea(auto_ind)          = 3.3e-5_r8    ! cell wall permeability to CO2(aq) (m/s)
              cell_eps_fix(auto_ind)         = 26.6_r8      ! fractionation effect of carbon fixation
 
-          else if (autotrophs(auto_ind)%Nfixer) then
+          else if (autotroph_settings(auto_ind)%Nfixer) then
              !----------------------------------------------------------------------------------------
              ! Diazotroph based on  Standard Phyto of Rau et al., (1996)
              !----------------------------------------------------------------------------------------
@@ -816,7 +816,7 @@ contains
              cell_permea(auto_ind)          = 3.0e-8_r8     ! cell wall permeability to CO2(aq) (m/s)
              cell_eps_fix(auto_ind)         = 30.0_r8       ! fractionation effect of carbon fixation
 
-         !else if (autotrophs(auto_ind)%exp_calcifier) then
+         !else if (autotroph_settings(auto_ind)%exp_calcifier) then
              !Currently not set up to separate exp_calcifiers, needs cell_radius value from data
              !----------------------------------------------------------------------------------------
              ! Calcifier based on P. glacialis ( Keller and morel, 1999; Popp et al., 1998 )
@@ -830,8 +830,8 @@ contains
              !   cell_permea(auto_ind)          = 1.1e-5_r8    ! cell wall permeability to CO2(aq) (m/s)
              !   cell_eps_fix(auto_ind)         = 23.0_r8      ! fractionation effect of carbon fixation
 
-          else if (autotrophs(auto_ind)%Nfixer .and.                   &
-                   autotrophs(auto_ind)%silicifier) then
+          else if (autotroph_settings(auto_ind)%Nfixer .and. &
+                   autotroph_settings(auto_ind)%silicifier) then
               log_message = "ciso: Currently Keller and Morel fractionation does not work for Diatoms-Diazotrophs"
               call marbl_status_log%log_error(log_message, subname)
               return

--- a/src/marbl_ciso_interior_tendency_mod.F90
+++ b/src/marbl_ciso_interior_tendency_mod.F90
@@ -738,7 +738,7 @@ contains
     integer,                              intent(in)    :: auto_ind
     integer,                              intent(in)    :: column_kmt
     logical,                              intent(in)    :: zero_mask(column_kmt)
-    type(marbl_living_tracer_index_type), intent(in)    :: autotroph_tracer_indices(autotroph_cnt)
+    type(marbl_living_tracer_index_type), intent(in)    :: autotroph_tracer_indices
     type(autotroph_local_type),           intent(inout) :: autotroph_local
 
     if (.not. ciso_on) return
@@ -748,13 +748,13 @@ contains
       autotroph_local%C14(auto_ind,1:column_kmt) = c0
     end where
 
-    if (autotroph_tracer_indices(auto_ind)%Ca13CO3_ind > 0) then
+    if (autotroph_tracer_indices%Ca13CO3_ind > 0) then
       where (zero_mask)
         autotroph_local%Ca13CO3(auto_ind,1:column_kmt) = c0
       end where
     end if
 
-    if (autotroph_tracer_indices(auto_ind)%Ca14CO3_ind > 0) then
+    if (autotroph_tracer_indices%Ca14CO3_ind > 0) then
       where (zero_mask)
         autotroph_local%Ca14CO3(auto_ind,1:column_kmt) = c0
       end where

--- a/src/marbl_ciso_interior_tendency_mod.F90
+++ b/src/marbl_ciso_interior_tendency_mod.F90
@@ -23,10 +23,10 @@ module marbl_ciso_interior_tendency_mod
   use marbl_interface_private_types, only : marbl_interior_tendency_share_type
   use marbl_interface_private_types, only : marbl_particulate_share_type
   use marbl_interface_private_types, only : marbl_tracer_index_type
+  use marbl_interface_private_types, only : autotroph_secondary_species_type
 
   use marbl_pft_mod, only : autotroph_local_type
   use marbl_pft_mod, only : marbl_zooplankton_share_type
-  use marbl_pft_mod, only : autotroph_secondary_species_type
 
   implicit none
   private
@@ -77,7 +77,7 @@ contains
     type(marbl_particulate_share_type),       intent(in)    :: marbl_particulate_share
     real (r8),                                intent(in)    :: tracer_local(:,:)
     type(autotroph_local_type),               intent(in)    :: autotroph_local(:,:)
-    type(autotroph_secondary_species_type),   intent(in)    :: autotroph_secondary_species(:,:)
+    type(autotroph_secondary_species_type),   intent(in)    :: autotroph_secondary_species
     real (r8),                                intent(in)    :: temperature(:)
     type(marbl_tracer_index_type),            intent(in)    :: marbl_tracer_indices
     real (r8),                                intent(inout) :: interior_tendencies(:,:)  ! computed source/sink terms (inout because we don't touch non-ciso tracers)

--- a/src/marbl_ciso_interior_tendency_mod.F90
+++ b/src/marbl_ciso_interior_tendency_mod.F90
@@ -47,7 +47,7 @@ contains
 
   subroutine marbl_ciso_interior_tendency_compute( &
        marbl_domain,                               &
-       marbl_interior_tendency_share,              &
+       interior_tendency_share,                    &
        marbl_zooplankton_share,                    &
        marbl_particulate_share,                    &
        tracer_local,                               &
@@ -72,7 +72,7 @@ contains
     use marbl_ciso_diagnostics_mod, only : store_diagnostics_ciso_interior
 
     type(marbl_domain_type),                  intent(in)    :: marbl_domain
-    type(marbl_interior_tendency_share_type), intent(in)    :: marbl_interior_tendency_share(:)
+    type(marbl_interior_tendency_share_type), intent(in)    :: interior_tendency_share
     type(marbl_zooplankton_share_type),       intent(in)    :: marbl_zooplankton_share(:)
     type(marbl_particulate_share_type),       intent(in)    :: marbl_particulate_share
     real (r8),                                intent(in)    :: tracer_local(:,:)
@@ -179,11 +179,12 @@ contains
          column_km          => marbl_domain%km,  &
          column_kmt         => marbl_domain%kmt, &
 
-         CO3                => marbl_interior_tendency_share%CO3_fields,           & ! INPUT carbonate ion
-         HCO3               => marbl_interior_tendency_share%HCO3_fields,          & ! INPUT bicarbonate ion
-         H2CO3              => marbl_interior_tendency_share%H2CO3_fields,         & ! INPUT carbonic acid
-         DOCtot_remin       => marbl_interior_tendency_share%DOCtot_remin_fields,  & ! INPUT remineralization of DOCtot (mmol C/m^3/sec)
-         DOCtot_loc         => marbl_interior_tendency_share%DOCtot_loc_fields,    & ! INPUT local copy of model DOCtot
+         CO3                => interior_tendency_share%CO3_fields,           & ! INPUT carbonate ion
+         HCO3               => interior_tendency_share%HCO3_fields,          & ! INPUT bicarbonate ion
+         H2CO3              => interior_tendency_share%H2CO3_fields,         & ! INPUT carbonic acid
+         DOCtot_remin       => interior_tendency_share%DOCtot_remin_fields,  & ! INPUT remineralization of DOCtot (mmol C/m^3/sec)
+         DOCtot_loc         => interior_tendency_share%DOCtot_loc_fields,    & ! INPUT local copy of model DOCtot
+
          DO13Ctot_loc       => tracer_local(marbl_tracer_indices%DO13Ctot_ind,:),  & ! local copy of model DO14Ctot
          DO14Ctot_loc       => tracer_local(marbl_tracer_indices%DO14Ctot_ind,:),  & ! local copy of model DO14Ctot
          DIC_loc            => tracer_local(marbl_tracer_indices%DIC_ind,:),       & ! INPUT local copy of model DIC
@@ -556,10 +557,10 @@ contains
        !-----------------------------------------------------------------------
 
        call compute_particulate_terms(k, marbl_domain, tracer_local(:,k), marbl_tracer_indices, &
-            marbl_interior_tendency_share(k), marbl_particulate_share, PO13C, P_Ca13CO3)
+            interior_tendency_share, marbl_particulate_share, PO13C, P_Ca13CO3)
 
        call compute_particulate_terms(k, marbl_domain, tracer_local(:,k), marbl_tracer_indices, &
-            marbl_interior_tendency_share(k), marbl_particulate_share, PO14C, P_Ca14CO3)
+            interior_tendency_share, marbl_particulate_share, PO14C, P_Ca14CO3)
 
        !-----------------------------------------------------------------------
        ! Update interior_tendencies for the 7 carbon pools for each Carbon isotope
@@ -1048,7 +1049,7 @@ contains
   !***********************************************************************
 
   subroutine compute_particulate_terms(k, domain, tracer_local, marbl_tracer_indices, &
-             marbl_interior_tendency_share, marbl_particulate_share, POC_ciso, P_CaCO3_ciso)
+             interior_tendency_share, marbl_particulate_share, POC_ciso, P_CaCO3_ciso)
 
     !----------------------------------------------------------------------------------------
     !  Compute outgoing fluxes and remineralization terms for Carbon isotopes.
@@ -1070,7 +1071,7 @@ contains
     type(marbl_domain_type),                  intent(in)    :: domain
     real(r8),                                 intent(in)    :: tracer_local(:)
     type(marbl_tracer_index_type),            intent(in)    :: marbl_tracer_indices
-    type(marbl_interior_tendency_share_type), intent(in)    :: marbl_interior_tendency_share
+    type(marbl_interior_tendency_share_type), intent(in)    :: interior_tendency_share
     type(marbl_particulate_share_type),       intent(in)    :: marbl_particulate_share
     type(column_sinking_particle_type),       intent(inout) :: POC_ciso          ! base units = nmol particulate organic Carbon isotope
     type(column_sinking_particle_type),       intent(inout) :: P_CaCO3_ciso      ! base units = nmol CaCO3 Carbon isotope
@@ -1095,8 +1096,8 @@ contains
          column_zw         => domain%zw(k)                                  , & ! IN
          O2_loc            => tracer_local(marbl_tracer_indices%O2_ind)     , & ! IN
          NO3_loc           => tracer_local(marbl_tracer_indices%NO3_ind)    , & ! IN
-         CO3               => marbl_interior_tendency_share%CO3_fields      , & ! IN
-         CO3_sat_calcite   => marbl_interior_tendency_share%CO3_sat_calcite , & ! IN
+         CO3               => interior_tendency_share%CO3_fields(k)         , & ! IN
+         CO3_sat_calcite   => interior_tendency_share%CO3_sat_calcite(k)    , & ! IN
          decay_CaCO3       => marbl_particulate_share%decay_CaCO3_fields    , & ! IN
          DECAY_Hard        => marbl_particulate_share%DECAY_Hard_fields     , & ! IN
          decay_POC_E       => marbl_particulate_share%decay_POC_E_fields    , & ! IN

--- a/src/marbl_ciso_interior_tendency_mod.F90
+++ b/src/marbl_ciso_interior_tendency_mod.F90
@@ -22,11 +22,10 @@ module marbl_ciso_interior_tendency_mod
   use marbl_interface_private_types, only : autotroph_local_type
   use marbl_interface_private_types, only : column_sinking_particle_type
   use marbl_interface_private_types, only : marbl_interior_tendency_share_type
+  use marbl_interface_private_types, only : zooplankton_share_type
   use marbl_interface_private_types, only : marbl_particulate_share_type
   use marbl_interface_private_types, only : marbl_tracer_index_type
   use marbl_interface_private_types, only : autotroph_derived_terms_type
-
-  use marbl_pft_mod, only : marbl_zooplankton_share_type
 
   implicit none
   private
@@ -48,7 +47,7 @@ contains
   subroutine marbl_ciso_interior_tendency_compute( &
        marbl_domain,                               &
        interior_tendency_share,                    &
-       marbl_zooplankton_share,                    &
+       zooplankton_share,                          &
        marbl_particulate_share,                    &
        tracer_local,                               &
        autotroph_local,                            &
@@ -73,7 +72,7 @@ contains
 
     type(marbl_domain_type),                  intent(in)    :: marbl_domain
     type(marbl_interior_tendency_share_type), intent(in)    :: interior_tendency_share
-    type(marbl_zooplankton_share_type),       intent(in)    :: marbl_zooplankton_share(:)
+    type(zooplankton_share_type),             intent(in)    :: zooplankton_share
     type(marbl_particulate_share_type),       intent(in)    :: marbl_particulate_share
     real (r8),                                intent(in)    :: tracer_local(:,:)
     type(autotroph_local_type),               intent(in)    :: autotroph_local
@@ -208,16 +207,16 @@ contains
          CaCO3_form         => autotroph_derived_terms%CaCO3_form,     & ! INPUT prod. of CaCO3 by small phyto (mmol CaCO3/m^3/sec)
          PCphoto            => autotroph_derived_terms%PCphoto,        & ! INPUT C-specific rate of photosynth. (1/sec)
 
-         zoototC_loc        => marbl_zooplankton_share%zoototC_loc_fields,      & ! INPUT local copy of model zoototC
-         zootot_loss        => marbl_zooplankton_share%zootot_loss_fields,      & ! INPUT mortality & higher trophic grazing on zooplankton (mmol C/m^3/sec)
-         zootot_loss_poc    => marbl_zooplankton_share%zootot_loss_poc_fields,  & ! INPUT zootot_loss routed to large detrital pool (mmol C/m^3/sec)
-         zootot_loss_doc    => marbl_zooplankton_share%zootot_loss_doc_fields,  & ! INPUT zootot_loss routed to doc (mmol C/m^3/sec)
-         zootot_loss_dic    => marbl_zooplankton_share%zootot_loss_dic_fields,  & ! INPUT zootot_loss routed to dic (mmol C/m^3/sec)
-         zootot_graze       => marbl_zooplankton_share%zootot_graze_fields,     & ! INPUT zooplankton losses due to grazing (mmol C/m^3/sec)
-         zootot_graze_zoo   => marbl_zooplankton_share%zootot_graze_zoo_fields, & ! INPUT grazing of zooplankton routed to zoo (mmol C/m^3/sec)
-         zootot_graze_poc   => marbl_zooplankton_share%zootot_graze_poc_fields, & ! INPUT grazing of zooplankton routed to poc (mmol C/m^3/sec)
-         zootot_graze_doc   => marbl_zooplankton_share%zootot_graze_doc_fields, & ! INPUT grazing of zooplankton routed to doc (mmol C/m^3/sec)
-         zootot_graze_dic   => marbl_zooplankton_share%zootot_graze_dic_fields, & ! INPUT grazing of zooplankton routed to dic (mmol C/m^3/sec)
+         zoototC_loc        => zooplankton_share%zoototC_loc_fields(:),      & ! INPUT local copy of model zoototC
+         zootot_loss        => zooplankton_share%zootot_loss_fields(:),      & ! INPUT mortality & higher trophic grazing on zooplankton (mmol C/m^3/sec)
+         zootot_loss_poc    => zooplankton_share%zootot_loss_poc_fields(:),  & ! INPUT zootot_loss routed to large detrital pool (mmol C/m^3/sec)
+         zootot_loss_doc    => zooplankton_share%zootot_loss_doc_fields(:),  & ! INPUT zootot_loss routed to doc (mmol C/m^3/sec)
+         zootot_loss_dic    => zooplankton_share%zootot_loss_dic_fields(:),  & ! INPUT zootot_loss routed to dic (mmol C/m^3/sec)
+         zootot_graze       => zooplankton_share%zootot_graze_fields(:),     & ! INPUT zooplankton losses due to grazing (mmol C/m^3/sec)
+         zootot_graze_zoo   => zooplankton_share%zootot_graze_zoo_fields(:), & ! INPUT grazing of zooplankton routed to zoo (mmol C/m^3/sec)
+         zootot_graze_poc   => zooplankton_share%zootot_graze_poc_fields(:), & ! INPUT grazing of zooplankton routed to poc (mmol C/m^3/sec)
+         zootot_graze_doc   => zooplankton_share%zootot_graze_doc_fields(:), & ! INPUT grazing of zooplankton routed to doc (mmol C/m^3/sec)
+         zootot_graze_dic   => zooplankton_share%zootot_graze_dic_fields(:), & ! INPUT grazing of zooplankton routed to dic (mmol C/m^3/sec)
 
          POC                => marbl_particulate_share%POC,     & ! INPUT
          P_CaCO3            => marbl_particulate_share%P_CaCO3, & ! INPUT

--- a/src/marbl_diagnostics_mod.F90
+++ b/src/marbl_diagnostics_mod.F90
@@ -2988,7 +2988,7 @@ contains
     type (autotroph_local_type),                         intent(in)    :: autotroph_local
     type (autotroph_derived_terms_type),                 intent(in)    :: autotroph_derived_terms
     type (zooplankton_derived_terms_type),               intent(in)    :: zooplankton_derived_terms
-    type (dissolved_organic_matter_type),                intent(in)    :: dissolved_organic_matter(domain%km)
+    type (dissolved_organic_matter_type),                intent(in)    :: dissolved_organic_matter
     type (marbl_particulate_share_type),                 intent(in)    :: marbl_particulate_share
     type (marbl_PAR_type),                               intent(in)    :: PAR
     real (r8),                                           intent(in)    :: PON_remin(domain%km)        ! remin of PON
@@ -3882,9 +3882,9 @@ contains
   subroutine store_diagnostics_dissolved_organic_matter(marbl_domain, &
        dissolved_organic_matter, marbl_diags)
 
-    type(marbl_domain_type)      , intent(in)    :: marbl_domain
-    type(dissolved_organic_matter_type) , intent(in)    :: dissolved_organic_matter(:) ! (km)
-    type(marbl_diagnostics_type)        , intent(inout) :: marbl_diags
+    type(marbl_domain_type)            , intent(in)    :: marbl_domain
+    type(dissolved_organic_matter_type), intent(in)    :: dissolved_organic_matter
+    type(marbl_diagnostics_type)       , intent(inout) :: marbl_diags
 
     !-----------------------------------------------------------------------
     !  local variables
@@ -3901,16 +3901,16 @@ contains
          )
 
     do k = 1, km
-       diags(ind%DOC_prod)%field_3d(k, 1)         = dissolved_organic_matter(k)%DOC_prod
-       diags(ind%DOC_remin)%field_3d(k, 1)        = dissolved_organic_matter(k)%DOC_remin
-       diags(ind%DOCr_remin)%field_3d(k, 1)       = dissolved_organic_matter(k)%DOCr_remin
-       diags(ind%DON_prod)%field_3d(k, 1)         = dissolved_organic_matter(k)%DON_prod
-       diags(ind%DON_remin)%field_3d(k, 1)        = dissolved_organic_matter(k)%DON_remin
-       diags(ind%DONr_remin)%field_3d(k, 1)       = dissolved_organic_matter(k)%DONr_remin
-       diags(ind%DOP_prod)%field_3d(k, 1)         = dissolved_organic_matter(k)%DOP_prod
-       diags(ind%DOP_remin)%field_3d(k, 1)        = dissolved_organic_matter(k)%DOP_remin
-       diags(ind%DOPr_remin)%field_3d(k, 1)       = dissolved_organic_matter(k)%DOPr_remin
-       diags(ind%DOP_loss_P_bal)%field_3d(k, 1)   = dissolved_organic_matter(k)%DOP_loss_P_bal
+       diags(ind%DOC_prod)%field_3d(k, 1)         = dissolved_organic_matter%DOC_prod(k)
+       diags(ind%DOC_remin)%field_3d(k, 1)        = dissolved_organic_matter%DOC_remin(k)
+       diags(ind%DOCr_remin)%field_3d(k, 1)       = dissolved_organic_matter%DOCr_remin(k)
+       diags(ind%DON_prod)%field_3d(k, 1)         = dissolved_organic_matter%DON_prod(k)
+       diags(ind%DON_remin)%field_3d(k, 1)        = dissolved_organic_matter%DON_remin(k)
+       diags(ind%DONr_remin)%field_3d(k, 1)       = dissolved_organic_matter%DONr_remin(k)
+       diags(ind%DOP_prod)%field_3d(k, 1)         = dissolved_organic_matter%DOP_prod(k)
+       diags(ind%DOP_remin)%field_3d(k, 1)        = dissolved_organic_matter%DOP_remin(k)
+       diags(ind%DOPr_remin)%field_3d(k, 1)       = dissolved_organic_matter%DOPr_remin(k)
+       diags(ind%DOP_loss_P_bal)%field_3d(k, 1)   = dissolved_organic_matter%DOP_loss_P_bal(k)
     end do
 
     call marbl_diagnostics_share_compute_vertical_integrals(diags(ind%DOC_prod)%field_3d(:,1), &

--- a/src/marbl_diagnostics_mod.F90
+++ b/src/marbl_diagnostics_mod.F90
@@ -3073,7 +3073,7 @@ contains
     call store_diagnostics_dissolved_organic_matter(domain, &
          dissolved_organic_matter, marbl_interior_tendency_diags)
 
-    call store_diagnostics_iron_cycle(domain, &
+    call store_diagnostics_iron_cycle( &
          fe_scavenge, fe_scavenge_rate, Lig_prod, Lig_loss, Lig_scavenge, &
          Fefree, Lig_photochem, Lig_deg, marbl_interior_tendency_diags)
 
@@ -3882,32 +3882,23 @@ contains
     type(dissolved_organic_matter_type), intent(in)    :: dissolved_organic_matter
     type(marbl_diagnostics_type)       , intent(inout) :: marbl_diags
 
-    !-----------------------------------------------------------------------
-    !  local variables
-    !-----------------------------------------------------------------------
-    integer(int_kind) :: k
-    !-----------------------------------------------------------------------
-
     associate(                                       &
-         km      => marbl_domain%km,                 &
          delta_z => marbl_domain%delta_z,            &
          kmt     => marbl_domain%kmt,                &
          diags   => marbl_diags%diags,               &
          ind     => marbl_interior_tendency_diag_ind &
          )
 
-    do k = 1, km
-       diags(ind%DOC_prod)%field_3d(k, 1)         = dissolved_organic_matter%DOC_prod(k)
-       diags(ind%DOC_remin)%field_3d(k, 1)        = dissolved_organic_matter%DOC_remin(k)
-       diags(ind%DOCr_remin)%field_3d(k, 1)       = dissolved_organic_matter%DOCr_remin(k)
-       diags(ind%DON_prod)%field_3d(k, 1)         = dissolved_organic_matter%DON_prod(k)
-       diags(ind%DON_remin)%field_3d(k, 1)        = dissolved_organic_matter%DON_remin(k)
-       diags(ind%DONr_remin)%field_3d(k, 1)       = dissolved_organic_matter%DONr_remin(k)
-       diags(ind%DOP_prod)%field_3d(k, 1)         = dissolved_organic_matter%DOP_prod(k)
-       diags(ind%DOP_remin)%field_3d(k, 1)        = dissolved_organic_matter%DOP_remin(k)
-       diags(ind%DOPr_remin)%field_3d(k, 1)       = dissolved_organic_matter%DOPr_remin(k)
-       diags(ind%DOP_loss_P_bal)%field_3d(k, 1)   = dissolved_organic_matter%DOP_loss_P_bal(k)
-    end do
+    diags(ind%DOC_prod)%field_3d(:, 1)         = dissolved_organic_matter%DOC_prod(:)
+    diags(ind%DOC_remin)%field_3d(:, 1)        = dissolved_organic_matter%DOC_remin(:)
+    diags(ind%DOCr_remin)%field_3d(:, 1)       = dissolved_organic_matter%DOCr_remin(:)
+    diags(ind%DON_prod)%field_3d(:, 1)         = dissolved_organic_matter%DON_prod(:)
+    diags(ind%DON_remin)%field_3d(:, 1)        = dissolved_organic_matter%DON_remin(:)
+    diags(ind%DONr_remin)%field_3d(:, 1)       = dissolved_organic_matter%DONr_remin(:)
+    diags(ind%DOP_prod)%field_3d(:, 1)         = dissolved_organic_matter%DOP_prod(:)
+    diags(ind%DOP_remin)%field_3d(:, 1)        = dissolved_organic_matter%DOP_remin(:)
+    diags(ind%DOPr_remin)%field_3d(:, 1)       = dissolved_organic_matter%DOPr_remin(:)
+    diags(ind%DOP_loss_P_bal)%field_3d(:, 1)   = dissolved_organic_matter%DOP_loss_P_bal(:)
 
     call marbl_diagnostics_share_compute_vertical_integrals(diags(ind%DOC_prod)%field_3d(:,1), &
          delta_z, kmt, full_depth_integral=diags(ind%DOC_prod_zint)%field_2d(1), &
@@ -3927,11 +3918,10 @@ contains
 
   !***********************************************************************
 
-  subroutine store_diagnostics_iron_cycle(marbl_domain, &
+  subroutine store_diagnostics_iron_cycle(&
        fe_scavenge, fe_scavenge_rate, Lig_prod, Lig_loss, Lig_scavenge, &
        Fefree, Lig_photochem, Lig_deg, marbl_diags)
 
-    type(marbl_domain_type)             , intent(in)    :: marbl_domain
     real(r8)                            , intent(in)    :: fe_scavenge(:)      ! (km)
     real(r8)                            , intent(in)    :: fe_scavenge_rate(:) ! (km)
     real(r8)                            , intent(in)    :: Lig_prod(:)         ! (km)
@@ -3942,28 +3932,19 @@ contains
     real(r8)                            , intent(in)    :: Lig_deg(:)          ! (km)
     type(marbl_diagnostics_type)        , intent(inout) :: marbl_diags
 
-    !-----------------------------------------------------------------------
-    !  local variables
-    !-----------------------------------------------------------------------
-    integer(int_kind) :: k
-    !-----------------------------------------------------------------------
-
     associate(                                     &
-         km    => marbl_domain%km,                 &
          diags => marbl_diags%diags,               &
          ind   => marbl_interior_tendency_diag_ind &
          )
 
-    do k = 1, km
-       diags(ind%Fe_scavenge)%field_3d(k, 1)      = Fe_scavenge(k)
-       diags(ind%Fe_scavenge_rate)%field_3d(k, 1) = Fe_scavenge_rate(k)
-       diags(ind%Lig_prod)%field_3d(k, 1)         = Lig_prod(k)
-       diags(ind%Lig_loss)%field_3d(k, 1)         = Lig_loss(k)
-       diags(ind%Lig_scavenge)%field_3d(k, 1)     = Lig_scavenge(k)
-       diags(ind%Fefree)%field_3d(k, 1)           = Fefree(k)
-       diags(ind%Lig_photochem)%field_3d(k, 1)    = Lig_photochem(k)
-       diags(ind%Lig_deg)%field_3d(k, 1)          = Lig_deg(k)
-    end do
+    diags(ind%Fe_scavenge)%field_3d(:, 1)      = Fe_scavenge(:)
+    diags(ind%Fe_scavenge_rate)%field_3d(:, 1) = Fe_scavenge_rate(:)
+    diags(ind%Lig_prod)%field_3d(:, 1)         = Lig_prod(:)
+    diags(ind%Lig_loss)%field_3d(:, 1)         = Lig_loss(:)
+    diags(ind%Lig_scavenge)%field_3d(:, 1)     = Lig_scavenge(:)
+    diags(ind%Fefree)%field_3d(:, 1)           = Fefree(:)
+    diags(ind%Lig_photochem)%field_3d(:, 1)    = Lig_photochem(:)
+    diags(ind%Lig_deg)%field_3d(:, 1)          = Lig_deg(:)
 
     end associate
 

--- a/src/marbl_diagnostics_mod.F90
+++ b/src/marbl_diagnostics_mod.F90
@@ -19,6 +19,7 @@ module marbl_diagnostics_mod
   use marbl_interface_private_types, only : dissolved_organic_matter_type
   use marbl_interface_private_types, only : column_sinking_particle_type
   use marbl_interface_private_types, only : marbl_PAR_type
+  use marbl_interface_private_types, only : autotroph_secondary_species_type
   use marbl_interface_private_types, only : marbl_particulate_share_type
   use marbl_interface_private_types, only : marbl_surface_flux_internal_type
   use marbl_interface_private_types, only : marbl_tracer_index_type
@@ -30,7 +31,6 @@ module marbl_diagnostics_mod
   use marbl_interface_public_types, only : marbl_diagnostics_type
 
   use marbl_pft_mod, only : autotroph_local_type
-  use marbl_pft_mod, only : autotroph_secondary_species_type
   use marbl_pft_mod, only : zooplankton_secondary_species_type
 
   use marbl_logging, only : marbl_log_type
@@ -2989,7 +2989,7 @@ contains
     type(marbl_tracer_index_type)             , intent(in) :: marbl_tracer_indices
     type (carbonate_type)                     , intent(in) :: carbonate(domain%km)
     type (autotroph_local_type)               , intent(in) :: autotroph_local(autotroph_cnt, domain%km)
-    type (autotroph_secondary_species_type)   , intent(in) :: autotroph_secondary_species(autotroph_cnt, domain%km)
+    type (autotroph_secondary_species_type)   , intent(in) :: autotroph_secondary_species
     type (zooplankton_secondary_species_type) , intent(in) :: zooplankton_secondary_species(zooplankton_cnt, domain%km)
     type (dissolved_organic_matter_type)      , intent(in) :: dissolved_organic_matter(domain%km)
     type (marbl_particulate_share_type)       , intent(in) :: marbl_particulate_share
@@ -3415,7 +3415,7 @@ contains
 
     type(marbl_domain_type)                , intent(in)    :: marbl_domain
     type(autotroph_local_type)             , intent(in)    :: autotroph_local(:,:) ! autotroph_cnt, km
-    type(autotroph_secondary_species_type) , intent(in)    :: autotroph_secondary_species(:,:) ! autotroph_cnt, km
+    type(autotroph_secondary_species_type) , intent(in)    :: autotroph_secondary_species
     type(marbl_diagnostics_type)           , intent(inout) :: marbl_interior_diags
 
     !-----------------------------------------------------------------------
@@ -3462,81 +3462,81 @@ contains
        ! normalize weight, so that its integral is 1
        autotrophC_weight(:) = autotrophC_weight(:) / autotrophC_zint_100m
 
-       diags(ind%N_lim_surf(n))%field_2d(1) = autotroph_secondary_species(n,1)%VNtot
-       limterm = autotroph_secondary_species(n,:)%VNtot * autotrophC_weight(:)
+       diags(ind%N_lim_surf(n))%field_2d(1) = autotroph_secondary_species%VNtot(n,1)
+       limterm = autotroph_secondary_species%VNtot(n,:) * autotrophC_weight(:)
        call marbl_diagnostics_share_compute_vertical_integrals(limterm, delta_z, kmt, &
             near_surface_integral=diags(ind%N_lim_Cweight_avg_100m(n))%field_2d(1))
 
-       diags(ind%P_lim_surf(n))%field_2d(1) = autotroph_secondary_species(n,1)%VPtot
-       limterm = autotroph_secondary_species(n,:)%VPtot * autotrophC_weight(:)
+       diags(ind%P_lim_surf(n))%field_2d(1) = autotroph_secondary_species%VPtot(n,1)
+       limterm = autotroph_secondary_species%VPtot(n,:) * autotrophC_weight(:)
        call marbl_diagnostics_share_compute_vertical_integrals(limterm, delta_z, kmt, &
             near_surface_integral=diags(ind%P_lim_Cweight_avg_100m(n))%field_2d(1))
 
-       diags(ind%Fe_lim_surf(n))%field_2d(1) = autotroph_secondary_species(n,1)%VFe
-       limterm = autotroph_secondary_species(n,:)%VFe * autotrophC_weight(:)
+       diags(ind%Fe_lim_surf(n))%field_2d(1) = autotroph_secondary_species%VFe(n,1)
+       limterm = autotroph_secondary_species%VFe(n,:) * autotrophC_weight(:)
        call marbl_diagnostics_share_compute_vertical_integrals(limterm, delta_z, kmt, &
             near_surface_integral=diags(ind%Fe_lim_Cweight_avg_100m(n))%field_2d(1))
 
        if (ind%SiO3_lim_surf(n).ne.-1) then
-          diags(ind%SiO3_lim_surf(n))%field_2d(1) = autotroph_secondary_species(n,1)%VSiO3
+          diags(ind%SiO3_lim_surf(n))%field_2d(1) = autotroph_secondary_species%VSiO3(n,1)
        endif
        if (ind%SiO3_lim_Cweight_avg_100m(n).ne.-1) then
-          limterm = autotroph_secondary_species(n,:)%VSiO3 * autotrophC_weight(:)
+          limterm = autotroph_secondary_species%VSiO3(n,:) * autotrophC_weight(:)
           call marbl_diagnostics_share_compute_vertical_integrals(limterm, delta_z, kmt, &
                near_surface_integral=diags(ind%SiO3_lim_Cweight_avg_100m(n))%field_2d(1))
        endif
 
-       diags(ind%light_lim_surf(n))%field_2d(1) = autotroph_secondary_species(n,1)%light_lim
-       limterm = autotroph_secondary_species(n,:)%light_lim * autotrophC_weight(:)
+       diags(ind%light_lim_surf(n))%field_2d(1) = autotroph_secondary_species%light_lim(n,1)
+       limterm = autotroph_secondary_species%light_lim(n,:) * autotrophC_weight(:)
        call marbl_diagnostics_share_compute_vertical_integrals(limterm, delta_z, kmt, &
             near_surface_integral=diags(ind%light_lim_Cweight_avg_100m(n))%field_2d(1))
 
        if (ind%Qp(n).ne.-1) then
-         diags(ind%Qp(n))%field_3d(:, 1)        = autotroph_secondary_species(n,:)%Qp
+         diags(ind%Qp(n))%field_3d(:, 1)        = autotroph_secondary_species%Qp(n,:)
        end if
 
-       diags(ind%photoNO3(n))%field_3d(:, 1)    = autotroph_secondary_species(n,:)%NO3_V
-       diags(ind%photoNH4(n))%field_3d(:, 1)    = autotroph_secondary_species(n,:)%NH4_V
-       diags(ind%PO4_uptake(n))%field_3d(:, 1)  = autotroph_secondary_species(n,:)%PO4_V
-       diags(ind%DOP_uptake(n))%field_3d(:, 1)  = autotroph_secondary_species(n,:)%DOP_V
-       diags(ind%photoFE(n))%field_3d(:, 1)     = autotroph_secondary_species(n,:)%photoFe
+       diags(ind%photoNO3(n))%field_3d(:, 1)    = autotroph_secondary_species%NO3_V(n,:)
+       diags(ind%photoNH4(n))%field_3d(:, 1)    = autotroph_secondary_species%NH4_V(n,:)
+       diags(ind%PO4_uptake(n))%field_3d(:, 1)  = autotroph_secondary_species%PO4_V(n,:)
+       diags(ind%DOP_uptake(n))%field_3d(:, 1)  = autotroph_secondary_species%DOP_V(n,:)
+       diags(ind%photoFE(n))%field_3d(:, 1)     = autotroph_secondary_species%photoFe(n,:)
 
        if (ind%bSi_form(n).ne.-1) then
-          diags(ind%bSi_form(n))%field_3d(:, 1)  = autotroph_secondary_species(n,:)%photoSi
+          diags(ind%bSi_form(n))%field_3d(:, 1)  = autotroph_secondary_species%photoSi(n,:)
           diags(ind%tot_bSi_form)%field_3d(:, 1) = diags(ind%tot_bSi_form)%field_3d(:, 1) + &
                diags(ind%bSi_form(n))%field_3d(:, 1)
        endif
 
        if (ind%CaCO3_form(n).ne.-1) then
-          diags(ind%CaCO3_form(n))%field_3d(:, 1)  = autotroph_secondary_species(n,:)%CaCO3_form
+          diags(ind%CaCO3_form(n))%field_3d(:, 1)  = autotroph_secondary_species%CaCO3_form(n,:)
           diags(ind%tot_CaCO3_form)%field_3d(:, 1) = diags(ind%tot_CaCO3_form)%field_3d(:, 1) + &
                diags(ind%CaCO3_form(n))%field_3d(:, 1)
        end if
 
        if (ind%Nfix(n).ne.-1) then
-          diags(ind%Nfix(n))%field_3d(:, 1)  = autotroph_secondary_species(n,:)%Nfix
+          diags(ind%Nfix(n))%field_3d(:, 1)  = autotroph_secondary_species%Nfix(n,:)
           diags(ind%tot_Nfix)%field_3d(:, 1) = diags(ind%tot_Nfix)%field_3d(:, 1) + &
                diags(ind%Nfix(n))%field_3d(:, 1)
        end if
 
-       diags(ind%auto_graze(n))%field_3d(:, 1)     = autotroph_secondary_species(n,:)%auto_graze
+       diags(ind%auto_graze(n))%field_3d(:, 1)     = autotroph_secondary_species%auto_graze(n,:)
        diags(ind%auto_graze_TOT)%field_3d(:, 1)    = diags(ind%auto_graze_TOT)%field_3d(:, 1) + &
-            autotroph_secondary_species(n,:)%auto_graze
-       diags(ind%auto_graze_poc(n))%field_3d(:, 1) = autotroph_secondary_species(n,:)%auto_graze_poc
-       diags(ind%auto_graze_doc(n))%field_3d(:, 1) = autotroph_secondary_species(n,:)%auto_graze_doc
-       diags(ind%auto_graze_zoo(n))%field_3d(:, 1) = autotroph_secondary_species(n,:)%auto_graze_zoo
-       diags(ind%auto_loss(n))%field_3d(:, 1)      = autotroph_secondary_species(n,:)%auto_loss
-       diags(ind%auto_loss_poc(n))%field_3d(:, 1)  = autotroph_secondary_species(n,:)%auto_loss_poc
-       diags(ind%auto_loss_doc(n))%field_3d(:, 1)  = autotroph_secondary_species(n,:)%auto_loss_doc
-       diags(ind%auto_agg(n))%field_3d(:, 1)       = autotroph_secondary_species(n,:)%auto_agg
-       diags(ind%photoC(n))%field_3d(:, 1)         = autotroph_secondary_species(n,:)%photoC
+            autotroph_secondary_species%auto_graze(n,:)
+       diags(ind%auto_graze_poc(n))%field_3d(:, 1) = autotroph_secondary_species%auto_graze_poc(n,:)
+       diags(ind%auto_graze_doc(n))%field_3d(:, 1) = autotroph_secondary_species%auto_graze_doc(n,:)
+       diags(ind%auto_graze_zoo(n))%field_3d(:, 1) = autotroph_secondary_species%auto_graze_zoo(n,:)
+       diags(ind%auto_loss(n))%field_3d(:, 1)      = autotroph_secondary_species%auto_loss(n,:)
+       diags(ind%auto_loss_poc(n))%field_3d(:, 1)  = autotroph_secondary_species%auto_loss_poc(n,:)
+       diags(ind%auto_loss_doc(n))%field_3d(:, 1)  = autotroph_secondary_species%auto_loss_doc(n,:)
+       diags(ind%auto_agg(n))%field_3d(:, 1)       = autotroph_secondary_species%auto_agg(n,:)
+       diags(ind%photoC(n))%field_3d(:, 1)         = autotroph_secondary_species%photoC(n,:)
        diags(ind%photoC_TOT)%field_3d(:, 1)        = diags(ind%photoC_TOT)%field_3d(:, 1) + &
-            autotroph_secondary_species(n,:)%photoC
+            autotroph_secondary_species%photoC(n,:)
 
        diags(ind%photoC_NO3(n))%field_3d(:, 1) = c0
-       where (autotroph_secondary_species(n,:)%VNtot > c0)
-          diags(ind%photoC_NO3(n))%field_3d(:, 1) = autotroph_secondary_species(n,:)%photoC * &
-               (autotroph_secondary_species(n,:)%VNO3 / autotroph_secondary_species(n,:)%VNtot)
+       where (autotroph_secondary_species%VNtot(n,:) > c0)
+          diags(ind%photoC_NO3(n))%field_3d(:, 1) = autotroph_secondary_species%photoC(n,:) * &
+               (autotroph_secondary_species%VNO3(n,:) / autotroph_secondary_species%VNtot(n,:))
 
           diags(ind%photoC_NO3_TOT)%field_3d(:, 1) = diags(ind%photoC_NO3_TOT)%field_3d(:, 1) + &
                diags(ind%photoC_NO3(n))%field_3d(:, 1)
@@ -3544,7 +3544,7 @@ contains
 
        ! per-autotroph vertical integrals and their sums
        if (ind%CaCO3_form_zint(n).ne.-1) then
-          call marbl_diagnostics_share_compute_vertical_integrals(autotroph_secondary_species(n,:)%CaCO3_form, &
+          call marbl_diagnostics_share_compute_vertical_integrals(autotroph_secondary_species%CaCO3_form(n,:), &
                delta_z, kmt, full_depth_integral=diags(ind%CaCO3_form_zint(n))%field_2d(1), &
                near_surface_integral=diags(ind%CaCO3_form_zint_100m(n))%field_2d(1))
 
@@ -3555,7 +3555,7 @@ contains
                diags(ind%CaCO3_form_zint_100m(n))%field_2d(1)
        end if
 
-       call marbl_diagnostics_share_compute_vertical_integrals(autotroph_secondary_species(n,:)%photoC, &
+       call marbl_diagnostics_share_compute_vertical_integrals(autotroph_secondary_species%photoC(n,:), &
             delta_z, kmt, full_depth_integral=diags(ind%photoC_zint(n))%field_2d(1), &
             near_surface_integral=diags(ind%photoC_zint_100m(n))%field_2d(1))
 
@@ -4056,7 +4056,7 @@ contains
     real(r8)                               , intent(in)    :: PON_sed_loss(:) ! km
     real(r8)                               , intent(in)    :: denitrif(:)     ! km
     real(r8)                               , intent(in)    :: sed_denitrif(:) ! km
-    type(autotroph_secondary_species_type) , intent(in)    :: autotroph_secondary_species(:,:)
+    type(autotroph_secondary_species_type) , intent(in)    :: autotroph_secondary_species
     real(r8)                               , intent(in)    :: interior_tendencies(:,:)         ! tracer_cnt, km
     type(marbl_tracer_index_type)          , intent(in)    :: marbl_tracer_indices
     type(marbl_diagnostics_type)           , intent(inout) :: marbl_diags
@@ -4094,7 +4094,7 @@ contains
     ! subtract out N fixation
     do n = 1, autotroph_cnt
        if (autotrophs(n)%Nfixer) then
-          work = work - autotroph_secondary_species(n,:)%Nfix
+          work = work - autotroph_secondary_species%Nfix(n,:)
        end if
     end do
 
@@ -4126,7 +4126,7 @@ contains
 
     type(marbl_domain_type)                , intent(in)    :: marbl_domain
     type(column_sinking_particle_type)     , intent(in)    :: POP
-    type(autotroph_secondary_species_type) , intent(in)    :: autotroph_secondary_species(:,:)
+    type(autotroph_secondary_species_type) , intent(in)    :: autotroph_secondary_species
     real(r8)                               , intent(in)    :: interior_tendencies(:,:)         ! tracer_cnt, km
     type(marbl_tracer_index_type)          , intent(in)    :: marbl_tracer_indices
     type(marbl_diagnostics_type)           , intent(inout) :: marbl_diags
@@ -4159,7 +4159,7 @@ contains
        work = work + sum(interior_tendencies(marbl_tracer_indices%auto_inds(:)%P_ind,:),dim=1)
     else
        do n = 1, autotroph_cnt
-          work = work + autotroph_secondary_species(n,:)%Qp * interior_tendencies(marbl_tracer_indices%auto_inds(n)%C_ind,:)
+          work = work + autotroph_secondary_species%Qp(n,:) * interior_tendencies(marbl_tracer_indices%auto_inds(n)%C_ind,:)
        end do
     endif
 

--- a/src/marbl_diagnostics_mod.F90
+++ b/src/marbl_diagnostics_mod.F90
@@ -9,7 +9,7 @@ module marbl_diagnostics_mod
 
   use marbl_settings_mod, only : autotroph_cnt
   use marbl_settings_mod, only : zooplankton_cnt
-  use marbl_settings_mod, only : autotrophs
+  use marbl_settings_mod, only : autotroph_settings
   use marbl_settings_mod, only : zooplankton
 
   use marbl_constants_mod, only : c0
@@ -20,8 +20,8 @@ module marbl_diagnostics_mod
   use marbl_interface_private_types, only : column_sinking_particle_type
   use marbl_interface_private_types, only : marbl_PAR_type
   use marbl_interface_private_types, only : autotroph_local_type
-  use marbl_interface_private_types, only : autotroph_secondary_species_type
-  use marbl_interface_private_types, only : zooplankton_secondary_species_type
+  use marbl_interface_private_types, only : autotroph_derived_terms_type
+  use marbl_interface_private_types, only : zooplankton_derived_terms_type
   use marbl_interface_private_types, only : marbl_particulate_share_type
   use marbl_interface_private_types, only : marbl_surface_flux_internal_type
   use marbl_interface_private_types, only : marbl_tracer_index_type
@@ -860,8 +860,8 @@ contains
         allocate(ind%auto_agg_zint_100m(autotroph_cnt))
       end if
       do n=1,autotroph_cnt
-        lname = trim(autotrophs(n)%lname) // ' N Limitation, Surface'
-        sname = trim(autotrophs(n)%sname) // '_N_lim_surf'
+        lname = trim(autotroph_settings(n)%lname) // ' N Limitation, Surface'
+        sname = trim(autotroph_settings(n)%sname) // '_N_lim_surf'
         units = '1'
         vgrid = 'none'
         truncate = .false.
@@ -872,8 +872,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' N Limitation, carbon biomass weighted average over 0-100m'
-        sname = trim(autotrophs(n)%sname) // '_N_lim_Cweight_avg_100m'
+        lname = trim(autotroph_settings(n)%lname) // ' N Limitation, carbon biomass weighted average over 0-100m'
+        sname = trim(autotroph_settings(n)%sname) // '_N_lim_Cweight_avg_100m'
         units = '1'
         vgrid = 'none'
         truncate = .false.
@@ -884,8 +884,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' P Limitation, Surface'
-        sname = trim(autotrophs(n)%sname) // '_P_lim_surf'
+        lname = trim(autotroph_settings(n)%lname) // ' P Limitation, Surface'
+        sname = trim(autotroph_settings(n)%sname) // '_P_lim_surf'
         units = '1'
         vgrid = 'none'
         truncate = .false.
@@ -896,8 +896,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' P Limitation, carbon biomass weighted average over 0-100m'
-        sname = trim(autotrophs(n)%sname) // '_P_lim_Cweight_avg_100m'
+        lname = trim(autotroph_settings(n)%lname) // ' P Limitation, carbon biomass weighted average over 0-100m'
+        sname = trim(autotroph_settings(n)%sname) // '_P_lim_Cweight_avg_100m'
         units = '1'
         vgrid = 'none'
         truncate = .false.
@@ -908,8 +908,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' Fe Limitation, Surface'
-        sname = trim(autotrophs(n)%sname) // '_Fe_lim_surf'
+        lname = trim(autotroph_settings(n)%lname) // ' Fe Limitation, Surface'
+        sname = trim(autotroph_settings(n)%sname) // '_Fe_lim_surf'
         units = '1'
         vgrid = 'none'
         truncate = .false.
@@ -920,8 +920,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' Fe Limitation, carbon biomass weighted average over 0-100m'
-        sname = trim(autotrophs(n)%sname) // '_Fe_lim_Cweight_avg_100m'
+        lname = trim(autotroph_settings(n)%lname) // ' Fe Limitation, carbon biomass weighted average over 0-100m'
+        sname = trim(autotroph_settings(n)%sname) // '_Fe_lim_Cweight_avg_100m'
         units = '1'
         vgrid = 'none'
         truncate = .false.
@@ -932,9 +932,9 @@ contains
           return
         end if
 
-        if (autotrophs(n)%silicifier) then
-          lname = trim(autotrophs(n)%lname) // ' SiO3 Limitation, Surface'
-          sname = trim(autotrophs(n)%sname) // '_SiO3_lim_surf'
+        if (autotroph_settings(n)%silicifier) then
+          lname = trim(autotroph_settings(n)%lname) // ' SiO3 Limitation, Surface'
+          sname = trim(autotroph_settings(n)%sname) // '_SiO3_lim_surf'
           units = '1'
           vgrid = 'none'
           truncate = .false.
@@ -945,8 +945,8 @@ contains
             return
           end if
 
-          lname = trim(autotrophs(n)%lname) // ' SiO3 Limitation, carbon biomass weighted average over 0-100m'
-          sname = trim(autotrophs(n)%sname) // '_SiO3_lim_Cweight_avg_100m'
+          lname = trim(autotroph_settings(n)%lname) // ' SiO3 Limitation, carbon biomass weighted average over 0-100m'
+          sname = trim(autotroph_settings(n)%sname) // '_SiO3_lim_Cweight_avg_100m'
           units = '1'
           vgrid = 'none'
           truncate = .false.
@@ -961,8 +961,8 @@ contains
           ind%SiO3_lim_Cweight_avg_100m(n) = -1
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' Light Limitation, Surface'
-        sname = trim(autotrophs(n)%sname) // '_light_lim_surf'
+        lname = trim(autotroph_settings(n)%lname) // ' Light Limitation, Surface'
+        sname = trim(autotroph_settings(n)%sname) // '_light_lim_surf'
         units = '1'
         vgrid = 'none'
         truncate = .false.
@@ -973,8 +973,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' Light Limitation, carbon biomass weighted average over 0-100m'
-        sname = trim(autotrophs(n)%sname) // '_light_lim_Cweight_avg_100m'
+        lname = trim(autotroph_settings(n)%lname) // ' Light Limitation, carbon biomass weighted average over 0-100m'
+        sname = trim(autotroph_settings(n)%sname) // '_light_lim_Cweight_avg_100m'
         units = '1'
         vgrid = 'none'
         truncate = .false.
@@ -985,8 +985,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' C Fixation Vertical Integral'
-        sname = 'photoC_' // trim(autotrophs(n)%sname) // '_zint'
+        lname = trim(autotroph_settings(n)%lname) // ' C Fixation Vertical Integral'
+        sname = 'photoC_' // trim(autotroph_settings(n)%sname) // '_zint'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -997,8 +997,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' C Fixation Vertical Integral, 0-100m'
-        sname = 'photoC_' // trim(autotrophs(n)%sname) // '_zint_100m'
+        lname = trim(autotroph_settings(n)%lname) // ' C Fixation Vertical Integral, 0-100m'
+        sname = 'photoC_' // trim(autotroph_settings(n)%sname) // '_zint_100m'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -1009,8 +1009,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' C Fixation from NO3 Vertical Integral'
-        sname = 'photoC_NO3_' // trim(autotrophs(n)%sname) // '_zint'
+        lname = trim(autotroph_settings(n)%lname) // ' C Fixation from NO3 Vertical Integral'
+        sname = 'photoC_NO3_' // trim(autotroph_settings(n)%sname) // '_zint'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -1021,9 +1021,9 @@ contains
           return
         end if
 
-        if (autotrophs(n)%imp_calcifier .or. autotrophs(n)%exp_calcifier) then
-          lname = trim(autotrophs(n)%lname) // ' CaCO3 Formation Vertical Integral'
-          sname = trim(autotrophs(n)%sname) // '_CaCO3_form_zint'
+        if (autotroph_settings(n)%imp_calcifier .or. autotroph_settings(n)%exp_calcifier) then
+          lname = trim(autotroph_settings(n)%lname) // ' CaCO3 Formation Vertical Integral'
+          sname = trim(autotroph_settings(n)%sname) // '_CaCO3_form_zint'
           units = 'mmol/m^3 cm/s'
           vgrid = 'none'
           truncate = .false.
@@ -1037,9 +1037,9 @@ contains
           ind%CaCO3_form_zint(n) = -1
         end if
 
-        if (autotrophs(n)%imp_calcifier .or. autotrophs(n)%exp_calcifier) then
-          lname = trim(autotrophs(n)%lname) // ' CaCO3 Formation Vertical Integral, 0-100m'
-          sname = trim(autotrophs(n)%sname) // '_CaCO3_form_zint_100m'
+        if (autotroph_settings(n)%imp_calcifier .or. autotroph_settings(n)%exp_calcifier) then
+          lname = trim(autotroph_settings(n)%lname) // ' CaCO3 Formation Vertical Integral, 0-100m'
+          sname = trim(autotroph_settings(n)%sname) // '_CaCO3_form_zint_100m'
           units = 'mmol/m^3 cm/s'
           vgrid = 'none'
           truncate = .false.
@@ -1053,8 +1053,8 @@ contains
           ind%CaCO3_form_zint_100m(n) = -1
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' Grazing Vertical Integral'
-        sname = 'graze_' // trim(autotrophs(n)%sname) // '_zint'
+        lname = trim(autotroph_settings(n)%lname) // ' Grazing Vertical Integral'
+        sname = 'graze_' // trim(autotroph_settings(n)%sname) // '_zint'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -1065,8 +1065,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' Grazing Vertical Integral, 0-100m'
-        sname = 'graze_' // trim(autotrophs(n)%sname) // '_zint_100m'
+        lname = trim(autotroph_settings(n)%lname) // ' Grazing Vertical Integral, 0-100m'
+        sname = 'graze_' // trim(autotroph_settings(n)%sname) // '_zint_100m'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -1077,8 +1077,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' Grazing to POC Vertical Integral'
-        sname = 'graze_' // trim(autotrophs(n)%sname) // '_poc_zint'
+        lname = trim(autotroph_settings(n)%lname) // ' Grazing to POC Vertical Integral'
+        sname = 'graze_' // trim(autotroph_settings(n)%sname) // '_poc_zint'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -1089,8 +1089,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' Grazing to POC Vertical Integral, 0-100m'
-        sname = 'graze_' // trim(autotrophs(n)%sname) // '_poc_zint_100m'
+        lname = trim(autotroph_settings(n)%lname) // ' Grazing to POC Vertical Integral, 0-100m'
+        sname = 'graze_' // trim(autotroph_settings(n)%sname) // '_poc_zint_100m'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -1101,8 +1101,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' Grazing to DOC Vertical Integral'
-        sname = 'graze_' // trim(autotrophs(n)%sname) // '_doc_zint'
+        lname = trim(autotroph_settings(n)%lname) // ' Grazing to DOC Vertical Integral'
+        sname = 'graze_' // trim(autotroph_settings(n)%sname) // '_doc_zint'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -1113,8 +1113,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' Grazing to DOC Vertical Integral, 0-100m'
-        sname = 'graze_' // trim(autotrophs(n)%sname) // '_doc_zint_100m'
+        lname = trim(autotroph_settings(n)%lname) // ' Grazing to DOC Vertical Integral, 0-100m'
+        sname = 'graze_' // trim(autotroph_settings(n)%sname) // '_doc_zint_100m'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -1125,8 +1125,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' Grazing to ZOO Vertical Integral'
-        sname = 'graze_' // trim(autotrophs(n)%sname) // '_zoo_zint'
+        lname = trim(autotroph_settings(n)%lname) // ' Grazing to ZOO Vertical Integral'
+        sname = 'graze_' // trim(autotroph_settings(n)%sname) // '_zoo_zint'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -1137,8 +1137,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' Grazing to ZOO Vertical Integral, 0-100m'
-        sname = 'graze_' // trim(autotrophs(n)%sname) // '_zoo_zint_100m'
+        lname = trim(autotroph_settings(n)%lname) // ' Grazing to ZOO Vertical Integral, 0-100m'
+        sname = 'graze_' // trim(autotroph_settings(n)%sname) // '_zoo_zint_100m'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -1149,8 +1149,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' Loss Vertical Integral'
-        sname = trim(autotrophs(n)%sname) // '_loss_zint'
+        lname = trim(autotroph_settings(n)%lname) // ' Loss Vertical Integral'
+        sname = trim(autotroph_settings(n)%sname) // '_loss_zint'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -1161,8 +1161,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' Loss Vertical Integral, 0-100m'
-        sname = trim(autotrophs(n)%sname) // '_loss_zint_100m'
+        lname = trim(autotroph_settings(n)%lname) // ' Loss Vertical Integral, 0-100m'
+        sname = trim(autotroph_settings(n)%sname) // '_loss_zint_100m'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -1173,8 +1173,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' Loss to POC Vertical Integral'
-        sname = trim(autotrophs(n)%sname) // '_loss_poc_zint'
+        lname = trim(autotroph_settings(n)%lname) // ' Loss to POC Vertical Integral'
+        sname = trim(autotroph_settings(n)%sname) // '_loss_poc_zint'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -1185,8 +1185,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' Loss to POC Vertical Integral, 0-100m'
-        sname = trim(autotrophs(n)%sname) // '_loss_poc_zint_100m'
+        lname = trim(autotroph_settings(n)%lname) // ' Loss to POC Vertical Integral, 0-100m'
+        sname = trim(autotroph_settings(n)%sname) // '_loss_poc_zint_100m'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -1197,8 +1197,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' Loss to DOC Vertical Integral'
-        sname = trim(autotrophs(n)%sname) // '_loss_doc_zint'
+        lname = trim(autotroph_settings(n)%lname) // ' Loss to DOC Vertical Integral'
+        sname = trim(autotroph_settings(n)%sname) // '_loss_doc_zint'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -1209,8 +1209,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' Loss to DOC Vertical Integral, 0-100m'
-        sname = trim(autotrophs(n)%sname) // '_loss_doc_zint_100m'
+        lname = trim(autotroph_settings(n)%lname) // ' Loss to DOC Vertical Integral, 0-100m'
+        sname = trim(autotroph_settings(n)%sname) // '_loss_doc_zint_100m'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -1221,8 +1221,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' Aggregation Vertical Integral'
-        sname = trim(autotrophs(n)%sname) // '_agg_zint'
+        lname = trim(autotroph_settings(n)%lname) // ' Aggregation Vertical Integral'
+        sname = trim(autotroph_settings(n)%sname) // '_agg_zint'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -1233,8 +1233,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' Aggregation Vertical Integral, 0-100m'
-        sname = trim(autotrophs(n)%sname) // '_agg_zint_100m'
+        lname = trim(autotroph_settings(n)%lname) // ' Aggregation Vertical Integral, 0-100m'
+        sname = trim(autotroph_settings(n)%sname) // '_agg_zint_100m'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -2501,8 +2501,8 @@ contains
       end if
       do n=1,autotroph_cnt
         if (lvariable_PtoC) then
-          lname = trim(autotrophs(n)%lname) // ' P:C ratio'
-          sname = trim(autotrophs(n)%sname) // '_Qp'
+          lname = trim(autotroph_settings(n)%lname) // ' P:C ratio'
+          sname = trim(autotroph_settings(n)%sname) // '_Qp'
           units = '1'
           vgrid = 'layer_avg'
           truncate = .true.
@@ -2516,8 +2516,8 @@ contains
           ind%Qp(n) = -1
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' C Fixation'
-        sname = 'photoC_' // trim(autotrophs(n)%sname)
+        lname = trim(autotroph_settings(n)%lname) // ' C Fixation'
+        sname = 'photoC_' // trim(autotroph_settings(n)%sname)
         units = 'mmol/m^3/s'
         vgrid = 'layer_avg'
         truncate = .true.
@@ -2528,8 +2528,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' C Fixation from NO3'
-        sname = 'photoC_NO3_' // trim(autotrophs(n)%sname)
+        lname = trim(autotroph_settings(n)%lname) // ' C Fixation from NO3'
+        sname = 'photoC_NO3_' // trim(autotroph_settings(n)%sname)
         units = 'mmol/m^3/s'
         vgrid = 'layer_avg'
         truncate = .true.
@@ -2540,8 +2540,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' Fe Uptake'
-        sname = 'photoFe_' // trim(autotrophs(n)%sname)
+        lname = trim(autotroph_settings(n)%lname) // ' Fe Uptake'
+        sname = 'photoFe_' // trim(autotroph_settings(n)%sname)
         units = 'mmol/m^3/s'
         vgrid = 'layer_avg'
         truncate = .true.
@@ -2552,8 +2552,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' NO3 Uptake'
-        sname = 'photoNO3_' // trim(autotrophs(n)%sname)
+        lname = trim(autotroph_settings(n)%lname) // ' NO3 Uptake'
+        sname = 'photoNO3_' // trim(autotroph_settings(n)%sname)
         units = 'mmol/m^3/s'
         vgrid = 'layer_avg'
         truncate = .true.
@@ -2564,8 +2564,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' NH4 Uptake'
-        sname = 'photoNH4_' // trim(autotrophs(n)%sname)
+        lname = trim(autotroph_settings(n)%lname) // ' NH4 Uptake'
+        sname = 'photoNH4_' // trim(autotroph_settings(n)%sname)
         units = 'mmol/m^3/s'
         vgrid = 'layer_avg'
         truncate = .true.
@@ -2576,8 +2576,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' DOP Uptake'
-        sname = 'DOP_' // trim(autotrophs(n)%sname) // '_uptake'
+        lname = trim(autotroph_settings(n)%lname) // ' DOP Uptake'
+        sname = 'DOP_' // trim(autotroph_settings(n)%sname) // '_uptake'
         units = 'mmol/m^3/s'
         vgrid = 'layer_avg'
         truncate = .true.
@@ -2588,8 +2588,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' PO4 Uptake'
-        sname = 'PO4_' // trim(autotrophs(n)%sname) // '_uptake'
+        lname = trim(autotroph_settings(n)%lname) // ' PO4 Uptake'
+        sname = 'PO4_' // trim(autotroph_settings(n)%sname) // '_uptake'
         units = 'mmol/m^3/s'
         vgrid = 'layer_avg'
         truncate = .true.
@@ -2600,8 +2600,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' Grazing'
-        sname = 'graze_' // trim(autotrophs(n)%sname)
+        lname = trim(autotroph_settings(n)%lname) // ' Grazing'
+        sname = 'graze_' // trim(autotroph_settings(n)%sname)
         units = 'mmol/m^3/s'
         vgrid = 'layer_avg'
         truncate = .true.
@@ -2612,8 +2612,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' Grazing to POC'
-        sname = 'graze_' // trim(autotrophs(n)%sname) // '_poc'
+        lname = trim(autotroph_settings(n)%lname) // ' Grazing to POC'
+        sname = 'graze_' // trim(autotroph_settings(n)%sname) // '_poc'
         units = 'mmol/m^3/s'
         vgrid = 'layer_avg'
         truncate = .true.
@@ -2624,8 +2624,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' Grazing to DOC'
-        sname = 'graze_' // trim(autotrophs(n)%sname) // '_doc'
+        lname = trim(autotroph_settings(n)%lname) // ' Grazing to DOC'
+        sname = 'graze_' // trim(autotroph_settings(n)%sname) // '_doc'
         units = 'mmol/m^3/s'
         vgrid = 'layer_avg'
         truncate = .true.
@@ -2636,8 +2636,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' Grazing to ZOO'
-        sname = 'graze_' // trim(autotrophs(n)%sname) // '_zoo'
+        lname = trim(autotroph_settings(n)%lname) // ' Grazing to ZOO'
+        sname = 'graze_' // trim(autotroph_settings(n)%sname) // '_zoo'
         units = 'mmol/m^3/s'
         vgrid = 'layer_avg'
         truncate = .true.
@@ -2648,8 +2648,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' Loss'
-        sname = trim(autotrophs(n)%sname) // '_loss'
+        lname = trim(autotroph_settings(n)%lname) // ' Loss'
+        sname = trim(autotroph_settings(n)%sname) // '_loss'
         units = 'mmol/m^3/s'
         vgrid = 'layer_avg'
         truncate = .true.
@@ -2660,8 +2660,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' Loss to POC'
-        sname = trim(autotrophs(n)%sname) // '_loss_poc'
+        lname = trim(autotroph_settings(n)%lname) // ' Loss to POC'
+        sname = trim(autotroph_settings(n)%sname) // '_loss_poc'
         units = 'mmol/m^3/s'
         vgrid = 'layer_avg'
         truncate = .true.
@@ -2672,8 +2672,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' Loss to DOC'
-        sname = trim(autotrophs(n)%sname) // '_loss_doc'
+        lname = trim(autotroph_settings(n)%lname) // ' Loss to DOC'
+        sname = trim(autotroph_settings(n)%sname) // '_loss_doc'
         units = 'mmol/m^3/s'
         vgrid = 'layer_avg'
         truncate = .true.
@@ -2684,8 +2684,8 @@ contains
           return
         end if
 
-        lname = trim(autotrophs(n)%lname) // ' Aggregation'
-        sname = trim(autotrophs(n)%sname) // '_agg'
+        lname = trim(autotroph_settings(n)%lname) // ' Aggregation'
+        sname = trim(autotroph_settings(n)%sname) // '_agg'
         units = 'mmol/m^3/s'
         vgrid = 'layer_avg'
         truncate = .true.
@@ -2696,9 +2696,9 @@ contains
           return
         end if
 
-        if (autotrophs(n)%silicifier) then
-          lname = trim(autotrophs(n)%lname) // ' Si Uptake'
-          sname = trim(autotrophs(n)%sname) // '_bSi_form'
+        if (autotroph_settings(n)%silicifier) then
+          lname = trim(autotroph_settings(n)%lname) // ' Si Uptake'
+          sname = trim(autotroph_settings(n)%sname) // '_bSi_form'
           units = 'mmol/m^3/s'
           vgrid = 'layer_avg'
           truncate = .true.
@@ -2712,9 +2712,9 @@ contains
           ind%bSi_form(n) = -1
         end if
 
-        if (autotrophs(n)%imp_calcifier .or. autotrophs(n)%exp_calcifier) then
-          lname = trim(autotrophs(n)%lname) // ' CaCO3 Formation'
-          sname = trim(autotrophs(n)%sname) // '_CaCO3_form'
+        if (autotroph_settings(n)%imp_calcifier .or. autotroph_settings(n)%exp_calcifier) then
+          lname = trim(autotroph_settings(n)%lname) // ' CaCO3 Formation'
+          sname = trim(autotroph_settings(n)%sname) // '_CaCO3_form'
           units = 'mmol/m^3/s'
           vgrid = 'layer_avg'
           truncate = .true.
@@ -2728,9 +2728,9 @@ contains
           ind%CaCO3_form(n) = -1
         end if
 
-        if (autotrophs(n)%Nfixer) then
-          lname = trim(autotrophs(n)%lname) // ' N Fixation'
-          sname = trim(autotrophs(n)%sname) // '_Nfix'
+        if (autotroph_settings(n)%Nfixer) then
+          lname = trim(autotroph_settings(n)%lname) // ' N Fixation'
+          sname = trim(autotroph_settings(n)%sname) // '_Nfix'
           units = 'mmol/m^3/s'
           vgrid = 'layer_avg'
           truncate = .true.
@@ -2952,7 +2952,7 @@ contains
 
   !***********************************************************************
 
-  subroutine marbl_diagnostics_interior_tendency_compute ( &
+  subroutine marbl_diagnostics_interior_tendency_compute( &
        domain,                                        &
        interior_tendency_forcing_ind,                 &
        interior_tendency_forcings,                    &
@@ -2961,8 +2961,8 @@ contains
        marbl_tracer_indices,                          &
        carbonate,                                     &
        autotroph_local,                               &
-       autotroph_secondary_species,                   &
-       zooplankton_secondary_species,                 &
+       autotroph_derived_terms,                       &
+       zooplankton_derived_terms,                     &
        dissolved_organic_matter,                      &
        marbl_particulate_share,                       &
        PAR,                                           &
@@ -2978,41 +2978,39 @@ contains
 
     use marbl_interface_private_types , only : marbl_interior_tendency_forcing_indexing_type
 
-    type (marbl_domain_type)                  , intent(in) :: domain
-    type(marbl_interior_tendency_forcing_indexing_type), intent(in) :: interior_tendency_forcing_ind
-
-    type(marbl_forcing_fields_type)           , intent(in) :: interior_tendency_forcings(:)
-    real (r8)                                 , intent(in) :: temperature(domain%km) ! in situ temperature
-    real(r8), intent(in) :: interior_tendencies(:,:) ! (tracer_cnt, km) computed source/sink terms
-
-    type(marbl_tracer_index_type)             , intent(in) :: marbl_tracer_indices
-    type (carbonate_type)                     , intent(in) :: carbonate(domain%km)
-    type (autotroph_local_type)               , intent(in) :: autotroph_local
-    type (autotroph_secondary_species_type)   , intent(in) :: autotroph_secondary_species
-    type (zooplankton_secondary_species_type) , intent(in) :: zooplankton_secondary_species
-    type (dissolved_organic_matter_type)      , intent(in) :: dissolved_organic_matter(domain%km)
-    type (marbl_particulate_share_type)       , intent(in) :: marbl_particulate_share
-    type (marbl_PAR_type)                     , intent(in) :: PAR
-    real (r8)                                 , intent(in) :: PON_remin(domain%km)        ! remin of PON
-    real (r8)                                 , intent(in) :: PON_sed_loss(domain%km)     ! loss of PON to sediments
-    real (r8)                                 , intent(in) :: sed_denitrif(domain%km)     ! sedimentary denitrification (nmol N/cm^3/sec)
-    real (r8)                                 , intent(in) :: other_remin(domain%km)      ! organic C remin not due oxic or denitrif (nmolC/cm^3/sec)
-    real (r8)                                 , intent(in) :: nitrif(domain%km)           ! nitrification (NH4 -> NO3) (mmol N/m^3/sec)
-    real (r8)                                 , intent(in) :: denitrif(domain%km)         ! WC nitrification (NO3 -> N2) (mmol N/m^3/sec)
-    real (r8)                                 , intent(in) :: column_o2(:)
-    real (r8)                                 , intent(in) :: o2_production(:)
-    real (r8)                                 , intent(in) :: o2_consumption(:)
-    real (r8)                                 , intent(in) :: fe_scavenge_rate(domain%km) ! annual scavenging rate of iron as % of ambient
-    real (r8)                                 , intent(in) :: fe_scavenge(domain%km)      ! loss of dissolved iron, scavenging (mmol Fe/m^3/sec)
-    real (r8)                                 , intent(in) :: Lig_prod(domain%km)
-    real (r8)                                 , intent(in) :: Lig_loss(domain%km)
-    real (r8)                                 , intent(in) :: Lig_scavenge(domain%km)
-    real (r8)                                 , intent(in) :: Fefree(domain%km)
-    real (r8)                                 , intent(in) :: Lig_photochem(domain%km)
-    real (r8)                                 , intent(in) :: Lig_deg(domain%km)
-    real (r8)                                 , intent(in) :: interior_restore(:,:)       ! (tracer_cnt, km) local restoring terms for nutrients (mmol ./m^3/sec)
-    type (marbl_diagnostics_type)             , intent(inout) :: marbl_interior_tendency_diags
-    type (marbl_log_type)                     , intent(inout) :: marbl_status_log
+    type (marbl_domain_type),                            intent(in)    :: domain
+    type(marbl_interior_tendency_forcing_indexing_type), intent(in)    :: interior_tendency_forcing_ind
+    type(marbl_forcing_fields_type),                     intent(in)    :: interior_tendency_forcings(:)
+    real (r8),                                           intent(in)    :: temperature(domain%km) ! in situ temperature
+    real(r8),                                            intent(in)    :: interior_tendencies(:,:) ! (tracer_cnt, km) computed source/sink terms
+    type(marbl_tracer_index_type),                       intent(in)    :: marbl_tracer_indices
+    type (carbonate_type),                               intent(in)    :: carbonate(domain%km)
+    type (autotroph_local_type),                         intent(in)    :: autotroph_local
+    type (autotroph_derived_terms_type),                 intent(in)    :: autotroph_derived_terms
+    type (zooplankton_derived_terms_type),               intent(in)    :: zooplankton_derived_terms
+    type (dissolved_organic_matter_type),                intent(in)    :: dissolved_organic_matter(domain%km)
+    type (marbl_particulate_share_type),                 intent(in)    :: marbl_particulate_share
+    type (marbl_PAR_type),                               intent(in)    :: PAR
+    real (r8),                                           intent(in)    :: PON_remin(domain%km)        ! remin of PON
+    real (r8),                                           intent(in)    :: PON_sed_loss(domain%km)     ! loss of PON to sediments
+    real (r8),                                           intent(in)    :: sed_denitrif(domain%km)     ! sedimentary denitrification (nmol N/cm^3/sec)
+    real (r8),                                           intent(in)    :: other_remin(domain%km)      ! organic C remin not due oxic or denitrif (nmolC/cm^3/sec)
+    real (r8),                                           intent(in)    :: nitrif(domain%km)           ! nitrification (NH4 -> NO3) (mmol N/m^3/sec)
+    real (r8),                                           intent(in)    :: denitrif(domain%km)         ! WC nitrification (NO3 -> N2) (mmol N/m^3/sec)
+    real (r8),                                           intent(in)    :: column_o2(:)
+    real (r8),                                           intent(in)    :: o2_production(:)
+    real (r8),                                           intent(in)    :: o2_consumption(:)
+    real (r8),                                           intent(in)    :: fe_scavenge_rate(domain%km) ! annual scavenging rate of iron as % of ambient
+    real (r8),                                           intent(in)    :: fe_scavenge(domain%km)      ! loss of dissolved iron, scavenging (mmol Fe/m^3/sec)
+    real (r8),                                           intent(in)    :: Lig_prod(domain%km)
+    real (r8),                                           intent(in)    :: Lig_loss(domain%km)
+    real (r8),                                           intent(in)    :: Lig_scavenge(domain%km)
+    real (r8),                                           intent(in)    :: Fefree(domain%km)
+    real (r8),                                           intent(in)    :: Lig_photochem(domain%km)
+    real (r8),                                           intent(in)    :: Lig_deg(domain%km)
+    real (r8),                                           intent(in)    :: interior_restore(:,:)       ! (tracer_cnt, km) local restoring terms for nutrients (mmol ./m^3/sec)
+    type (marbl_diagnostics_type),                       intent(inout) :: marbl_interior_tendency_diags
+    type (marbl_log_type),                               intent(inout) :: marbl_status_log
 
     character(len=*), parameter :: subname = 'marbl_diagnostics_mod:marbl_diagnostics_interior_tendency_compute'
 
@@ -3040,11 +3038,9 @@ contains
       return
     end if
 
-    call store_diagnostics_autotrophs(domain, &
-         autotroph_local, autotroph_secondary_species, marbl_interior_tendency_diags)
+    call store_diagnostics_autotrophs(domain, autotroph_local, autotroph_derived_terms, marbl_interior_tendency_diags)
 
-    call store_diagnostics_zooplankton(domain, &
-         zooplankton_secondary_species, marbl_interior_tendency_diags)
+    call store_diagnostics_zooplankton(domain, zooplankton_derived_terms, marbl_interior_tendency_diags)
 
     call store_diagnostics_particulates(domain, &
          interior_tendency_forcing_ind, interior_tendency_forcings, &
@@ -3082,7 +3078,7 @@ contains
          Fefree, Lig_photochem, Lig_deg, marbl_interior_tendency_diags)
 
     call store_diagnostics_nitrogen_fluxes(domain, &
-         PON_sed_loss, denitrif, sed_denitrif, autotroph_secondary_species, interior_tendencies, &
+         PON_sed_loss, denitrif, sed_denitrif, autotroph_derived_terms, interior_tendencies, &
          marbl_tracer_indices, marbl_interior_tendency_diags, marbl_status_log)
     if (marbl_status_log%labort_marbl) then
       call marbl_status_log%log_error_trace('store_diagnostics_nitrogen_fluxes', subname)
@@ -3091,7 +3087,7 @@ contains
 
     associate( POP => marbl_particulate_share%POP )
     call store_diagnostics_phosphorus_fluxes(domain, POP, &
-         autotroph_secondary_species, interior_tendencies, &
+         autotroph_derived_terms, interior_tendencies, &
          marbl_tracer_indices, marbl_interior_tendency_diags, marbl_status_log)
     if (marbl_status_log%labort_marbl) then
       call marbl_status_log%log_error_trace('store_diagnostics_phosphorus_fluxes', subname)
@@ -3410,12 +3406,12 @@ contains
   !***********************************************************************
 
   subroutine store_diagnostics_autotrophs(marbl_domain, &
-       autotroph_local, autotroph_secondary_species, marbl_interior_diags)
+       autotroph_local, autotroph_derived_terms, marbl_interior_diags)
 
-    type(marbl_domain_type)                , intent(in)    :: marbl_domain
-    type(autotroph_local_type)             , intent(in)    :: autotroph_local
-    type(autotroph_secondary_species_type) , intent(in)    :: autotroph_secondary_species
-    type(marbl_diagnostics_type)           , intent(inout) :: marbl_interior_diags
+    type(marbl_domain_type),            intent(in)    :: marbl_domain
+    type(autotroph_local_type),         intent(in)    :: autotroph_local
+    type(autotroph_derived_terms_type), intent(in)    :: autotroph_derived_terms
+    type(marbl_diagnostics_type),       intent(inout) :: marbl_interior_diags
 
     !-----------------------------------------------------------------------
     !  local variables
@@ -3461,81 +3457,81 @@ contains
        ! normalize weight, so that its integral is 1
        autotrophC_weight(:) = autotrophC_weight(:) / autotrophC_zint_100m
 
-       diags(ind%N_lim_surf(n))%field_2d(1) = autotroph_secondary_species%VNtot(n,1)
-       limterm = autotroph_secondary_species%VNtot(n,:) * autotrophC_weight(:)
+       diags(ind%N_lim_surf(n))%field_2d(1) = autotroph_derived_terms%VNtot(n,1)
+       limterm = autotroph_derived_terms%VNtot(n,:) * autotrophC_weight(:)
        call marbl_diagnostics_share_compute_vertical_integrals(limterm, delta_z, kmt, &
             near_surface_integral=diags(ind%N_lim_Cweight_avg_100m(n))%field_2d(1))
 
-       diags(ind%P_lim_surf(n))%field_2d(1) = autotroph_secondary_species%VPtot(n,1)
-       limterm = autotroph_secondary_species%VPtot(n,:) * autotrophC_weight(:)
+       diags(ind%P_lim_surf(n))%field_2d(1) = autotroph_derived_terms%VPtot(n,1)
+       limterm = autotroph_derived_terms%VPtot(n,:) * autotrophC_weight(:)
        call marbl_diagnostics_share_compute_vertical_integrals(limterm, delta_z, kmt, &
             near_surface_integral=diags(ind%P_lim_Cweight_avg_100m(n))%field_2d(1))
 
-       diags(ind%Fe_lim_surf(n))%field_2d(1) = autotroph_secondary_species%VFe(n,1)
-       limterm = autotroph_secondary_species%VFe(n,:) * autotrophC_weight(:)
+       diags(ind%Fe_lim_surf(n))%field_2d(1) = autotroph_derived_terms%VFe(n,1)
+       limterm = autotroph_derived_terms%VFe(n,:) * autotrophC_weight(:)
        call marbl_diagnostics_share_compute_vertical_integrals(limterm, delta_z, kmt, &
             near_surface_integral=diags(ind%Fe_lim_Cweight_avg_100m(n))%field_2d(1))
 
        if (ind%SiO3_lim_surf(n).ne.-1) then
-          diags(ind%SiO3_lim_surf(n))%field_2d(1) = autotroph_secondary_species%VSiO3(n,1)
+          diags(ind%SiO3_lim_surf(n))%field_2d(1) = autotroph_derived_terms%VSiO3(n,1)
        endif
        if (ind%SiO3_lim_Cweight_avg_100m(n).ne.-1) then
-          limterm = autotroph_secondary_species%VSiO3(n,:) * autotrophC_weight(:)
+          limterm = autotroph_derived_terms%VSiO3(n,:) * autotrophC_weight(:)
           call marbl_diagnostics_share_compute_vertical_integrals(limterm, delta_z, kmt, &
                near_surface_integral=diags(ind%SiO3_lim_Cweight_avg_100m(n))%field_2d(1))
        endif
 
-       diags(ind%light_lim_surf(n))%field_2d(1) = autotroph_secondary_species%light_lim(n,1)
-       limterm = autotroph_secondary_species%light_lim(n,:) * autotrophC_weight(:)
+       diags(ind%light_lim_surf(n))%field_2d(1) = autotroph_derived_terms%light_lim(n,1)
+       limterm = autotroph_derived_terms%light_lim(n,:) * autotrophC_weight(:)
        call marbl_diagnostics_share_compute_vertical_integrals(limterm, delta_z, kmt, &
             near_surface_integral=diags(ind%light_lim_Cweight_avg_100m(n))%field_2d(1))
 
        if (ind%Qp(n).ne.-1) then
-         diags(ind%Qp(n))%field_3d(:, 1)        = autotroph_secondary_species%Qp(n,:)
+         diags(ind%Qp(n))%field_3d(:, 1)        = autotroph_derived_terms%Qp(n,:)
        end if
 
-       diags(ind%photoNO3(n))%field_3d(:, 1)    = autotroph_secondary_species%NO3_V(n,:)
-       diags(ind%photoNH4(n))%field_3d(:, 1)    = autotroph_secondary_species%NH4_V(n,:)
-       diags(ind%PO4_uptake(n))%field_3d(:, 1)  = autotroph_secondary_species%PO4_V(n,:)
-       diags(ind%DOP_uptake(n))%field_3d(:, 1)  = autotroph_secondary_species%DOP_V(n,:)
-       diags(ind%photoFE(n))%field_3d(:, 1)     = autotroph_secondary_species%photoFe(n,:)
+       diags(ind%photoNO3(n))%field_3d(:, 1)    = autotroph_derived_terms%NO3_V(n,:)
+       diags(ind%photoNH4(n))%field_3d(:, 1)    = autotroph_derived_terms%NH4_V(n,:)
+       diags(ind%PO4_uptake(n))%field_3d(:, 1)  = autotroph_derived_terms%PO4_V(n,:)
+       diags(ind%DOP_uptake(n))%field_3d(:, 1)  = autotroph_derived_terms%DOP_V(n,:)
+       diags(ind%photoFE(n))%field_3d(:, 1)     = autotroph_derived_terms%photoFe(n,:)
 
        if (ind%bSi_form(n).ne.-1) then
-          diags(ind%bSi_form(n))%field_3d(:, 1)  = autotroph_secondary_species%photoSi(n,:)
+          diags(ind%bSi_form(n))%field_3d(:, 1)  = autotroph_derived_terms%photoSi(n,:)
           diags(ind%tot_bSi_form)%field_3d(:, 1) = diags(ind%tot_bSi_form)%field_3d(:, 1) + &
                diags(ind%bSi_form(n))%field_3d(:, 1)
        endif
 
        if (ind%CaCO3_form(n).ne.-1) then
-          diags(ind%CaCO3_form(n))%field_3d(:, 1)  = autotroph_secondary_species%CaCO3_form(n,:)
+          diags(ind%CaCO3_form(n))%field_3d(:, 1)  = autotroph_derived_terms%CaCO3_form(n,:)
           diags(ind%tot_CaCO3_form)%field_3d(:, 1) = diags(ind%tot_CaCO3_form)%field_3d(:, 1) + &
                diags(ind%CaCO3_form(n))%field_3d(:, 1)
        end if
 
        if (ind%Nfix(n).ne.-1) then
-          diags(ind%Nfix(n))%field_3d(:, 1)  = autotroph_secondary_species%Nfix(n,:)
+          diags(ind%Nfix(n))%field_3d(:, 1)  = autotroph_derived_terms%Nfix(n,:)
           diags(ind%tot_Nfix)%field_3d(:, 1) = diags(ind%tot_Nfix)%field_3d(:, 1) + &
                diags(ind%Nfix(n))%field_3d(:, 1)
        end if
 
-       diags(ind%auto_graze(n))%field_3d(:, 1)     = autotroph_secondary_species%auto_graze(n,:)
+       diags(ind%auto_graze(n))%field_3d(:, 1)     = autotroph_derived_terms%auto_graze(n,:)
        diags(ind%auto_graze_TOT)%field_3d(:, 1)    = diags(ind%auto_graze_TOT)%field_3d(:, 1) + &
-            autotroph_secondary_species%auto_graze(n,:)
-       diags(ind%auto_graze_poc(n))%field_3d(:, 1) = autotroph_secondary_species%auto_graze_poc(n,:)
-       diags(ind%auto_graze_doc(n))%field_3d(:, 1) = autotroph_secondary_species%auto_graze_doc(n,:)
-       diags(ind%auto_graze_zoo(n))%field_3d(:, 1) = autotroph_secondary_species%auto_graze_zoo(n,:)
-       diags(ind%auto_loss(n))%field_3d(:, 1)      = autotroph_secondary_species%auto_loss(n,:)
-       diags(ind%auto_loss_poc(n))%field_3d(:, 1)  = autotroph_secondary_species%auto_loss_poc(n,:)
-       diags(ind%auto_loss_doc(n))%field_3d(:, 1)  = autotroph_secondary_species%auto_loss_doc(n,:)
-       diags(ind%auto_agg(n))%field_3d(:, 1)       = autotroph_secondary_species%auto_agg(n,:)
-       diags(ind%photoC(n))%field_3d(:, 1)         = autotroph_secondary_species%photoC(n,:)
+            autotroph_derived_terms%auto_graze(n,:)
+       diags(ind%auto_graze_poc(n))%field_3d(:, 1) = autotroph_derived_terms%auto_graze_poc(n,:)
+       diags(ind%auto_graze_doc(n))%field_3d(:, 1) = autotroph_derived_terms%auto_graze_doc(n,:)
+       diags(ind%auto_graze_zoo(n))%field_3d(:, 1) = autotroph_derived_terms%auto_graze_zoo(n,:)
+       diags(ind%auto_loss(n))%field_3d(:, 1)      = autotroph_derived_terms%auto_loss(n,:)
+       diags(ind%auto_loss_poc(n))%field_3d(:, 1)  = autotroph_derived_terms%auto_loss_poc(n,:)
+       diags(ind%auto_loss_doc(n))%field_3d(:, 1)  = autotroph_derived_terms%auto_loss_doc(n,:)
+       diags(ind%auto_agg(n))%field_3d(:, 1)       = autotroph_derived_terms%auto_agg(n,:)
+       diags(ind%photoC(n))%field_3d(:, 1)         = autotroph_derived_terms%photoC(n,:)
        diags(ind%photoC_TOT)%field_3d(:, 1)        = diags(ind%photoC_TOT)%field_3d(:, 1) + &
-            autotroph_secondary_species%photoC(n,:)
+            autotroph_derived_terms%photoC(n,:)
 
        diags(ind%photoC_NO3(n))%field_3d(:, 1) = c0
-       where (autotroph_secondary_species%VNtot(n,:) > c0)
-          diags(ind%photoC_NO3(n))%field_3d(:, 1) = autotroph_secondary_species%photoC(n,:) * &
-               (autotroph_secondary_species%VNO3(n,:) / autotroph_secondary_species%VNtot(n,:))
+       where (autotroph_derived_terms%VNtot(n,:) > c0)
+          diags(ind%photoC_NO3(n))%field_3d(:, 1) = autotroph_derived_terms%photoC(n,:) * &
+               (autotroph_derived_terms%VNO3(n,:) / autotroph_derived_terms%VNtot(n,:))
 
           diags(ind%photoC_NO3_TOT)%field_3d(:, 1) = diags(ind%photoC_NO3_TOT)%field_3d(:, 1) + &
                diags(ind%photoC_NO3(n))%field_3d(:, 1)
@@ -3543,7 +3539,7 @@ contains
 
        ! per-autotroph vertical integrals and their sums
        if (ind%CaCO3_form_zint(n).ne.-1) then
-          call marbl_diagnostics_share_compute_vertical_integrals(autotroph_secondary_species%CaCO3_form(n,:), &
+          call marbl_diagnostics_share_compute_vertical_integrals(autotroph_derived_terms%CaCO3_form(n,:), &
                delta_z, kmt, full_depth_integral=diags(ind%CaCO3_form_zint(n))%field_2d(1), &
                near_surface_integral=diags(ind%CaCO3_form_zint_100m(n))%field_2d(1))
 
@@ -3554,7 +3550,7 @@ contains
                diags(ind%CaCO3_form_zint_100m(n))%field_2d(1)
        end if
 
-       call marbl_diagnostics_share_compute_vertical_integrals(autotroph_secondary_species%photoC(n,:), &
+       call marbl_diagnostics_share_compute_vertical_integrals(autotroph_derived_terms%photoC(n,:), &
             delta_z, kmt, full_depth_integral=diags(ind%photoC_zint(n))%field_2d(1), &
             near_surface_integral=diags(ind%photoC_zint_100m(n))%field_2d(1))
 
@@ -3813,11 +3809,11 @@ contains
   !***********************************************************************
 
   subroutine store_diagnostics_zooplankton(marbl_domain, &
-       zooplankton_secondary_species, marbl_interior_diags)
+       zooplankton_derived_terms, marbl_interior_diags)
 
-    type(marbl_domain_type)                  , intent(in)    :: marbl_domain
-    type(zooplankton_secondary_species_type) , intent(in)    :: zooplankton_secondary_species
-    type(marbl_diagnostics_type)             , intent(inout) :: marbl_interior_diags
+    type(marbl_domain_type),              intent(in)    :: marbl_domain
+    type(zooplankton_derived_terms_type), intent(in)    :: zooplankton_derived_terms
+    type(marbl_diagnostics_type),         intent(inout) :: marbl_interior_diags
 
     !-----------------------------------------------------------------------
     !  local variables
@@ -3833,14 +3829,14 @@ contains
          )
 
     do n = 1, zooplankton_cnt
-       diags(ind%zoo_loss(n))%field_3d(:, 1)      = zooplankton_secondary_species%zoo_loss(n,:)
-       diags(ind%zoo_loss_poc(n))%field_3d(:, 1)  = zooplankton_secondary_species%zoo_loss_poc(n,:)
-       diags(ind%zoo_loss_doc(n))%field_3d(:, 1)  = zooplankton_secondary_species%zoo_loss_doc(n,:)
-       diags(ind%zoo_graze(n))%field_3d(:, 1)     = zooplankton_secondary_species%zoo_graze(n,:)
-       diags(ind%zoo_graze_poc(n))%field_3d(:, 1) = zooplankton_secondary_species%zoo_graze_poc(n,:)
-       diags(ind%zoo_graze_doc(n))%field_3d(:, 1) = zooplankton_secondary_species%zoo_graze_doc(n,:)
-       diags(ind%zoo_graze_zoo(n))%field_3d(:, 1) = zooplankton_secondary_species%zoo_graze_zoo(n,:)
-       diags(ind%x_graze_zoo(n))%field_3d(:, 1)   = zooplankton_secondary_species%x_graze_zoo(n,:)
+       diags(ind%zoo_loss(n))%field_3d(:, 1)      = zooplankton_derived_terms%zoo_loss(n,:)
+       diags(ind%zoo_loss_poc(n))%field_3d(:, 1)  = zooplankton_derived_terms%zoo_loss_poc(n,:)
+       diags(ind%zoo_loss_doc(n))%field_3d(:, 1)  = zooplankton_derived_terms%zoo_loss_doc(n,:)
+       diags(ind%zoo_graze(n))%field_3d(:, 1)     = zooplankton_derived_terms%zoo_graze(n,:)
+       diags(ind%zoo_graze_poc(n))%field_3d(:, 1) = zooplankton_derived_terms%zoo_graze_poc(n,:)
+       diags(ind%zoo_graze_doc(n))%field_3d(:, 1) = zooplankton_derived_terms%zoo_graze_doc(n,:)
+       diags(ind%zoo_graze_zoo(n))%field_3d(:, 1) = zooplankton_derived_terms%zoo_graze_zoo(n,:)
+       diags(ind%x_graze_zoo(n))%field_3d(:, 1)   = zooplankton_derived_terms%x_graze_zoo(n,:)
 
        ! vertical integrals
 
@@ -4045,21 +4041,21 @@ contains
   !***********************************************************************
 
   subroutine store_diagnostics_nitrogen_fluxes(marbl_domain, &
-       PON_sed_loss, denitrif, sed_denitrif, autotroph_secondary_species, interior_tendencies, &
+       PON_sed_loss, denitrif, sed_denitrif, autotroph_derived_terms, interior_tendencies, &
        marbl_tracer_indices, marbl_diags, marbl_status_log)
 
     use marbl_settings_mod, only : Q
     use marbl_settings_mod, only : Jint_Ntot_thres
 
-    type(marbl_domain_type)         , intent(in)    :: marbl_domain
-    real(r8)                               , intent(in)    :: PON_sed_loss(:) ! km
-    real(r8)                               , intent(in)    :: denitrif(:)     ! km
-    real(r8)                               , intent(in)    :: sed_denitrif(:) ! km
-    type(autotroph_secondary_species_type) , intent(in)    :: autotroph_secondary_species
-    real(r8)                               , intent(in)    :: interior_tendencies(:,:)         ! tracer_cnt, km
-    type(marbl_tracer_index_type)          , intent(in)    :: marbl_tracer_indices
-    type(marbl_diagnostics_type)           , intent(inout) :: marbl_diags
-    type(marbl_log_type)                   , intent(inout) :: marbl_status_log
+    type(marbl_domain_type),            intent(in)    :: marbl_domain
+    real(r8),                           intent(in)    :: PON_sed_loss(:) ! km
+    real(r8),                           intent(in)    :: denitrif(:)     ! km
+    real(r8),                           intent(in)    :: sed_denitrif(:) ! km
+    type(autotroph_derived_terms_type), intent(in)    :: autotroph_derived_terms
+    real(r8),                           intent(in)    :: interior_tendencies(:,:)         ! tracer_cnt, km
+    type(marbl_tracer_index_type),      intent(in)    :: marbl_tracer_indices
+    type(marbl_diagnostics_type),       intent(inout) :: marbl_diags
+    type(marbl_log_type),               intent(inout) :: marbl_status_log
 
     !-----------------------------------------------------------------------
     !  local variables
@@ -4092,8 +4088,8 @@ contains
 
     ! subtract out N fixation
     do n = 1, autotroph_cnt
-       if (autotrophs(n)%Nfixer) then
-          work = work - autotroph_secondary_species%Nfix(n,:)
+       if (autotroph_settings(n)%Nfixer) then
+          work = work - autotroph_derived_terms%Nfix(n,:)
        end if
     end do
 
@@ -4116,20 +4112,20 @@ contains
   !***********************************************************************
 
   subroutine store_diagnostics_phosphorus_fluxes(marbl_domain, POP, &
-       autotroph_secondary_species, interior_tendencies, &
+       autotroph_derived_terms, interior_tendencies, &
        marbl_tracer_indices, marbl_diags, marbl_status_log)
 
     use marbl_pft_mod, only : Qp_zoo
     use marbl_settings_mod, only : lvariable_PtoC
     use marbl_settings_mod, only : Jint_Ptot_thres
 
-    type(marbl_domain_type)                , intent(in)    :: marbl_domain
-    type(column_sinking_particle_type)     , intent(in)    :: POP
-    type(autotroph_secondary_species_type) , intent(in)    :: autotroph_secondary_species
-    real(r8)                               , intent(in)    :: interior_tendencies(:,:)         ! tracer_cnt, km
-    type(marbl_tracer_index_type)          , intent(in)    :: marbl_tracer_indices
-    type(marbl_diagnostics_type)           , intent(inout) :: marbl_diags
-    type(marbl_log_type)                   , intent(inout) :: marbl_status_log
+    type(marbl_domain_type),            intent(in)    :: marbl_domain
+    type(column_sinking_particle_type), intent(in)    :: POP
+    type(autotroph_derived_terms_type), intent(in)    :: autotroph_derived_terms
+    real(r8),                           intent(in)    :: interior_tendencies(:,:)         ! tracer_cnt, km
+    type(marbl_tracer_index_type),      intent(in)    :: marbl_tracer_indices
+    type(marbl_diagnostics_type),       intent(inout) :: marbl_diags
+    type(marbl_log_type),               intent(inout) :: marbl_status_log
 
     !-----------------------------------------------------------------------
     !  local variables
@@ -4158,7 +4154,7 @@ contains
        work = work + sum(interior_tendencies(marbl_tracer_indices%auto_inds(:)%P_ind,:),dim=1)
     else
        do n = 1, autotroph_cnt
-          work = work + autotroph_secondary_species%Qp(n,:) * interior_tendencies(marbl_tracer_indices%auto_inds(n)%C_ind,:)
+          work = work + autotroph_derived_terms%Qp(n,:) * interior_tendencies(marbl_tracer_indices%auto_inds(n)%C_ind,:)
        end do
     endif
 

--- a/src/marbl_diagnostics_mod.F90
+++ b/src/marbl_diagnostics_mod.F90
@@ -20,6 +20,7 @@ module marbl_diagnostics_mod
   use marbl_interface_private_types, only : column_sinking_particle_type
   use marbl_interface_private_types, only : marbl_PAR_type
   use marbl_interface_private_types, only : autotroph_secondary_species_type
+  use marbl_interface_private_types, only : zooplankton_secondary_species_type
   use marbl_interface_private_types, only : marbl_particulate_share_type
   use marbl_interface_private_types, only : marbl_surface_flux_internal_type
   use marbl_interface_private_types, only : marbl_tracer_index_type
@@ -31,7 +32,6 @@ module marbl_diagnostics_mod
   use marbl_interface_public_types, only : marbl_diagnostics_type
 
   use marbl_pft_mod, only : autotroph_local_type
-  use marbl_pft_mod, only : zooplankton_secondary_species_type
 
   use marbl_logging, only : marbl_log_type
   use marbl_logging, only : marbl_logging_add_diagnostics_error
@@ -2990,7 +2990,7 @@ contains
     type (carbonate_type)                     , intent(in) :: carbonate(domain%km)
     type (autotroph_local_type)               , intent(in) :: autotroph_local(autotroph_cnt, domain%km)
     type (autotroph_secondary_species_type)   , intent(in) :: autotroph_secondary_species
-    type (zooplankton_secondary_species_type) , intent(in) :: zooplankton_secondary_species(zooplankton_cnt, domain%km)
+    type (zooplankton_secondary_species_type) , intent(in) :: zooplankton_secondary_species
     type (dissolved_organic_matter_type)      , intent(in) :: dissolved_organic_matter(domain%km)
     type (marbl_particulate_share_type)       , intent(in) :: marbl_particulate_share
     type (marbl_PAR_type)                     , intent(in) :: PAR
@@ -3817,7 +3817,7 @@ contains
        zooplankton_secondary_species, marbl_interior_diags)
 
     type(marbl_domain_type)                  , intent(in)    :: marbl_domain
-    type(zooplankton_secondary_species_type) , intent(in)    :: zooplankton_secondary_species(:,:)
+    type(zooplankton_secondary_species_type) , intent(in)    :: zooplankton_secondary_species
     type(marbl_diagnostics_type)             , intent(inout) :: marbl_interior_diags
 
     !-----------------------------------------------------------------------
@@ -3834,14 +3834,14 @@ contains
          )
 
     do n = 1, zooplankton_cnt
-       diags(ind%zoo_loss(n))%field_3d(:, 1)      = zooplankton_secondary_species(n,:)%zoo_loss
-       diags(ind%zoo_loss_poc(n))%field_3d(:, 1)  = zooplankton_secondary_species(n,:)%zoo_loss_poc
-       diags(ind%zoo_loss_doc(n))%field_3d(:, 1)  = zooplankton_secondary_species(n,:)%zoo_loss_doc
-       diags(ind%zoo_graze(n))%field_3d(:, 1)     = zooplankton_secondary_species(n,:)%zoo_graze
-       diags(ind%zoo_graze_poc(n))%field_3d(:, 1) = zooplankton_secondary_species(n,:)%zoo_graze_poc
-       diags(ind%zoo_graze_doc(n))%field_3d(:, 1) = zooplankton_secondary_species(n,:)%zoo_graze_doc
-       diags(ind%zoo_graze_zoo(n))%field_3d(:, 1) = zooplankton_secondary_species(n,:)%zoo_graze_zoo
-       diags(ind%x_graze_zoo(n))%field_3d(:, 1)   = zooplankton_secondary_species(n,:)%x_graze_zoo
+       diags(ind%zoo_loss(n))%field_3d(:, 1)      = zooplankton_secondary_species%zoo_loss(n,:)
+       diags(ind%zoo_loss_poc(n))%field_3d(:, 1)  = zooplankton_secondary_species%zoo_loss_poc(n,:)
+       diags(ind%zoo_loss_doc(n))%field_3d(:, 1)  = zooplankton_secondary_species%zoo_loss_doc(n,:)
+       diags(ind%zoo_graze(n))%field_3d(:, 1)     = zooplankton_secondary_species%zoo_graze(n,:)
+       diags(ind%zoo_graze_poc(n))%field_3d(:, 1) = zooplankton_secondary_species%zoo_graze_poc(n,:)
+       diags(ind%zoo_graze_doc(n))%field_3d(:, 1) = zooplankton_secondary_species%zoo_graze_doc(n,:)
+       diags(ind%zoo_graze_zoo(n))%field_3d(:, 1) = zooplankton_secondary_species%zoo_graze_zoo(n,:)
+       diags(ind%x_graze_zoo(n))%field_3d(:, 1)   = zooplankton_secondary_species%x_graze_zoo(n,:)
 
        ! vertical integrals
 

--- a/src/marbl_diagnostics_mod.F90
+++ b/src/marbl_diagnostics_mod.F90
@@ -2984,7 +2984,7 @@ contains
     real (r8),                                           intent(in)    :: temperature(domain%km) ! in situ temperature
     real(r8),                                            intent(in)    :: interior_tendencies(:,:) ! (tracer_cnt, km) computed source/sink terms
     type(marbl_tracer_index_type),                       intent(in)    :: marbl_tracer_indices
-    type (carbonate_type),                               intent(in)    :: carbonate(domain%km)
+    type (carbonate_type),                               intent(in)    :: carbonate
     type (autotroph_local_type),                         intent(in)    :: autotroph_local
     type (autotroph_derived_terms_type),                 intent(in)    :: autotroph_derived_terms
     type (zooplankton_derived_terms_type),               intent(in)    :: zooplankton_derived_terms
@@ -3276,7 +3276,7 @@ contains
              marbl_interior_diags, marbl_status_log)
 
     type(marbl_domain_type)      , intent(in)    :: marbl_domain
-    type(carbonate_type)         , intent(in)    :: carbonate(:)
+    type(carbonate_type)         , intent(in)    :: carbonate
     type(marbl_diagnostics_type) , intent(inout) :: marbl_interior_diags
     type(marbl_log_type)         , intent(inout) :: marbl_status_log
 
@@ -3284,17 +3284,15 @@ contains
     !  local variables
     !-----------------------------------------------------------------------
     character(len=*), parameter :: subname = 'marbl_diagnostics_mod:store_diagnostics_carbonate'
-
-    integer(int_kind) :: k
     !-----------------------------------------------------------------------
 
     associate(                                                  &
          km                => marbl_domain%km,                  &
          diags             => marbl_interior_diags%diags,       &
          ind               => marbl_interior_tendency_diag_ind, &
-         CO3               => carbonate(:)%CO3,                 &
-         CO3_sat_calcite   => carbonate(:)%CO3_sat_calcite,     &
-         CO3_sat_aragonite => carbonate(:)%CO3_sat_aragonite    &
+         CO3               => carbonate%CO3(:),                 &
+         CO3_sat_calcite   => carbonate%CO3_sat_calcite(:),     &
+         CO3_sat_aragonite => carbonate%CO3_sat_aragonite(:)    &
          )
 
     ! Find depth where CO3 = CO3_sat_calcite or CO3_sat_argonite
@@ -3315,18 +3313,16 @@ contains
       return
     end if
 
-    do k = 1, km
-       diags(ind%CO3)%field_3d(k, 1)           = carbonate(k)%CO3
-       diags(ind%HCO3)%field_3d(k, 1)          = carbonate(k)%HCO3
-       diags(ind%H2CO3)%field_3d(k, 1)         = carbonate(k)%H2CO3
-       diags(ind%pH_3D)%field_3d(k, 1)         = carbonate(k)%pH
-       diags(ind%CO3_ALT_CO2)%field_3d(k, 1)   = carbonate(k)%CO3_ALT_CO2
-       diags(ind%HCO3_ALT_CO2)%field_3d(k, 1)  = carbonate(k)%HCO3_ALT_CO2
-       diags(ind%H2CO3_ALT_CO2)%field_3d(k, 1) = carbonate(k)%H2CO3_ALT_CO2
-       diags(ind%pH_3D_ALT_CO2)%field_3d(k, 1) = carbonate(k)%pH_ALT_CO2
-       diags(ind%co3_sat_calc)%field_3d(k, 1)  = carbonate(k)%CO3_sat_calcite
-       diags(ind%co3_sat_arag)%field_3d(k, 1)  = carbonate(k)%CO3_sat_aragonite
-    end do
+    diags(ind%CO3)%field_3d(:, 1)           = carbonate%CO3(:)
+    diags(ind%HCO3)%field_3d(:, 1)          = carbonate%HCO3(:)
+    diags(ind%H2CO3)%field_3d(:, 1)         = carbonate%H2CO3(:)
+    diags(ind%pH_3D)%field_3d(:, 1)         = carbonate%pH(:)
+    diags(ind%CO3_ALT_CO2)%field_3d(:, 1)   = carbonate%CO3_ALT_CO2(:)
+    diags(ind%HCO3_ALT_CO2)%field_3d(:, 1)  = carbonate%HCO3_ALT_CO2(:)
+    diags(ind%H2CO3_ALT_CO2)%field_3d(:, 1) = carbonate%H2CO3_ALT_CO2(:)
+    diags(ind%pH_3D_ALT_CO2)%field_3d(:, 1) = carbonate%pH_ALT_CO2(:)
+    diags(ind%co3_sat_calc)%field_3d(:, 1)  = carbonate%CO3_sat_calcite(:)
+    diags(ind%co3_sat_arag)%field_3d(:, 1)  = carbonate%CO3_sat_aragonite(:)
 
     end associate
 

--- a/src/marbl_diagnostics_mod.F90
+++ b/src/marbl_diagnostics_mod.F90
@@ -19,6 +19,7 @@ module marbl_diagnostics_mod
   use marbl_interface_private_types, only : dissolved_organic_matter_type
   use marbl_interface_private_types, only : column_sinking_particle_type
   use marbl_interface_private_types, only : marbl_PAR_type
+  use marbl_interface_private_types, only : autotroph_local_type
   use marbl_interface_private_types, only : autotroph_secondary_species_type
   use marbl_interface_private_types, only : zooplankton_secondary_species_type
   use marbl_interface_private_types, only : marbl_particulate_share_type
@@ -30,8 +31,6 @@ module marbl_diagnostics_mod
   use marbl_interface_public_types, only : marbl_forcing_fields_type
   use marbl_interface_public_types, only : marbl_saved_state_type
   use marbl_interface_public_types, only : marbl_diagnostics_type
-
-  use marbl_pft_mod, only : autotroph_local_type
 
   use marbl_logging, only : marbl_log_type
   use marbl_logging, only : marbl_logging_add_diagnostics_error
@@ -2988,7 +2987,7 @@ contains
 
     type(marbl_tracer_index_type)             , intent(in) :: marbl_tracer_indices
     type (carbonate_type)                     , intent(in) :: carbonate(domain%km)
-    type (autotroph_local_type)               , intent(in) :: autotroph_local(autotroph_cnt, domain%km)
+    type (autotroph_local_type)               , intent(in) :: autotroph_local
     type (autotroph_secondary_species_type)   , intent(in) :: autotroph_secondary_species
     type (zooplankton_secondary_species_type) , intent(in) :: zooplankton_secondary_species
     type (dissolved_organic_matter_type)      , intent(in) :: dissolved_organic_matter(domain%km)
@@ -3414,7 +3413,7 @@ contains
        autotroph_local, autotroph_secondary_species, marbl_interior_diags)
 
     type(marbl_domain_type)                , intent(in)    :: marbl_domain
-    type(autotroph_local_type)             , intent(in)    :: autotroph_local(:,:) ! autotroph_cnt, km
+    type(autotroph_local_type)             , intent(in)    :: autotroph_local
     type(autotroph_secondary_species_type) , intent(in)    :: autotroph_secondary_species
     type(marbl_diagnostics_type)           , intent(inout) :: marbl_interior_diags
 
@@ -3448,7 +3447,7 @@ contains
 
     do n = 1, autotroph_cnt
        ! compute biomass weighted average of limitation terms over 0..100m
-       autotrophC_weight(:) = autotroph_local(n,:)%C
+       autotrophC_weight(:) = autotroph_local%C(n,:)
        call marbl_diagnostics_share_compute_vertical_integrals(autotrophC_weight, delta_z, kmt, &
             near_surface_integral=autotrophC_zint_100m)
 

--- a/src/marbl_diagnostics_mod.F90
+++ b/src/marbl_diagnostics_mod.F90
@@ -10,7 +10,7 @@ module marbl_diagnostics_mod
   use marbl_settings_mod, only : autotroph_cnt
   use marbl_settings_mod, only : zooplankton_cnt
   use marbl_settings_mod, only : autotroph_settings
-  use marbl_settings_mod, only : zooplankton
+  use marbl_settings_mod, only : zooplankton_settings
 
   use marbl_constants_mod, only : c0
   use marbl_constants_mod, only : c1
@@ -1290,8 +1290,8 @@ contains
         allocate(ind%x_graze_zoo_zint_100m(zooplankton_cnt))
       end if
       do n = 1,zooplankton_cnt
-        lname = trim(zooplankton(n)%lname) // ' Loss Vertical Integral'
-        sname = trim(zooplankton(n)%sname) // '_loss_zint'
+        lname = trim(zooplankton_settings(n)%lname) // ' Loss Vertical Integral'
+        sname = trim(zooplankton_settings(n)%sname) // '_loss_zint'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -1302,8 +1302,8 @@ contains
           return
         end if
 
-        lname = trim(zooplankton(n)%lname) // ' Loss Vertical Integral, 0-100m'
-        sname = trim(zooplankton(n)%sname) // '_loss_zint_100m'
+        lname = trim(zooplankton_settings(n)%lname) // ' Loss Vertical Integral, 0-100m'
+        sname = trim(zooplankton_settings(n)%sname) // '_loss_zint_100m'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -1314,8 +1314,8 @@ contains
           return
         end if
 
-        lname = trim(zooplankton(n)%lname) // ' Loss to POC Vertical Integral'
-        sname = trim(zooplankton(n)%sname) // '_loss_poc_zint'
+        lname = trim(zooplankton_settings(n)%lname) // ' Loss to POC Vertical Integral'
+        sname = trim(zooplankton_settings(n)%sname) // '_loss_poc_zint'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -1326,8 +1326,8 @@ contains
           return
         end if
 
-        lname = trim(zooplankton(n)%lname) // ' Loss to POC Vertical Integral, 0-100m'
-        sname = trim(zooplankton(n)%sname) // '_loss_poc_zint_100m'
+        lname = trim(zooplankton_settings(n)%lname) // ' Loss to POC Vertical Integral, 0-100m'
+        sname = trim(zooplankton_settings(n)%sname) // '_loss_poc_zint_100m'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -1338,8 +1338,8 @@ contains
           return
         end if
 
-        lname = trim(zooplankton(n)%lname) // ' Loss to DOC Vertical Integral'
-        sname = trim(zooplankton(n)%sname) // '_loss_doc_zint'
+        lname = trim(zooplankton_settings(n)%lname) // ' Loss to DOC Vertical Integral'
+        sname = trim(zooplankton_settings(n)%sname) // '_loss_doc_zint'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -1350,8 +1350,8 @@ contains
           return
         end if
 
-        lname = trim(zooplankton(n)%lname) // ' Loss to DOC Vertical Integral, 0-100m'
-        sname = trim(zooplankton(n)%sname) // '_loss_doc_zint_100m'
+        lname = trim(zooplankton_settings(n)%lname) // ' Loss to DOC Vertical Integral, 0-100m'
+        sname = trim(zooplankton_settings(n)%sname) // '_loss_doc_zint_100m'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -1362,8 +1362,8 @@ contains
           return
         end if
 
-        lname = trim(zooplankton(n)%lname) // ' Grazing Vertical Integral'
-        sname = 'graze_' // trim(zooplankton(n)%sname) // '_zint'
+        lname = trim(zooplankton_settings(n)%lname) // ' Grazing Vertical Integral'
+        sname = 'graze_' // trim(zooplankton_settings(n)%sname) // '_zint'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -1374,8 +1374,8 @@ contains
           return
         end if
 
-        lname = trim(zooplankton(n)%lname) // ' Grazing Vertical Integral, 0-100m'
-        sname = 'graze_' // trim(zooplankton(n)%sname) // '_zint_100m'
+        lname = trim(zooplankton_settings(n)%lname) // ' Grazing Vertical Integral, 0-100m'
+        sname = 'graze_' // trim(zooplankton_settings(n)%sname) // '_zint_100m'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -1386,8 +1386,8 @@ contains
           return
         end if
 
-        lname = trim(zooplankton(n)%lname) // ' Grazing to POC Vertical Integral'
-        sname = 'graze_' // trim(zooplankton(n)%sname) // '_poc_zint'
+        lname = trim(zooplankton_settings(n)%lname) // ' Grazing to POC Vertical Integral'
+        sname = 'graze_' // trim(zooplankton_settings(n)%sname) // '_poc_zint'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -1398,8 +1398,8 @@ contains
           return
         end if
 
-        lname = trim(zooplankton(n)%lname) // ' Grazing to POC Vertical Integral, 0-100m'
-        sname = 'graze_' // trim(zooplankton(n)%sname) // '_poc_zint_100m'
+        lname = trim(zooplankton_settings(n)%lname) // ' Grazing to POC Vertical Integral, 0-100m'
+        sname = 'graze_' // trim(zooplankton_settings(n)%sname) // '_poc_zint_100m'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -1410,8 +1410,8 @@ contains
           return
         end if
 
-        lname = trim(zooplankton(n)%lname) // ' Grazing to DOC Vertical Integral'
-        sname = 'graze_' // trim(zooplankton(n)%sname) // '_doc_zint'
+        lname = trim(zooplankton_settings(n)%lname) // ' Grazing to DOC Vertical Integral'
+        sname = 'graze_' // trim(zooplankton_settings(n)%sname) // '_doc_zint'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -1422,8 +1422,8 @@ contains
           return
         end if
 
-        lname = trim(zooplankton(n)%lname) // ' Grazing to DOC Vertical Integral, 0-100m'
-        sname = 'graze_' // trim(zooplankton(n)%sname) // '_doc_zint_100m'
+        lname = trim(zooplankton_settings(n)%lname) // ' Grazing to DOC Vertical Integral, 0-100m'
+        sname = 'graze_' // trim(zooplankton_settings(n)%sname) // '_doc_zint_100m'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -1434,8 +1434,8 @@ contains
           return
         end if
 
-        lname = trim(zooplankton(n)%lname) // ' Grazing to ZOO Vertical Integral'
-        sname = 'graze_' // trim(zooplankton(n)%sname) // '_zoo_zint'
+        lname = trim(zooplankton_settings(n)%lname) // ' Grazing to ZOO Vertical Integral'
+        sname = 'graze_' // trim(zooplankton_settings(n)%sname) // '_zoo_zint'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -1446,8 +1446,8 @@ contains
           return
         end if
 
-        lname = trim(zooplankton(n)%lname) // ' Grazing to ZOO Vertical Integral, 0-100m'
-        sname = 'graze_' // trim(zooplankton(n)%sname) // '_zoo_zint_100m'
+        lname = trim(zooplankton_settings(n)%lname) // ' Grazing to ZOO Vertical Integral, 0-100m'
+        sname = 'graze_' // trim(zooplankton_settings(n)%sname) // '_zoo_zint_100m'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -1458,8 +1458,8 @@ contains
           return
         end if
 
-        lname = trim(zooplankton(n)%lname) // ' Grazing Gain Vertical Integral'
-        sname = 'x_graze_' // trim(zooplankton(n)%sname) // '_zint'
+        lname = trim(zooplankton_settings(n)%lname) // ' Grazing Gain Vertical Integral'
+        sname = 'x_graze_' // trim(zooplankton_settings(n)%sname) // '_zint'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -1470,8 +1470,8 @@ contains
           return
         end if
 
-        lname = trim(zooplankton(n)%lname) // ' Grazing Gain Vertical Integral, 0-100m'
-        sname = 'x_graze_' // trim(zooplankton(n)%sname) // '_zint_100m'
+        lname = trim(zooplankton_settings(n)%lname) // ' Grazing Gain Vertical Integral, 0-100m'
+        sname = 'x_graze_' // trim(zooplankton_settings(n)%sname) // '_zint_100m'
         units = 'mmol/m^3 cm/s'
         vgrid = 'none'
         truncate = .false.
@@ -2794,8 +2794,8 @@ contains
         allocate(ind%x_graze_zoo(zooplankton_cnt))
       end if
       do n = 1,zooplankton_cnt
-        lname    = trim(zooplankton(n)%lname) // ' Loss'
-        sname    = trim(zooplankton(n)%sname) // '_loss'
+        lname    = trim(zooplankton_settings(n)%lname) // ' Loss'
+        sname    = trim(zooplankton_settings(n)%sname) // '_loss'
         units    = 'mmol/m^3/s'
         vgrid    = 'layer_avg'
         truncate = .true.
@@ -2806,8 +2806,8 @@ contains
           return
         end if
 
-        lname    = trim(zooplankton(n)%lname) // ' Loss to POC'
-        sname    = trim(zooplankton(n)%sname) // '_loss_poc'
+        lname    = trim(zooplankton_settings(n)%lname) // ' Loss to POC'
+        sname    = trim(zooplankton_settings(n)%sname) // '_loss_poc'
         units    = 'mmol/m^3/s'
         vgrid    = 'layer_avg'
         truncate = .true.
@@ -2818,8 +2818,8 @@ contains
           return
         end if
 
-        lname    = trim(zooplankton(n)%lname) // ' Loss to DOC'
-        sname    = trim(zooplankton(n)%sname) // '_loss_doc'
+        lname    = trim(zooplankton_settings(n)%lname) // ' Loss to DOC'
+        sname    = trim(zooplankton_settings(n)%sname) // '_loss_doc'
         units    = 'mmol/m^3/s'
         vgrid    = 'layer_avg'
         truncate = .true.
@@ -2830,8 +2830,8 @@ contains
           return
         end if
 
-        lname    = trim(zooplankton(n)%lname) // ' grazing loss'
-        sname    = 'graze_' // trim(zooplankton(n)%sname)
+        lname    = trim(zooplankton_settings(n)%lname) // ' grazing loss'
+        sname    = 'graze_' // trim(zooplankton_settings(n)%sname)
         units    = 'mmol/m^3/s'
         vgrid    = 'layer_avg'
         truncate = .true.
@@ -2842,8 +2842,8 @@ contains
           return
         end if
 
-        lname    = trim(zooplankton(n)%lname) // ' grazing loss to POC'
-        sname    = 'graze_' // trim(zooplankton(n)%sname) // '_poc'
+        lname    = trim(zooplankton_settings(n)%lname) // ' grazing loss to POC'
+        sname    = 'graze_' // trim(zooplankton_settings(n)%sname) // '_poc'
         units    = 'mmol/m^3/s'
         vgrid    = 'layer_avg'
         truncate = .true.
@@ -2854,8 +2854,8 @@ contains
           return
         end if
 
-        lname    = trim(zooplankton(n)%lname) // ' grazing loss to DOC'
-        sname    = 'graze_' // trim(zooplankton(n)%sname) // '_doc'
+        lname    = trim(zooplankton_settings(n)%lname) // ' grazing loss to DOC'
+        sname    = 'graze_' // trim(zooplankton_settings(n)%sname) // '_doc'
         units    = 'mmol/m^3/s'
         vgrid    = 'layer_avg'
         truncate = .true.
@@ -2866,8 +2866,8 @@ contains
           return
         end if
 
-        lname    = trim(zooplankton(n)%lname) // ' grazing loss to ZOO'
-        sname    = 'graze_' // trim(zooplankton(n)%sname) // '_zoo'
+        lname    = trim(zooplankton_settings(n)%lname) // ' grazing loss to ZOO'
+        sname    = 'graze_' // trim(zooplankton_settings(n)%sname) // '_zoo'
         units    = 'mmol/m^3/s'
         vgrid    = 'layer_avg'
         truncate = .true.
@@ -2878,8 +2878,8 @@ contains
           return
         end if
 
-        lname    = trim(zooplankton(n)%lname) // ' grazing gain'
-        sname    = 'x_graze_' // trim(zooplankton(n)%sname)
+        lname    = trim(zooplankton_settings(n)%lname) // ' grazing gain'
+        sname    = 'x_graze_' // trim(zooplankton_settings(n)%sname)
         units    = 'mmol/m^3/s'
         vgrid    = 'layer_avg'
         truncate = .true.

--- a/src/marbl_init_mod.F90
+++ b/src/marbl_init_mod.F90
@@ -135,7 +135,7 @@ contains
 
     use marbl_settings_mod, only : ciso_on
     use marbl_settings_mod, only : lvariable_PtoC
-    use marbl_settings_mod, only : autotrophs
+    use marbl_settings_mod, only : autotroph_settings
     use marbl_settings_mod, only : zooplankton
     use marbl_settings_mod, only : tracer_restore_vars
     use marbl_ciso_init_mod, only : marbl_ciso_init_tracer_metadata
@@ -157,7 +157,7 @@ contains
 
     ! Construct tracer indices
     allocate(tracer_indices)
-    call tracer_indices%construct(ciso_on, lvariable_PtoC, autotrophs, zooplankton, &
+    call tracer_indices%construct(ciso_on, lvariable_PtoC, autotroph_settings, zooplankton, &
                                   marbl_status_log)
     if (marbl_status_log%labort_marbl) then
       call marbl_status_log%log_error_trace("tracer_indices%construct", subname)
@@ -581,7 +581,7 @@ contains
     !  initialize autotroph tracer_d values and tracer indices
     !-----------------------------------------------------------------------
 
-    use marbl_settings_mod, only : autotrophs
+    use marbl_settings_mod, only : autotroph_settings
 
     type (marbl_tracer_metadata_type) , intent(inout) :: marbl_tracer_metadata(:)   ! descriptors for each tracer
     type    (marbl_tracer_index_type) , intent(in)    :: marbl_tracer_indices
@@ -594,39 +594,39 @@ contains
 
     do auto_ind = 1, autotroph_cnt
        n = marbl_tracer_indices%auto_inds(auto_ind)%Chl_ind
-       marbl_tracer_metadata(n)%short_name = trim(autotrophs(auto_ind)%sname) // 'Chl'
-       marbl_tracer_metadata(n)%long_name  = trim(autotrophs(auto_ind)%lname) // ' Chlorophyll'
+       marbl_tracer_metadata(n)%short_name = trim(autotroph_settings(auto_ind)%sname) // 'Chl'
+       marbl_tracer_metadata(n)%long_name  = trim(autotroph_settings(auto_ind)%lname) // ' Chlorophyll'
        marbl_tracer_metadata(n)%units      = 'mg/m^3'
        marbl_tracer_metadata(n)%tend_units = 'mg/m^3/s'
        marbl_tracer_metadata(n)%flux_units = 'mg/m^3 cm/s'
 
        n = marbl_tracer_indices%auto_inds(auto_ind)%C_ind
-       marbl_tracer_metadata(n)%short_name = trim(autotrophs(auto_ind)%sname) // 'C'
-       marbl_tracer_metadata(n)%long_name  = trim(autotrophs(auto_ind)%lname) // ' Carbon'
+       marbl_tracer_metadata(n)%short_name = trim(autotroph_settings(auto_ind)%sname) // 'C'
+       marbl_tracer_metadata(n)%long_name  = trim(autotroph_settings(auto_ind)%lname) // ' Carbon'
        marbl_tracer_metadata(n)%units      = 'mmol/m^3'
        marbl_tracer_metadata(n)%tend_units = 'mmol/m^3/s'
        marbl_tracer_metadata(n)%flux_units = 'mmol/m^3 cm/s'
 
        n = marbl_tracer_indices%auto_inds(auto_ind)%P_ind
        if (n.gt.0) then
-          marbl_tracer_metadata(n)%short_name = trim(autotrophs(auto_ind)%sname) // 'P'
-          marbl_tracer_metadata(n)%long_name  = trim(autotrophs(auto_ind)%lname) // ' Phosphorus'
+          marbl_tracer_metadata(n)%short_name = trim(autotroph_settings(auto_ind)%sname) // 'P'
+          marbl_tracer_metadata(n)%long_name  = trim(autotroph_settings(auto_ind)%lname) // ' Phosphorus'
           marbl_tracer_metadata(n)%units      = 'mmol/m^3'
           marbl_tracer_metadata(n)%tend_units = 'mmol/m^3/s'
           marbl_tracer_metadata(n)%flux_units = 'mmol/m^3 cm/s'
        endif
 
        n = marbl_tracer_indices%auto_inds(auto_ind)%Fe_ind
-       marbl_tracer_metadata(n)%short_name = trim(autotrophs(auto_ind)%sname) // 'Fe'
-       marbl_tracer_metadata(n)%long_name  = trim(autotrophs(auto_ind)%lname) // ' Iron'
+       marbl_tracer_metadata(n)%short_name = trim(autotroph_settings(auto_ind)%sname) // 'Fe'
+       marbl_tracer_metadata(n)%long_name  = trim(autotroph_settings(auto_ind)%lname) // ' Iron'
        marbl_tracer_metadata(n)%units      = 'mmol/m^3'
        marbl_tracer_metadata(n)%tend_units = 'mmol/m^3/s'
        marbl_tracer_metadata(n)%flux_units = 'mmol/m^3 cm/s'
 
        n = marbl_tracer_indices%auto_inds(auto_ind)%Si_ind
        if (n .gt. 0) then
-          marbl_tracer_metadata(n)%short_name = trim(autotrophs(auto_ind)%sname) // 'Si'
-          marbl_tracer_metadata(n)%long_name  = trim(autotrophs(auto_ind)%lname) // ' Silicon'
+          marbl_tracer_metadata(n)%short_name = trim(autotroph_settings(auto_ind)%sname) // 'Si'
+          marbl_tracer_metadata(n)%long_name  = trim(autotroph_settings(auto_ind)%lname) // ' Silicon'
           marbl_tracer_metadata(n)%units      = 'mmol/m^3'
           marbl_tracer_metadata(n)%tend_units = 'mmol/m^3/s'
           marbl_tracer_metadata(n)%flux_units = 'mmol/m^3 cm/s'
@@ -634,8 +634,8 @@ contains
 
        n = marbl_tracer_indices%auto_inds(auto_ind)%CaCO3_ind
        if (n .gt. 0) then
-          marbl_tracer_metadata(n)%short_name = trim(autotrophs(auto_ind)%sname) // 'CaCO3'
-          marbl_tracer_metadata(n)%long_name  = trim(autotrophs(auto_ind)%lname) // ' CaCO3'
+          marbl_tracer_metadata(n)%short_name = trim(autotroph_settings(auto_ind)%sname) // 'CaCO3'
+          marbl_tracer_metadata(n)%long_name  = trim(autotroph_settings(auto_ind)%lname) // ' CaCO3'
           marbl_tracer_metadata(n)%units      = 'mmol/m^3'
           marbl_tracer_metadata(n)%tend_units = 'mmol/m^3/s'
           marbl_tracer_metadata(n)%flux_units = 'mmol/m^3 cm/s'

--- a/src/marbl_init_mod.F90
+++ b/src/marbl_init_mod.F90
@@ -307,7 +307,7 @@ contains
 
   !***********************************************************************
 
-  subroutine marbl_init_bury_coeff(marbl_particulate_share, num_levels, marbl_status_log)
+  subroutine marbl_init_bury_coeff(marbl_particulate_share, marbl_status_log)
 
     use marbl_logging, only : marbl_log_type
     use marbl_settings_mod, only : init_bury_coeff_opt
@@ -317,8 +317,7 @@ contains
     use marbl_settings_mod, only : parm_init_bSi_bury_coeff
     use marbl_interface_private_types, only : marbl_particulate_share_type
 
-    type(marbl_particulate_share_type), intent(out)   :: marbl_particulate_share
-    integer(int_kind),                  intent(in)    :: num_levels
+    type(marbl_particulate_share_type), intent(inout) :: marbl_particulate_share
     type(marbl_log_type),               intent(inout) :: marbl_status_log
 
     !---------------------------------------------------------------------------
@@ -327,8 +326,6 @@ contains
     character(len=*), parameter :: subname = 'marbl_init_mod:marbl_init_bury_coeff'
 
     !---------------------------------------------------------------------------
-
-    call marbl_particulate_share%construct(num_levels)
 
     ! if ladjust_bury_coeff is true, then bury coefficients are set at runtime
     ! so they do not need to be initialized here
@@ -351,8 +348,6 @@ contains
   subroutine marbl_init_forcing_fields(domain, &
                                        tracer_metadata, &
                                        surface_flux_forcing_ind, &
-                                       surface_flux_share, &
-                                       surface_flux_internal, &
                                        surface_flux_forcings, &
                                        interior_tendency_forcing_ind, &
                                        interior_tendency_forcings, &
@@ -360,8 +355,6 @@ contains
 
     use marbl_interface_public_types, only : marbl_domain_type
     use marbl_interface_private_types, only : marbl_surface_flux_forcing_indexing_type
-    use marbl_interface_private_types, only : marbl_surface_flux_share_type
-    use marbl_interface_private_types, only : marbl_surface_flux_internal_type
     use marbl_interface_private_types, only : marbl_interior_tendency_forcing_indexing_type
     use marbl_settings_mod, only : ciso_on
     use marbl_settings_mod, only : lflux_gas_o2
@@ -372,8 +365,6 @@ contains
     type(marbl_domain_type),                             intent(in)    :: domain
     type(marbl_tracer_metadata_type),                    intent(in)    :: tracer_metadata(:)
     type(marbl_surface_flux_forcing_indexing_type),      intent(out)   :: surface_flux_forcing_ind
-    type(marbl_surface_flux_share_type),                 intent(out)   :: surface_flux_share
-    type(marbl_surface_flux_internal_type),              intent(out)   :: surface_flux_internal
     type(marbl_forcing_fields_type), allocatable,        intent(out)   :: surface_flux_forcings(:)
     type(marbl_interior_tendency_forcing_indexing_type), intent(out)   :: interior_tendency_forcing_ind
     type(marbl_forcing_fields_type), allocatable,        intent(out)   :: interior_tendency_forcings(:)
@@ -407,10 +398,6 @@ contains
         call marbl_status_log%log_error_trace("interior_tendency_forcing_ind%construct", subname)
         return
       end if
-
-      ! Construct share / internal types for surface flux computation
-      call surface_flux_share%construct(num_elements_surface_flux)
-      call surface_flux_internal%construct(num_elements_surface_flux)
 
       ! Initialize surface forcing fields
       allocate(surface_flux_forcings(num_surface_flux_forcing_fields))

--- a/src/marbl_init_mod.F90
+++ b/src/marbl_init_mod.F90
@@ -136,7 +136,7 @@ contains
     use marbl_settings_mod, only : ciso_on
     use marbl_settings_mod, only : lvariable_PtoC
     use marbl_settings_mod, only : autotroph_settings
-    use marbl_settings_mod, only : zooplankton
+    use marbl_settings_mod, only : zooplankton_settings
     use marbl_settings_mod, only : tracer_restore_vars
     use marbl_ciso_init_mod, only : marbl_ciso_init_tracer_metadata
 
@@ -157,7 +157,7 @@ contains
 
     ! Construct tracer indices
     allocate(tracer_indices)
-    call tracer_indices%construct(ciso_on, lvariable_PtoC, autotroph_settings, zooplankton, &
+    call tracer_indices%construct(ciso_on, lvariable_PtoC, autotroph_settings, zooplankton_settings, &
                                   marbl_status_log)
     if (marbl_status_log%labort_marbl) then
       call marbl_status_log%log_error_trace("tracer_indices%construct", subname)
@@ -550,7 +550,7 @@ contains
     !  initialize zooplankton tracer_d values and tracer indices
     !-----------------------------------------------------------------------
 
-    use marbl_settings_mod, only : zooplankton
+    use marbl_settings_mod, only : zooplankton_settings
 
     type (marbl_tracer_metadata_type) , intent(inout) :: marbl_tracer_metadata(:)             ! descriptors for each tracer
     type (marbl_tracer_index_type)    , intent(in)    :: marbl_tracer_indices
@@ -563,8 +563,8 @@ contains
 
     do zoo_ind = 1, zooplankton_cnt
        n = marbl_tracer_indices%zoo_inds(zoo_ind)%C_ind
-       marbl_tracer_metadata(n)%short_name = trim(zooplankton(zoo_ind)%sname) // 'C'
-       marbl_tracer_metadata(n)%long_name  = trim(zooplankton(zoo_ind)%lname) // ' Carbon'
+       marbl_tracer_metadata(n)%short_name = trim(zooplankton_settings(zoo_ind)%sname) // 'C'
+       marbl_tracer_metadata(n)%long_name  = trim(zooplankton_settings(zoo_ind)%lname) // ' Carbon'
        marbl_tracer_metadata(n)%units      = 'mmol/m^3'
        marbl_tracer_metadata(n)%tend_units = 'mmol/m^3/s'
        marbl_tracer_metadata(n)%flux_units = 'mmol/m^3 cm/s'

--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -39,6 +39,7 @@ module marbl_interface
   use marbl_interface_private_types, only : marbl_interior_tendency_saved_state_indexing_type
   use marbl_interface_private_types, only : marbl_PAR_type
   use marbl_interface_private_types, only : autotroph_secondary_species_type
+  use marbl_interface_private_types, only : autotroph_local_type
   use marbl_interface_private_types, only : zooplankton_secondary_species_type
   use marbl_interface_private_types, only : marbl_particulate_share_type
   use marbl_interface_private_types, only : marbl_surface_flux_share_type
@@ -108,6 +109,7 @@ module marbl_interface
      ! private data
      type(marbl_PAR_type),                     private :: PAR
      type(autotroph_secondary_species_type),   private :: autotroph_secondary_species
+     type(autotroph_local_type),               private :: autotroph_local
      type(zooplankton_secondary_species_type), private :: zooplankton_secondary_species
      type(marbl_particulate_share_type),       private :: particulate_share
      type(marbl_surface_flux_share_type),      private :: surface_flux_share
@@ -188,6 +190,7 @@ contains
     use marbl_settings_mod, only : marbl_settings_set_all_derived
     use marbl_settings_mod, only : marbl_settings_consistency_check
     use marbl_settings_mod, only : autotroph_cnt
+    use marbl_settings_mod, only : ciso_on
     use marbl_diagnostics_mod, only : marbl_diagnostics_init
     use marbl_saved_state_mod, only : marbl_saved_state_init
 
@@ -265,6 +268,7 @@ contains
 
     call this%PAR%construct(num_levels, num_PAR_subcols)
     call this%autotroph_secondary_species%construct(autotroph_cnt, num_levels)
+    call this%autotroph_local%construct(ciso_on, autotroph_cnt, num_levels)
     call this%zooplankton_secondary_species%construct(zooplankton_cnt, num_levels)
 
     !-----------------------------------------------------------------------
@@ -855,6 +859,7 @@ contains
          marbl_timer_indices               = this%timer_ids,                        &
          PAR                               = this%PAR,                              &
          autotroph_secondary_species       = this%autotroph_secondary_species,      &
+         autotroph_local                   = this%autotroph_local,                  &
          zooplankton_secondary_species     = this%zooplankton_secondary_species,    &
          saved_state                       = this%interior_tendency_saved_state,    &
          marbl_timers                      = this%timers,                           &
@@ -1006,6 +1011,7 @@ contains
     call this%particulate_share%destruct()
     call this%PAR%destruct()
     call this%autotroph_secondary_species%destruct()
+    call this%autotroph_local%destruct()
     call this%zooplankton_secondary_species%destruct()
     call this%domain%destruct()
 

--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -43,6 +43,7 @@ module marbl_interface
   use marbl_interface_private_types, only : zooplankton_derived_terms_type
   use marbl_interface_private_types, only : zooplankton_local_type
   use marbl_interface_private_types, only : marbl_particulate_share_type
+  use marbl_interface_private_types, only : marbl_interior_tendency_share_type
   use marbl_interface_private_types, only : dissolved_organic_matter_type
   use marbl_interface_private_types, only : marbl_surface_flux_share_type
   use marbl_interface_private_types, only : marbl_surface_flux_internal_type
@@ -109,19 +110,20 @@ module marbl_interface
      type(marbl_running_mean_0d_type)          , public, allocatable  :: glo_scalar_rmean_surface_flux(:)
 
      ! private data
-     type(marbl_PAR_type),                   private :: PAR
-     type(autotroph_derived_terms_type),     private :: autotroph_derived_terms
-     type(autotroph_local_type),             private :: autotroph_local
-     type(zooplankton_derived_terms_type),   private :: zooplankton_derived_terms
-     type(zooplankton_local_type),           private :: zooplankton_local
-     type(marbl_particulate_share_type),     private :: particulate_share
-     type(dissolved_organic_matter_type),    private :: dissolved_organic_matter
-     type(marbl_surface_flux_share_type),    private :: surface_flux_share
-     type(marbl_surface_flux_internal_type), private :: surface_flux_internal
-     logical,                                private :: lallow_glo_ops
-     type(marbl_internal_timers_type),       private :: timers
-     type(marbl_timer_indexing_type),        private :: timer_ids
-     type(marbl_settings_type),              private :: settings
+     type(marbl_PAR_type),                     private :: PAR
+     type(autotroph_derived_terms_type),       private :: autotroph_derived_terms
+     type(autotroph_local_type),               private :: autotroph_local
+     type(zooplankton_derived_terms_type),     private :: zooplankton_derived_terms
+     type(zooplankton_local_type),             private :: zooplankton_local
+     type(marbl_particulate_share_type),       private :: particulate_share
+     type(marbl_interior_tendency_share_type), private :: interior_tendency_share
+     type(dissolved_organic_matter_type),      private :: dissolved_organic_matter
+     type(marbl_surface_flux_share_type),      private :: surface_flux_share
+     type(marbl_surface_flux_internal_type),   private :: surface_flux_internal
+     logical,                                  private :: lallow_glo_ops
+     type(marbl_internal_timers_type),         private :: timers
+     type(marbl_timer_indexing_type),          private :: timer_ids
+     type(marbl_settings_type),                private :: settings
 
    contains
 
@@ -276,6 +278,7 @@ contains
     call this%autotroph_local%construct(ciso_on, autotroph_cnt, num_levels)
     call this%zooplankton_derived_terms%construct(zooplankton_cnt, num_levels)
     call this%zooplankton_local%construct(zooplankton_cnt, num_levels)
+    call this%interior_tendency_share%construct(num_levels)
 
     !-----------------------------------------------------------------------
     !  Set up tracers
@@ -871,6 +874,7 @@ contains
          zooplankton_local                 = this%zooplankton_local,                &
          saved_state                       = this%interior_tendency_saved_state,    &
          marbl_timers                      = this%timers,                           &
+         interior_tendency_share           = this%interior_tendency_share,          &
          marbl_particulate_share           = this%particulate_share,                &
          interior_tendency_diags           = this%interior_tendency_diags,          &
          interior_tendencies               = this%interior_tendencies,              &
@@ -1023,6 +1027,7 @@ contains
     call this%autotroph_local%destruct()
     call this%zooplankton_derived_terms%destruct()
     call this%zooplankton_local%destruct()
+    call this%interior_tendency_share%destruct()
     call this%domain%destruct()
 
     call this%timers%shutdown(this%timer_ids, this%timer_summary, this%StatusLog)

--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -953,8 +953,8 @@ contains
 
     use marbl_settings_mod, only : max_grazer_prey_cnt
     use marbl_settings_mod, only : autotroph_settings
-    use marbl_settings_mod, only : zooplankton
-    use marbl_settings_mod, only : grazing
+    use marbl_settings_mod, only : zooplankton_settings
+    use marbl_settings_mod, only : grazer_settings
     use marbl_settings_mod, only : tracer_restore_vars
     use marbl_diagnostics_mod, only : marbl_interior_tendency_diag_ind
 
@@ -980,14 +980,14 @@ contains
     ! FIXME #69: this is not ideal for threaded runs
     if (allocated(autotroph_settings)) then
       deallocate(autotroph_settings)
-      deallocate(zooplankton)
+      deallocate(zooplankton_settings)
       do m=1,max_grazer_prey_cnt
         do n=1,zooplankton_cnt
-          deallocate(grazing(m,n)%auto_ind)
-          deallocate(grazing(m,n)%zoo_ind)
+          deallocate(grazer_settings(m,n)%auto_ind)
+          deallocate(grazer_settings(m,n)%zoo_ind)
         end do
       end do
-      deallocate(grazing)
+      deallocate(grazer_settings)
     end if
     call marbl_interior_tendency_diag_ind%destruct()
 

--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -980,7 +980,7 @@ contains
     use marbl_settings_mod, only : max_grazer_prey_cnt
     use marbl_settings_mod, only : autotroph_settings
     use marbl_settings_mod, only : zooplankton_settings
-    use marbl_settings_mod, only : grazer_settings
+    use marbl_settings_mod, only : grazing_relationship_settings
     use marbl_settings_mod, only : tracer_restore_vars
     use marbl_diagnostics_mod, only : marbl_interior_tendency_diag_ind
 
@@ -1009,11 +1009,11 @@ contains
       deallocate(zooplankton_settings)
       do m=1,max_grazer_prey_cnt
         do n=1,zooplankton_cnt
-          deallocate(grazer_settings(m,n)%auto_ind)
-          deallocate(grazer_settings(m,n)%zoo_ind)
+          deallocate(grazing_relationship_settings(m,n)%auto_ind)
+          deallocate(grazing_relationship_settings(m,n)%zoo_ind)
         end do
       end do
-      deallocate(grazer_settings)
+      deallocate(grazing_relationship_settings)
     end if
     call marbl_interior_tendency_diag_ind%destruct()
 

--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -45,6 +45,7 @@ module marbl_interface
   use marbl_interface_private_types, only : marbl_particulate_share_type
   use marbl_interface_private_types, only : marbl_interior_tendency_share_type
   use marbl_interface_private_types, only : dissolved_organic_matter_type
+  use marbl_interface_private_types, only : carbonate_type
   use marbl_interface_private_types, only : marbl_surface_flux_share_type
   use marbl_interface_private_types, only : marbl_surface_flux_internal_type
   use marbl_interface_private_types, only : marbl_tracer_index_type
@@ -118,6 +119,7 @@ module marbl_interface
      type(marbl_particulate_share_type),       private :: particulate_share
      type(marbl_interior_tendency_share_type), private :: interior_tendency_share
      type(dissolved_organic_matter_type),      private :: dissolved_organic_matter
+     type(carbonate_type),                     private :: carbonate
      type(marbl_surface_flux_share_type),      private :: surface_flux_share
      type(marbl_surface_flux_internal_type),   private :: surface_flux_internal
      logical,                                  private :: lallow_glo_ops
@@ -274,6 +276,7 @@ contains
 
     call this%PAR%construct(num_levels, num_PAR_subcols)
     call this%dissolved_organic_matter%construct(num_levels)
+    call this%carbonate%construct(num_levels)
     call this%autotroph_derived_terms%construct(autotroph_cnt, num_levels)
     call this%autotroph_local%construct(ciso_on, autotroph_cnt, num_levels)
     call this%zooplankton_derived_terms%construct(zooplankton_cnt, num_levels)
@@ -868,6 +871,7 @@ contains
          marbl_timer_indices               = this%timer_ids,                        &
          PAR                               = this%PAR,                              &
          dissolved_organic_matter          = this%dissolved_organic_matter,         &
+         carbonate                         = this%carbonate,                        &
          autotroph_derived_terms           = this%autotroph_derived_terms,          &
          autotroph_local                   = this%autotroph_local,                  &
          zooplankton_derived_terms         = this%zooplankton_derived_terms,        &
@@ -1023,6 +1027,7 @@ contains
     call this%particulate_share%destruct()
     call this%PAR%destruct()
     call this%dissolved_organic_matter%destruct()
+    call this%carbonate%destruct()
     call this%autotroph_derived_terms%destruct()
     call this%autotroph_local%destruct()
     call this%zooplankton_derived_terms%destruct()

--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -43,6 +43,7 @@ module marbl_interface
   use marbl_interface_private_types, only : zooplankton_derived_terms_type
   use marbl_interface_private_types, only : zooplankton_local_type
   use marbl_interface_private_types, only : marbl_particulate_share_type
+  use marbl_interface_private_types, only : dissolved_organic_matter_type
   use marbl_interface_private_types, only : marbl_surface_flux_share_type
   use marbl_interface_private_types, only : marbl_surface_flux_internal_type
   use marbl_interface_private_types, only : marbl_tracer_index_type
@@ -114,6 +115,7 @@ module marbl_interface
      type(zooplankton_derived_terms_type),   private :: zooplankton_derived_terms
      type(zooplankton_local_type),           private :: zooplankton_local
      type(marbl_particulate_share_type),     private :: particulate_share
+     type(dissolved_organic_matter_type),    private :: dissolved_organic_matter
      type(marbl_surface_flux_share_type),    private :: surface_flux_share
      type(marbl_surface_flux_internal_type), private :: surface_flux_internal
      logical,                                private :: lallow_glo_ops
@@ -269,6 +271,7 @@ contains
     !--------------------------------------------------------------------
 
     call this%PAR%construct(num_levels, num_PAR_subcols)
+    call this%dissolved_organic_matter%construct(num_levels)
     call this%autotroph_derived_terms%construct(autotroph_cnt, num_levels)
     call this%autotroph_local%construct(ciso_on, autotroph_cnt, num_levels)
     call this%zooplankton_derived_terms%construct(zooplankton_cnt, num_levels)
@@ -861,6 +864,7 @@ contains
          marbl_tracer_indices              = this%tracer_indices,                   &
          marbl_timer_indices               = this%timer_ids,                        &
          PAR                               = this%PAR,                              &
+         dissolved_organic_matter          = this%dissolved_organic_matter,         &
          autotroph_derived_terms           = this%autotroph_derived_terms,          &
          autotroph_local                   = this%autotroph_local,                  &
          zooplankton_derived_terms         = this%zooplankton_derived_terms,        &
@@ -1014,6 +1018,7 @@ contains
     call this%settings%destruct()
     call this%particulate_share%destruct()
     call this%PAR%destruct()
+    call this%dissolved_organic_matter%destruct()
     call this%autotroph_derived_terms%destruct()
     call this%autotroph_local%destruct()
     call this%zooplankton_derived_terms%destruct()

--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -39,6 +39,7 @@ module marbl_interface
   use marbl_interface_private_types, only : marbl_interior_tendency_saved_state_indexing_type
   use marbl_interface_private_types, only : marbl_PAR_type
   use marbl_interface_private_types, only : autotroph_secondary_species_type
+  use marbl_interface_private_types, only : zooplankton_secondary_species_type
   use marbl_interface_private_types, only : marbl_particulate_share_type
   use marbl_interface_private_types, only : marbl_surface_flux_share_type
   use marbl_interface_private_types, only : marbl_surface_flux_internal_type
@@ -105,15 +106,16 @@ module marbl_interface
      type(marbl_running_mean_0d_type)          , public, allocatable  :: glo_scalar_rmean_surface_flux(:)
 
      ! private data
-     type(marbl_PAR_type),                   private :: PAR
-     type(autotroph_secondary_species_type), private :: autotroph_secondary_species
-     type(marbl_particulate_share_type),     private :: particulate_share
-     type(marbl_surface_flux_share_type),    private :: surface_flux_share
-     type(marbl_surface_flux_internal_type), private :: surface_flux_internal
-     logical,                                private :: lallow_glo_ops
-     type(marbl_internal_timers_type),       private :: timers
-     type(marbl_timer_indexing_type),        private :: timer_ids
-     type(marbl_settings_type),              private :: settings
+     type(marbl_PAR_type),                     private :: PAR
+     type(autotroph_secondary_species_type),   private :: autotroph_secondary_species
+     type(zooplankton_secondary_species_type), private :: zooplankton_secondary_species
+     type(marbl_particulate_share_type),       private :: particulate_share
+     type(marbl_surface_flux_share_type),      private :: surface_flux_share
+     type(marbl_surface_flux_internal_type),   private :: surface_flux_internal
+     logical,                                  private :: lallow_glo_ops
+     type(marbl_internal_timers_type),         private :: timers
+     type(marbl_timer_indexing_type),          private :: timer_ids
+     type(marbl_settings_type),                private :: settings
 
    contains
 
@@ -263,6 +265,7 @@ contains
 
     call this%PAR%construct(num_levels, num_PAR_subcols)
     call this%autotroph_secondary_species%construct(autotroph_cnt, num_levels)
+    call this%zooplankton_secondary_species%construct(zooplankton_cnt, num_levels)
 
     !-----------------------------------------------------------------------
     !  Set up tracers
@@ -852,6 +855,7 @@ contains
          marbl_timer_indices               = this%timer_ids,                        &
          PAR                               = this%PAR,                              &
          autotroph_secondary_species       = this%autotroph_secondary_species,      &
+         zooplankton_secondary_species     = this%zooplankton_secondary_species,    &
          saved_state                       = this%interior_tendency_saved_state,    &
          marbl_timers                      = this%timers,                           &
          marbl_particulate_share           = this%particulate_share,                &
@@ -1002,6 +1006,7 @@ contains
     call this%particulate_share%destruct()
     call this%PAR%destruct()
     call this%autotroph_secondary_species%destruct()
+    call this%zooplankton_secondary_species%destruct()
     call this%domain%destruct()
 
     call this%timers%shutdown(this%timer_ids, this%timer_summary, this%StatusLog)

--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -42,6 +42,7 @@ module marbl_interface
   use marbl_interface_private_types, only : autotroph_local_type
   use marbl_interface_private_types, only : zooplankton_derived_terms_type
   use marbl_interface_private_types, only : zooplankton_local_type
+  use marbl_interface_private_types, only : zooplankton_share_type
   use marbl_interface_private_types, only : marbl_particulate_share_type
   use marbl_interface_private_types, only : marbl_interior_tendency_share_type
   use marbl_interface_private_types, only : dissolved_organic_matter_type
@@ -116,6 +117,7 @@ module marbl_interface
      type(autotroph_local_type),               private :: autotroph_local
      type(zooplankton_derived_terms_type),     private :: zooplankton_derived_terms
      type(zooplankton_local_type),             private :: zooplankton_local
+     type(zooplankton_share_type),             private :: zooplankton_share
      type(marbl_particulate_share_type),       private :: particulate_share
      type(marbl_interior_tendency_share_type), private :: interior_tendency_share
      type(dissolved_organic_matter_type),      private :: dissolved_organic_matter
@@ -282,7 +284,10 @@ contains
     call this%autotroph_local%construct(ciso_on, autotroph_cnt, num_levels)
     call this%zooplankton_derived_terms%construct(zooplankton_cnt, num_levels)
     call this%zooplankton_local%construct(zooplankton_cnt, num_levels)
-    if (ciso_on) call this%interior_tendency_share%construct(num_levels)
+    if (ciso_on) then
+      call this%zooplankton_share%construct(num_levels)
+      call this%interior_tendency_share%construct(num_levels)
+    end if
 
     !-----------------------------------------------------------------------
     !  Set up tracers
@@ -879,6 +884,7 @@ contains
          autotroph_local                   = this%autotroph_local,                  &
          zooplankton_derived_terms         = this%zooplankton_derived_terms,        &
          zooplankton_local                 = this%zooplankton_local,                &
+         zooplankton_share                 = this%zooplankton_share,                &
          saved_state                       = this%interior_tendency_saved_state,    &
          marbl_timers                      = this%timers,                           &
          interior_tendency_share           = this%interior_tendency_share,          &
@@ -1036,7 +1042,10 @@ contains
     call this%autotroph_local%destruct()
     call this%zooplankton_derived_terms%destruct()
     call this%zooplankton_local%destruct()
-    if (ciso_on) call this%interior_tendency_share%destruct()
+    if (ciso_on) then
+      call this%zooplankton_share%destruct()
+      call this%interior_tendency_share%destruct()
+    end if
     call this%domain%destruct()
 
     call this%timers%shutdown(this%timer_ids, this%timer_summary, this%StatusLog)

--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -41,6 +41,7 @@ module marbl_interface
   use marbl_interface_private_types, only : autotroph_derived_terms_type
   use marbl_interface_private_types, only : autotroph_local_type
   use marbl_interface_private_types, only : zooplankton_derived_terms_type
+  use marbl_interface_private_types, only : zooplankton_local_type
   use marbl_interface_private_types, only : marbl_particulate_share_type
   use marbl_interface_private_types, only : marbl_surface_flux_share_type
   use marbl_interface_private_types, only : marbl_surface_flux_internal_type
@@ -111,6 +112,7 @@ module marbl_interface
      type(autotroph_derived_terms_type),     private :: autotroph_derived_terms
      type(autotroph_local_type),             private :: autotroph_local
      type(zooplankton_derived_terms_type),   private :: zooplankton_derived_terms
+     type(zooplankton_local_type),           private :: zooplankton_local
      type(marbl_particulate_share_type),     private :: particulate_share
      type(marbl_surface_flux_share_type),    private :: surface_flux_share
      type(marbl_surface_flux_internal_type), private :: surface_flux_internal
@@ -270,6 +272,7 @@ contains
     call this%autotroph_derived_terms%construct(autotroph_cnt, num_levels)
     call this%autotroph_local%construct(ciso_on, autotroph_cnt, num_levels)
     call this%zooplankton_derived_terms%construct(zooplankton_cnt, num_levels)
+    call this%zooplankton_local%construct(zooplankton_cnt, num_levels)
 
     !-----------------------------------------------------------------------
     !  Set up tracers
@@ -861,6 +864,7 @@ contains
          autotroph_derived_terms           = this%autotroph_derived_terms,          &
          autotroph_local                   = this%autotroph_local,                  &
          zooplankton_derived_terms         = this%zooplankton_derived_terms,        &
+         zooplankton_local                 = this%zooplankton_local,                &
          saved_state                       = this%interior_tendency_saved_state,    &
          marbl_timers                      = this%timers,                           &
          marbl_particulate_share           = this%particulate_share,                &
@@ -1013,6 +1017,7 @@ contains
     call this%autotroph_derived_terms%destruct()
     call this%autotroph_local%destruct()
     call this%zooplankton_derived_terms%destruct()
+    call this%zooplankton_local%destruct()
     call this%domain%destruct()
 
     call this%timers%shutdown(this%timer_ids, this%timer_summary, this%StatusLog)

--- a/src/marbl_interface_private_types.F90
+++ b/src/marbl_interface_private_types.F90
@@ -82,6 +82,24 @@ module marbl_interface_private_types
     procedure, public :: destruct => autotroph_secondary_species_destructor
   end type autotroph_secondary_species_type
 
+  !****************************************************************************
+
+  type, public :: autotroph_local_type
+    real(r8), allocatable :: Chl(:,:)     ! local copy of model autotroph Chl
+    real(r8), allocatable :: C(:,:)       ! local copy of model autotroph C
+    real(r8), allocatable :: P(:,:)       ! local copy of model autotroph P
+    real(r8), allocatable :: Fe(:,:)      ! local copy of model autotroph Fe
+    real(r8), allocatable :: Si(:,:)      ! local copy of model autotroph Si
+    real(r8), allocatable :: CaCO3(:,:)   ! local copy of model autotroph CaCO3
+    real(r8), allocatable :: C13(:,:)     ! local copy of model autotroph C13
+    real(r8), allocatable :: C14(:,:)     ! local copy of model autotroph C14
+    real(r8), allocatable :: Ca13CO3(:,:) ! local copy of model autotroph Ca13CO3
+    real(r8), allocatable :: Ca14CO3(:,:) ! local copy of model autotroph Ca14CO3
+  contains
+    procedure, public :: construct => autotroph_local_constructor
+    procedure, public :: destruct => autotroph_local_destructor
+  end type autotroph_local_type
+
   !*****************************************************************************
 
   type, public :: zooplankton_secondary_species_type
@@ -964,6 +982,54 @@ contains
     deallocate(self%remaining_P_dip)
 
   end subroutine autotroph_secondary_species_destructor
+
+  !***********************************************************************
+
+  subroutine autotroph_local_constructor(self, ciso_on, autotroph_cnt, km)
+
+    class(autotroph_local_type), intent(inout) :: self
+    logical,                     intent(in)    :: ciso_on
+    integer,                     intent(in)    :: autotroph_cnt
+    integer,                     intent(in)    :: km
+
+    allocate(self%Chl(autotroph_cnt, km))
+    allocate(self%C(autotroph_cnt, km))
+    allocate(self%P(autotroph_cnt, km))
+    allocate(self%Fe(autotroph_cnt, km))
+    allocate(self%Si(autotroph_cnt, km))
+    allocate(self%CaCO3(autotroph_cnt, km))
+    if (ciso_on) then
+      allocate(self%C13(autotroph_cnt, km))
+      allocate(self%C14(autotroph_cnt, km))
+      allocate(self%Ca13CO3(autotroph_cnt, km))
+      allocate(self%Ca14CO3(autotroph_cnt, km))
+    else
+      allocate(self%C13(0,0))
+      allocate(self%C14(0,0))
+      allocate(self%Ca13CO3(0,0))
+      allocate(self%Ca14CO3(0,0))
+    end if
+
+  end subroutine autotroph_local_constructor
+
+  !***********************************************************************
+
+  subroutine autotroph_local_destructor(self)
+
+    class(autotroph_local_type), intent(inout) :: self
+
+    deallocate(self%Chl)
+    deallocate(self%C)
+    deallocate(self%P)
+    deallocate(self%Fe)
+    deallocate(self%Si)
+    deallocate(self%CaCO3)
+    deallocate(self%C13)
+    deallocate(self%C14)
+    deallocate(self%Ca13CO3)
+    deallocate(self%Ca14CO3)
+
+  end subroutine autotroph_local_destructor
 
   !***********************************************************************
 

--- a/src/marbl_interface_private_types.F90
+++ b/src/marbl_interface_private_types.F90
@@ -30,6 +30,58 @@ module marbl_interface_private_types
      procedure, public :: destruct => marbl_PAR_destructor
   end type marbl_PAR_type
 
+  !*****************************************************************************
+
+  type, public :: autotroph_secondary_species_type
+     real(r8), allocatable :: thetaC(:,:)          ! current Chl/C ratio (mg Chl/mmol C)
+     real(r8), allocatable :: QCaCO3(:,:)          ! current CaCO3/C ratio (mmol CaCO3/mmol C)
+     real(r8), allocatable :: Qp(:,:)              ! current P/C ratio (mmol P/mmol C)
+     real(r8), allocatable :: gQp(:,:)             ! P/C for growth
+     real(r8), allocatable :: Qfe(:,:)             ! current Fe/C ratio (mmol Fe/mmol C)
+     real(r8), allocatable :: gQfe(:,:)            ! fe/C for growth
+     real(r8), allocatable :: Qsi(:,:)             ! current Si/C ratio (mmol Si/mmol C)
+     real(r8), allocatable :: gQsi(:,:)            ! diatom Si/C ratio for growth (new biomass)
+     real(r8), allocatable :: VNO3(:,:)            ! NH4 uptake rate (non-dim)
+     real(r8), allocatable :: VNH4(:,:)            ! NO3 uptake rate (non-dim)
+     real(r8), allocatable :: VNtot(:,:)           ! total N uptake rate (non-dim)
+     real(r8), allocatable :: NO3_V(:,:)           ! nitrate uptake (mmol NO3/m^3/sec)
+     real(r8), allocatable :: NH4_V(:,:)           ! ammonium uptake (mmol NH4/m^3/sec)
+     real(r8), allocatable :: PO4_V(:,:)           ! PO4 uptake (mmol PO4/m^3/sec)
+     real(r8), allocatable :: DOP_V(:,:)           ! DOP uptake (mmol DOP/m^3/sec)
+     real(r8), allocatable :: VPO4(:,:)            ! C-specific PO4 uptake (non-dim)
+     real(r8), allocatable :: VDOP(:,:)            ! C-specific DOP uptake rate (non-dim)
+     real(r8), allocatable :: VPtot(:,:)           ! total P uptake rate (non-dim)
+     real(r8), allocatable :: f_nut(:,:)           ! nut limitation factor, modifies C fixation (non-dim)
+     real(r8), allocatable :: VFe(:,:)             ! C-specific Fe uptake (non-dim)
+     real(r8), allocatable :: VSiO3(:,:)           ! C-specific SiO3 uptake (non-dim)
+     real(r8), allocatable :: light_lim(:,:)       ! light limitation factor
+     real(r8), allocatable :: PCphoto(:,:)         ! C-specific rate of photosynth. (1/sec)
+     real(r8), allocatable :: photoC(:,:)          ! C-fixation (mmol C/m^3/sec)
+     real(r8), allocatable :: photoFe(:,:)         ! iron uptake
+     real(r8), allocatable :: photoSi(:,:)         ! silicon uptake (mmol Si/m^3/sec)
+     real(r8), allocatable :: photoacc(:,:)        ! Chl synth. term in photoadapt. (GD98) (mg Chl/m^3/sec)
+     real(r8), allocatable :: auto_loss(:,:)       ! autotroph non-grazing mort (mmol C/m^3/sec)
+     real(r8), allocatable :: auto_loss_poc(:,:)   ! auto_loss routed to poc (mmol C/m^3/sec)
+     real(r8), allocatable :: auto_loss_doc(:,:)   ! auto_loss routed to doc (mmol C/m^3/sec)
+     real(r8), allocatable :: auto_loss_dic(:,:)   ! auto_loss routed to dic (mmol C/m^3/sec)
+     real(r8), allocatable :: auto_agg(:,:)        ! autotroph aggregation (mmol C/m^3/sec)
+     real(r8), allocatable :: auto_graze(:,:)      ! autotroph grazing rate (mmol C/m^3/sec)
+     real(r8), allocatable :: auto_graze_zoo(:,:)  ! auto_graze routed to zoo (mmol C/m^3/sec)
+     real(r8), allocatable :: auto_graze_poc(:,:)  ! auto_graze routed to poc (mmol C/m^3/sec)
+     real(r8), allocatable :: auto_graze_doc(:,:)  ! auto_graze routed to doc (mmol C/m^3/sec)
+     real(r8), allocatable :: auto_graze_dic(:,:)  ! auto_graze routed to dic (mmol C/m^3/sec)
+     real(r8), allocatable :: Pprime(:,:)          ! used to limit autotroph mort at low biomass (mmol C/m^3)
+     real(r8), allocatable :: CaCO3_form(:,:)      ! calcification of CaCO3 by small phyto (mmol CaCO3/m^3/sec)
+     real(r8), allocatable :: Nfix(:,:)            ! total Nitrogen fixation (mmol N/m^3/sec)
+     real(r8), allocatable :: Nexcrete(:,:)        ! fixed N excretion
+     real(r8), allocatable :: remaining_P_dop(:,:) ! remaining_P from grazing routed to DOP pool
+     real(r8), allocatable :: remaining_P_pop(:,:) ! remaining_P from grazing routed to POP pool
+     real(r8), allocatable :: remaining_P_dip(:,:) ! remaining_P from grazing routed to remin
+  contains
+     procedure, public :: construct => autotroph_secondary_species_constructor
+     procedure, public :: destruct => autotroph_secondary_species_destructor
+  end type autotroph_secondary_species_type
+
   !****************************************************************************
 
   ! derived type for implicit handling of sinking particulate matter
@@ -786,6 +838,114 @@ contains
   end subroutine marbl_PAR_destructor
 
   !***********************************************************************
+
+  subroutine autotroph_secondary_species_constructor(self, autotroph_cnt, km)
+
+    class(autotroph_secondary_species_type), intent(inout) :: self
+    integer,                                 intent(in)    :: autotroph_cnt
+    integer,                                 intent(in)    :: km
+
+    allocate(self%thetaC(autotroph_cnt, km))
+    allocate(self%QCaCO3(autotroph_cnt, km))
+    allocate(self%Qp(autotroph_cnt, km))
+    allocate(self%gQp(autotroph_cnt, km))
+    allocate(self%Qfe(autotroph_cnt, km))
+    allocate(self%gQfe(autotroph_cnt, km))
+    allocate(self%Qsi(autotroph_cnt, km))
+    allocate(self%gQsi(autotroph_cnt, km))
+    allocate(self%VNO3(autotroph_cnt, km))
+    allocate(self%VNH4(autotroph_cnt, km))
+    allocate(self%VNtot(autotroph_cnt, km))
+    allocate(self%NO3_V(autotroph_cnt, km))
+    allocate(self%NH4_V(autotroph_cnt, km))
+    allocate(self%PO4_V(autotroph_cnt, km))
+    allocate(self%DOP_V(autotroph_cnt, km))
+    allocate(self%VPO4(autotroph_cnt, km))
+    allocate(self%VDOP(autotroph_cnt, km))
+    allocate(self%VPtot(autotroph_cnt, km))
+    allocate(self%f_nut(autotroph_cnt, km))
+    allocate(self%VFe(autotroph_cnt, km))
+    allocate(self%VSiO3(autotroph_cnt, km))
+    allocate(self%light_lim(autotroph_cnt, km))
+    allocate(self%PCphoto(autotroph_cnt, km))
+    allocate(self%photoC(autotroph_cnt, km))
+    allocate(self%photoFe(autotroph_cnt, km))
+    allocate(self%photoSi(autotroph_cnt, km))
+    allocate(self%photoacc(autotroph_cnt, km))
+    allocate(self%auto_loss(autotroph_cnt, km))
+    allocate(self%auto_loss_poc(autotroph_cnt, km))
+    allocate(self%auto_loss_doc(autotroph_cnt, km))
+    allocate(self%auto_loss_dic(autotroph_cnt, km))
+    allocate(self%auto_agg(autotroph_cnt, km))
+    allocate(self%auto_graze(autotroph_cnt, km))
+    allocate(self%auto_graze_zoo(autotroph_cnt, km))
+    allocate(self%auto_graze_poc(autotroph_cnt, km))
+    allocate(self%auto_graze_doc(autotroph_cnt, km))
+    allocate(self%auto_graze_dic(autotroph_cnt, km))
+    allocate(self%Pprime(autotroph_cnt, km))
+    allocate(self%CaCO3_form(autotroph_cnt, km))
+    allocate(self%Nfix(autotroph_cnt, km))
+    allocate(self%Nexcrete(autotroph_cnt, km))
+    allocate(self%remaining_P_dop(autotroph_cnt, km))
+    allocate(self%remaining_P_pop(autotroph_cnt, km))
+    allocate(self%remaining_P_dip(autotroph_cnt, km))
+
+  end subroutine autotroph_secondary_species_constructor
+
+  !*****************************************************************************
+
+  subroutine autotroph_secondary_species_destructor(self)
+
+    class(autotroph_secondary_species_type), intent(inout) :: self
+
+    deallocate(self%thetaC)
+    deallocate(self%QCaCO3)
+    deallocate(self%Qp)
+    deallocate(self%gQp)
+    deallocate(self%Qfe)
+    deallocate(self%gQfe)
+    deallocate(self%Qsi)
+    deallocate(self%gQsi)
+    deallocate(self%VNO3)
+    deallocate(self%VNH4)
+    deallocate(self%VNtot)
+    deallocate(self%NO3_V)
+    deallocate(self%NH4_V)
+    deallocate(self%PO4_V)
+    deallocate(self%DOP_V)
+    deallocate(self%VPO4)
+    deallocate(self%VDOP)
+    deallocate(self%VPtot)
+    deallocate(self%f_nut)
+    deallocate(self%VFe)
+    deallocate(self%VSiO3)
+    deallocate(self%light_lim)
+    deallocate(self%PCphoto)
+    deallocate(self%photoC)
+    deallocate(self%photoFe)
+    deallocate(self%photoSi)
+    deallocate(self%photoacc)
+    deallocate(self%auto_loss)
+    deallocate(self%auto_loss_poc)
+    deallocate(self%auto_loss_doc)
+    deallocate(self%auto_loss_dic)
+    deallocate(self%auto_agg)
+    deallocate(self%auto_graze)
+    deallocate(self%auto_graze_zoo)
+    deallocate(self%auto_graze_poc)
+    deallocate(self%auto_graze_doc)
+    deallocate(self%auto_graze_dic)
+    deallocate(self%Pprime)
+    deallocate(self%CaCO3_form)
+    deallocate(self%Nfix)
+    deallocate(self%Nexcrete)
+    deallocate(self%remaining_P_dop)
+    deallocate(self%remaining_P_pop)
+    deallocate(self%remaining_P_dip)
+
+  end subroutine autotroph_secondary_species_destructor
+
+  !*****************************************************************************
 
   subroutine marbl_surface_flux_internal_constructor(this, num_elements)
 

--- a/src/marbl_interface_private_types.F90
+++ b/src/marbl_interface_private_types.F90
@@ -130,6 +130,24 @@ module marbl_interface_private_types
     procedure, public :: destruct => zooplankton_local_destructor
   end type zooplankton_local_type
 
+  !***********************************************************************
+
+  type, public :: zooplankton_share_type
+     real(r8), allocatable :: zoototC_loc_fields(:)      ! local copy of model zooC
+     real(r8), allocatable :: zootot_loss_fields(:)      ! mortality & higher trophic grazing on zooplankton (mmol C/m^3/sec)
+     real(r8), allocatable :: zootot_loss_poc_fields(:)  ! zoo_loss routed to large detrital (mmol C/m^3/sec)
+     real(r8), allocatable :: zootot_loss_doc_fields(:)  ! zoo_loss routed to doc (mmol C/m^3/sec)
+     real(r8), allocatable :: zootot_loss_dic_fields(:)  ! zoo_loss routed to dic (mmol C/m^3/sec)
+     real(r8), allocatable :: zootot_graze_fields(:)     ! zooplankton losses due to grazing (mmol C/m^3/sec)
+     real(r8), allocatable :: zootot_graze_zoo_fields(:) ! grazing of zooplankton routed to zoo (mmol C/m^3/sec)
+     real(r8), allocatable :: zootot_graze_poc_fields(:) ! grazing of zooplankton routed to poc (mmol C/m^3/sec)
+     real(r8), allocatable :: zootot_graze_doc_fields(:) ! grazing of zooplankton routed to doc (mmol C/m^3/sec)
+     real(r8), allocatable :: zootot_graze_dic_fields(:) ! grazing of zooplankton routed to dic (mmol C/m^3/sec)
+   contains
+     procedure, public :: construct => zooplankton_share_constructor
+     procedure, public :: destruct => zooplankton_share_destructor
+  end type zooplankton_share_type
+
   !****************************************************************************
 
   ! derived type for implicit handling of sinking particulate matter
@@ -1193,6 +1211,45 @@ contains
     deallocate(self%C)
 
   end subroutine zooplankton_local_destructor
+
+  !***********************************************************************
+
+  subroutine zooplankton_share_constructor(self, km)
+
+    class(zooplankton_share_type), intent(inout) :: self
+    integer,                       intent(in)    :: km
+
+    allocate(self%zoototC_loc_fields(km))
+    allocate(self%zootot_loss_fields(km))
+    allocate(self%zootot_loss_poc_fields(km))
+    allocate(self%zootot_loss_doc_fields(km))
+    allocate(self%zootot_loss_dic_fields(km))
+    allocate(self%zootot_graze_fields(km))
+    allocate(self%zootot_graze_zoo_fields(km))
+    allocate(self%zootot_graze_poc_fields(km))
+    allocate(self%zootot_graze_doc_fields(km))
+    allocate(self%zootot_graze_dic_fields(km))
+
+  end subroutine zooplankton_share_constructor
+
+  !***********************************************************************
+
+  subroutine zooplankton_share_destructor(self)
+
+    class(zooplankton_share_type), intent(inout) :: self
+
+    deallocate(self%zoototC_loc_fields)
+    deallocate(self%zootot_loss_fields)
+    deallocate(self%zootot_loss_poc_fields)
+    deallocate(self%zootot_loss_doc_fields)
+    deallocate(self%zootot_loss_dic_fields)
+    deallocate(self%zootot_graze_fields)
+    deallocate(self%zootot_graze_zoo_fields)
+    deallocate(self%zootot_graze_poc_fields)
+    deallocate(self%zootot_graze_doc_fields)
+    deallocate(self%zootot_graze_dic_fields)
+
+  end subroutine zooplankton_share_destructor
 
   !*****************************************************************************
 

--- a/src/marbl_interface_private_types.F90
+++ b/src/marbl_interface_private_types.F90
@@ -123,6 +123,15 @@ module marbl_interface_private_types
 
   !****************************************************************************
 
+  type, public :: zooplankton_local_type
+    real(r8), allocatable :: C(:,:)  ! local copy of model zooplankton C
+  contains
+    procedure, public :: construct => zooplankton_local_constructor
+    procedure, public :: destruct => zooplankton_local_destructor
+  end type zooplankton_local_type
+
+  !****************************************************************************
+
   ! derived type for implicit handling of sinking particulate matter
   type, public :: column_sinking_particle_type
      real(r8) :: diss                       ! dissolution length for soft subclass
@@ -1075,6 +1084,28 @@ contains
     deallocate(self%Zprime)
 
   end subroutine zooplankton_derived_terms_destructor
+
+  !***********************************************************************
+
+  subroutine zooplankton_local_constructor(self, zooplankton_cnt, km)
+
+    class(zooplankton_local_type), intent(inout) :: self
+    integer,                       intent(in)    :: zooplankton_cnt
+    integer,                       intent(in)    :: km
+
+    allocate(self%C(zooplankton_cnt, km))
+
+  end subroutine zooplankton_local_constructor
+
+  !***********************************************************************
+
+  subroutine zooplankton_local_destructor(self)
+
+    class(zooplankton_local_type), intent(inout) :: self
+
+    deallocate(self%C)
+
+  end subroutine zooplankton_local_destructor
 
   !*****************************************************************************
 

--- a/src/marbl_interface_private_types.F90
+++ b/src/marbl_interface_private_types.F90
@@ -187,13 +187,16 @@ module marbl_interface_private_types
   !****************************************************************************
 
   type, public :: marbl_interior_tendency_share_type
-     real(r8) :: QA_dust_def         ! incoming deficit in the QA(dust) POC flux
-     real(r8) :: CO3_fields
-     real(r8) :: HCO3_fields         ! bicarbonate ion
-     real(r8) :: H2CO3_fields        ! carbonic acid
-     real(r8) :: CO3_sat_calcite
-     real(r8) :: DOCtot_loc_fields   ! local copy of model DOC+DOCr
-     real(r8) :: DOCtot_remin_fields ! remineralization of DOC+DOCr (mmol C/m^3/sec)
+     real(r8), allocatable :: QA_dust_def(:)         ! incoming deficit in the QA(dust) POC flux
+     real(r8), allocatable :: CO3_fields(:)
+     real(r8), allocatable :: HCO3_fields(:)         ! bicarbonate ion
+     real(r8), allocatable :: H2CO3_fields(:)        ! carbonic acid
+     real(r8), allocatable :: CO3_sat_calcite(:)
+     real(r8), allocatable :: DOCtot_loc_fields(:)   ! local copy of model DOC+DOCr
+     real(r8), allocatable :: DOCtot_remin_fields(:) ! remineralization of DOC+DOCr (mmol C/m^3/sec)
+   contains
+     procedure, public :: construct => marbl_interior_tendency_share_constructor
+     procedure, public :: destruct => marbl_interior_tendency_share_destructor
   end type marbl_interior_tendency_share_type
 
   !***********************************************************************
@@ -1225,6 +1228,39 @@ contains
     end if
 
   end subroutine marbl_surface_flux_internal_destructor
+
+  !*****************************************************************************
+
+  subroutine marbl_interior_tendency_share_constructor(this, num_levels)
+
+    class(marbl_interior_tendency_share_type), intent(out) :: this
+    integer (int_kind),                        intent(in)  :: num_levels
+
+    allocate(this%QA_dust_def(num_levels))
+    allocate(this%CO3_fields(num_levels))
+    allocate(this%HCO3_fields(num_levels))
+    allocate(this%H2CO3_fields(num_levels))
+    allocate(this%CO3_sat_calcite(num_levels))
+    allocate(this%DOCtot_loc_fields(num_levels))
+    allocate(this%DOCtot_remin_fields(num_levels))
+
+  end subroutine marbl_interior_tendency_share_constructor
+
+  !***********************************************************************
+
+  subroutine marbl_interior_tendency_share_destructor(this)
+
+    class(marbl_interior_tendency_share_type), intent(inout) :: this
+
+    deallocate(this%QA_dust_def)
+    deallocate(this%CO3_fields)
+    deallocate(this%HCO3_fields)
+    deallocate(this%H2CO3_fields)
+    deallocate(this%CO3_sat_calcite)
+    deallocate(this%DOCtot_loc_fields)
+    deallocate(this%DOCtot_remin_fields)
+
+  end subroutine marbl_interior_tendency_share_destructor
 
   !*****************************************************************************
 

--- a/src/marbl_interface_private_types.F90
+++ b/src/marbl_interface_private_types.F90
@@ -32,7 +32,7 @@ module marbl_interface_private_types
 
   !*****************************************************************************
 
-  type, public :: autotroph_secondary_species_type
+  type, public :: autotroph_derived_terms_type
     real(r8), allocatable :: thetaC(:,:)          ! current Chl/C ratio (mg Chl/mmol C)
     real(r8), allocatable :: QCaCO3(:,:)          ! current CaCO3/C ratio (mmol CaCO3/mmol C)
     real(r8), allocatable :: Qp(:,:)              ! current P/C ratio (mmol P/mmol C)
@@ -78,13 +78,14 @@ module marbl_interface_private_types
     real(r8), allocatable :: remaining_P_pop(:,:) ! remaining_P from grazing routed to POP pool
     real(r8), allocatable :: remaining_P_dip(:,:) ! remaining_P from grazing routed to remin
   contains
-    procedure, public :: construct => autotroph_secondary_species_constructor
-    procedure, public :: destruct => autotroph_secondary_species_destructor
-  end type autotroph_secondary_species_type
+    procedure, public :: construct => autotroph_derived_terms_constructor
+    procedure, public :: destruct => autotroph_derived_terms_destructor
+  end type autotroph_derived_terms_type
 
   !****************************************************************************
 
   type, public :: autotroph_local_type
+    ! FIXME #316: replace with indices into tracer_local
     real(r8), allocatable :: Chl(:,:)     ! local copy of model autotroph Chl
     real(r8), allocatable :: C(:,:)       ! local copy of model autotroph C
     real(r8), allocatable :: P(:,:)       ! local copy of model autotroph P
@@ -102,7 +103,7 @@ module marbl_interface_private_types
 
   !*****************************************************************************
 
-  type, public :: zooplankton_secondary_species_type
+  type, public :: zooplankton_derived_terms_type
     real(r8), allocatable :: f_zoo_detr(:,:)       ! frac of zoo losses into large detrital pool (non-dim)
     real(r8), allocatable :: x_graze_zoo(:,:)      ! {auto, zoo}_graze routed to zoo (mmol C/m^3/sec)
     real(r8), allocatable :: zoo_graze(:,:)        ! zooplankton losses due to grazing (mmol C/m^3/sec)
@@ -116,9 +117,9 @@ module marbl_interface_private_types
     real(r8), allocatable :: zoo_loss_dic(:,:)     ! zoo_loss routed to dic (mmol C/m^3/sec)
     real(r8), allocatable :: Zprime(:,:)           ! used to limit zoo mort at low biomass (mmol C/m^3)
   contains
-    procedure, public :: construct => zooplankton_secondary_species_constructor
-    procedure, public :: destruct => zooplankton_secondary_species_destructor
-  end type zooplankton_secondary_species_type
+    procedure, public :: construct => zooplankton_derived_terms_constructor
+    procedure, public :: destruct => zooplankton_derived_terms_destructor
+  end type zooplankton_derived_terms_type
 
   !****************************************************************************
 
@@ -877,11 +878,11 @@ contains
 
   !***********************************************************************
 
-  subroutine autotroph_secondary_species_constructor(self, autotroph_cnt, km)
+  subroutine autotroph_derived_terms_constructor(self, autotroph_cnt, km)
 
-    class(autotroph_secondary_species_type), intent(inout) :: self
-    integer,                                 intent(in)    :: autotroph_cnt
-    integer,                                 intent(in)    :: km
+    class(autotroph_derived_terms_type), intent(inout) :: self
+    integer,                             intent(in)    :: autotroph_cnt
+    integer,                             intent(in)    :: km
 
     allocate(self%thetaC(autotroph_cnt, km))
     allocate(self%QCaCO3(autotroph_cnt, km))
@@ -928,13 +929,13 @@ contains
     allocate(self%remaining_P_pop(autotroph_cnt, km))
     allocate(self%remaining_P_dip(autotroph_cnt, km))
 
-  end subroutine autotroph_secondary_species_constructor
+  end subroutine autotroph_derived_terms_constructor
 
   !*****************************************************************************
 
-  subroutine autotroph_secondary_species_destructor(self)
+  subroutine autotroph_derived_terms_destructor(self)
 
-    class(autotroph_secondary_species_type), intent(inout) :: self
+    class(autotroph_derived_terms_type), intent(inout) :: self
 
     deallocate(self%thetaC)
     deallocate(self%QCaCO3)
@@ -981,7 +982,7 @@ contains
     deallocate(self%remaining_P_pop)
     deallocate(self%remaining_P_dip)
 
-  end subroutine autotroph_secondary_species_destructor
+  end subroutine autotroph_derived_terms_destructor
 
   !***********************************************************************
 
@@ -1033,11 +1034,11 @@ contains
 
   !***********************************************************************
 
-  subroutine zooplankton_secondary_species_constructor(self, zooplankton_cnt, km)
+  subroutine zooplankton_derived_terms_constructor(self, zooplankton_cnt, km)
 
-    class(zooplankton_secondary_species_type), intent(inout) :: self
-    integer,                                   intent(in)    :: zooplankton_cnt
-    integer,                                   intent(in)    :: km
+    class(zooplankton_derived_terms_type), intent(inout) :: self
+    integer,                               intent(in)    :: zooplankton_cnt
+    integer,                               intent(in)    :: km
 
     allocate(self%f_zoo_detr(zooplankton_cnt, km))
     allocate(self%x_graze_zoo(zooplankton_cnt, km))
@@ -1052,13 +1053,13 @@ contains
     allocate(self%zoo_loss_dic(zooplankton_cnt, km))
     allocate(self%Zprime(zooplankton_cnt, km))
 
-  end subroutine zooplankton_secondary_species_constructor
+  end subroutine zooplankton_derived_terms_constructor
 
   !***********************************************************************
 
-  subroutine zooplankton_secondary_species_destructor(self)
+  subroutine zooplankton_derived_terms_destructor(self)
 
-    class(zooplankton_secondary_species_type), intent(inout) :: self
+    class(zooplankton_derived_terms_type), intent(inout) :: self
 
     deallocate(self%f_zoo_detr)
     deallocate(self%x_graze_zoo)
@@ -1073,7 +1074,7 @@ contains
     deallocate(self%zoo_loss_dic)
     deallocate(self%Zprime)
 
-  end subroutine zooplankton_secondary_species_destructor
+  end subroutine zooplankton_derived_terms_destructor
 
   !*****************************************************************************
 
@@ -1154,7 +1155,7 @@ contains
 
   !*****************************************************************************
 
-  subroutine tracer_index_constructor(this, ciso_on, lvariable_PtoC, autotrophs, &
+  subroutine tracer_index_constructor(this, ciso_on, lvariable_PtoC, autotroph_settings, &
              zooplankton, marbl_status_log)
 
     ! This subroutine sets the tracer indices for the non-autotroph tracers. To
@@ -1162,13 +1163,13 @@ contains
     ! tracer_cnt by 1 for each tracer that is included. Note that this gives an
     ! accurate count whether the carbon isotope tracers are included or not.
 
-    use marbl_pft_mod, only : autotroph_type
+    use marbl_pft_mod, only : autotroph_settings_type
     use marbl_pft_mod, only : zooplankton_type
 
     class(marbl_tracer_index_type), intent(out)   :: this
     logical,                        intent(in)    :: ciso_on
     logical,                        intent(in)    :: lvariable_PtoC
-    type(autotroph_type),           intent(in)    :: autotrophs(:)
+    type(autotroph_settings_type),  intent(in)    :: autotroph_settings(:)
     type(zooplankton_type),         intent(in)    :: zooplankton(:)
     type(marbl_log_type),           intent(inout) :: marbl_status_log
 
@@ -1176,7 +1177,7 @@ contains
     character(len=char_len) :: ind_name
     integer :: autotroph_cnt, zooplankton_cnt, n
 
-    autotroph_cnt = size(autotrophs)
+    autotroph_cnt = size(autotroph_settings)
     zooplankton_cnt = size(zooplankton)
 
     !Allocate memory
@@ -1208,28 +1209,28 @@ contains
     end do
 
     do n=1,autotroph_cnt
-      write(ind_name, "(2A)") trim(autotrophs(n)%sname), "Chl"
+      write(ind_name, "(2A)") trim(autotroph_settings(n)%sname), "Chl"
       call this%add_tracer_index(ind_name, 'ecosys_base', this%auto_inds(n)%Chl_ind, marbl_status_log)
 
-      write(ind_name, "(2A)") trim(autotrophs(n)%sname), "C"
+      write(ind_name, "(2A)") trim(autotroph_settings(n)%sname), "C"
       call this%add_tracer_index(ind_name, 'ecosys_base', this%auto_inds(n)%C_ind, marbl_status_log)
 
       if (lvariable_PtoC) then
-        write(ind_name, "(2A)") trim(autotrophs(n)%sname), "P"
+        write(ind_name, "(2A)") trim(autotroph_settings(n)%sname), "P"
         call this%add_tracer_index(ind_name, 'ecosys_base', this%auto_inds(n)%P_ind, marbl_status_log)
       end if
 
-      write(ind_name, "(2A)") trim(autotrophs(n)%sname), "Fe"
+      write(ind_name, "(2A)") trim(autotroph_settings(n)%sname), "Fe"
       call this%add_tracer_index(ind_name, 'ecosys_base', this%auto_inds(n)%Fe_ind, marbl_status_log)
 
-      if (autotrophs(n)%silicifier) then
-        write(ind_name, "(2A)") trim(autotrophs(n)%sname), "Si"
+      if (autotroph_settings(n)%silicifier) then
+        write(ind_name, "(2A)") trim(autotroph_settings(n)%sname), "Si"
         call this%add_tracer_index(ind_name, 'ecosys_base', this%auto_inds(n)%Si_ind, marbl_status_log)
       end if
 
-      if (autotrophs(n)%imp_calcifier.or.                            &
-          autotrophs(n)%exp_calcifier) then
-        write(ind_name, "(2A)") trim(autotrophs(n)%sname), "CaCO3"
+      if (autotroph_settings(n)%imp_calcifier.or. &
+          autotroph_settings(n)%exp_calcifier) then
+        write(ind_name, "(2A)") trim(autotroph_settings(n)%sname), "CaCO3"
         call this%add_tracer_index(ind_name, 'ecosys_base', this%auto_inds(n)%CaCO3_ind, marbl_status_log)
       end if
     end do
@@ -1243,18 +1244,18 @@ contains
       call this%add_tracer_index('zootot14C',   'ciso', this%zootot14C_ind,   marbl_status_log)
 
       do n=1,autotroph_cnt
-        write(ind_name, "(2A)") trim(autotrophs(n)%sname), "C13"
+        write(ind_name, "(2A)") trim(autotroph_settings(n)%sname), "C13"
         call this%add_tracer_index(ind_name, 'ciso', this%auto_inds(n)%C13_ind, marbl_status_log)
 
-        write(ind_name, "(2A)") trim(autotrophs(n)%sname), "C14"
+        write(ind_name, "(2A)") trim(autotroph_settings(n)%sname), "C14"
         call this%add_tracer_index(ind_name, 'ciso', this%auto_inds(n)%C14_ind, marbl_status_log)
 
-        if (autotrophs(n)%imp_calcifier .or. &
-            autotrophs(n)%exp_calcifier) then
-        write(ind_name, "(2A)") trim(autotrophs(n)%sname), "Ca13CO3"
+        if (autotroph_settings(n)%imp_calcifier .or. &
+            autotroph_settings(n)%exp_calcifier) then
+        write(ind_name, "(2A)") trim(autotroph_settings(n)%sname), "Ca13CO3"
           call this%add_tracer_index(ind_name, 'ciso', this%auto_inds(n)%Ca13CO3_ind, marbl_status_log)
 
-        write(ind_name, "(2A)") trim(autotrophs(n)%sname), "Ca14CO3"
+        write(ind_name, "(2A)") trim(autotroph_settings(n)%sname), "Ca14CO3"
           call this%add_tracer_index(ind_name, 'ciso', this%auto_inds(n)%Ca14CO3_ind, marbl_status_log)
         end if
       end do

--- a/src/marbl_interface_private_types.F90
+++ b/src/marbl_interface_private_types.F90
@@ -229,16 +229,19 @@ module marbl_interface_private_types
   !*****************************************************************************
 
   type, public :: carbonate_type
-     real (r8) :: CO3           ! carbonate ion
-     real (r8) :: HCO3          ! bicarbonate ion
-     real (r8) :: H2CO3         ! carbonic acid
-     real (r8) :: pH
-     real (r8) :: CO3_sat_calcite
-     real (r8) :: CO3_sat_aragonite
-     real (r8) :: CO3_ALT_CO2   ! carbonate ion, alternative CO2
-     real (r8) :: HCO3_ALT_CO2  ! bicarbonate ion, alternative CO2
-     real (r8) :: H2CO3_ALT_CO2 ! carbonic acid, alternative CO2
-     real (r8) :: pH_ALT_CO2
+     real(r8), allocatable :: CO3(:)           ! carbonate ion
+     real(r8), allocatable :: HCO3(:)          ! bicarbonate ion
+     real(r8), allocatable :: H2CO3(:)         ! carbonic acid
+     real(r8), allocatable :: pH(:)
+     real(r8), allocatable :: CO3_sat_calcite(:)
+     real(r8), allocatable :: CO3_sat_aragonite(:)
+     real(r8), allocatable :: CO3_ALT_CO2(:)   ! carbonate ion, alternative CO2
+     real(r8), allocatable :: HCO3_ALT_CO2(:)  ! bicarbonate ion, alternative CO2
+     real(r8), allocatable :: H2CO3_ALT_CO2(:) ! carbonic acid, alternative CO2
+     real(r8), allocatable :: pH_ALT_CO2(:)
+   contains
+     procedure, public :: construct => carbonate_constructor
+     procedure, public :: destruct  => carbonate_destructor
   end type carbonate_type
 
   !*****************************************************************************
@@ -830,6 +833,45 @@ contains
      call this%dust%destruct()
 
    end subroutine marbl_particulate_share_destructor
+
+   !***********************************************************************
+
+    subroutine carbonate_constructor(this, num_levels)
+
+      class(carbonate_type), intent(inout) :: this
+      integer (int_kind),    intent(in)    :: num_levels
+
+      allocate(this%CO3(num_levels))
+      allocate(this%HCO3(num_levels))
+      allocate(this%H2CO3(num_levels))
+      allocate(this%pH(num_levels))
+      allocate(this%CO3_sat_calcite(num_levels))
+      allocate(this%CO3_sat_aragonite(num_levels))
+      allocate(this%CO3_ALT_CO2(num_levels))
+      allocate(this%HCO3_ALT_CO2(num_levels))
+      allocate(this%H2CO3_ALT_CO2(num_levels))
+      allocate(this%pH_ALT_CO2(num_levels))
+
+    end subroutine carbonate_constructor
+
+    !***********************************************************************
+
+     subroutine carbonate_destructor(this)
+
+       class(carbonate_type), intent(inout) :: this
+
+       deallocate(this%CO3)
+       deallocate(this%HCO3)
+       deallocate(this%H2CO3)
+       deallocate(this%pH)
+       deallocate(this%CO3_sat_calcite)
+       deallocate(this%CO3_sat_aragonite)
+       deallocate(this%CO3_ALT_CO2)
+       deallocate(this%HCO3_ALT_CO2)
+       deallocate(this%H2CO3_ALT_CO2)
+       deallocate(this%pH_ALT_CO2)
+
+     end subroutine carbonate_destructor
 
    !***********************************************************************
 

--- a/src/marbl_interface_private_types.F90
+++ b/src/marbl_interface_private_types.F90
@@ -852,7 +852,7 @@ contains
 
      subroutine dissolved_organic_matter_destructor(this)
 
-       class(dissolved_organic_matter_type), intent(out) :: this
+       class(dissolved_organic_matter_type), intent(inout) :: this
 
        deallocate(this%DOC_prod)
        deallocate(this%DOC_remin)

--- a/src/marbl_interface_private_types.F90
+++ b/src/marbl_interface_private_types.F90
@@ -1156,7 +1156,7 @@ contains
   !*****************************************************************************
 
   subroutine tracer_index_constructor(this, ciso_on, lvariable_PtoC, autotroph_settings, &
-             zooplankton, marbl_status_log)
+             zooplankton_settings, marbl_status_log)
 
     ! This subroutine sets the tracer indices for the non-autotroph tracers. To
     ! know where to start the indexing for the autotroph tracers, it increments
@@ -1164,21 +1164,21 @@ contains
     ! accurate count whether the carbon isotope tracers are included or not.
 
     use marbl_pft_mod, only : autotroph_settings_type
-    use marbl_pft_mod, only : zooplankton_type
+    use marbl_pft_mod, only : zooplankton_settings_type
 
-    class(marbl_tracer_index_type), intent(out)   :: this
-    logical,                        intent(in)    :: ciso_on
-    logical,                        intent(in)    :: lvariable_PtoC
-    type(autotroph_settings_type),  intent(in)    :: autotroph_settings(:)
-    type(zooplankton_type),         intent(in)    :: zooplankton(:)
-    type(marbl_log_type),           intent(inout) :: marbl_status_log
+    class(marbl_tracer_index_type),  intent(out)   :: this
+    logical,                         intent(in)    :: ciso_on
+    logical,                         intent(in)    :: lvariable_PtoC
+    type(autotroph_settings_type),   intent(in)    :: autotroph_settings(:)
+    type(zooplankton_settings_type), intent(in)    :: zooplankton_settings(:)
+    type(marbl_log_type),            intent(inout) :: marbl_status_log
 
     character(len=*), parameter :: subname = 'marbl_interface_private_types:tracer_index_constructor'
     character(len=char_len) :: ind_name
     integer :: autotroph_cnt, zooplankton_cnt, n
 
     autotroph_cnt = size(autotroph_settings)
-    zooplankton_cnt = size(zooplankton)
+    zooplankton_cnt = size(zooplankton_settings)
 
     !Allocate memory
     allocate(this%auto_inds(autotroph_cnt))
@@ -1204,7 +1204,7 @@ contains
     call this%add_tracer_index('docr', 'ecosys_base', this%docr_ind, marbl_status_log)
 
     do n=1,zooplankton_cnt
-      write(ind_name, "(2A)") trim(zooplankton(n)%sname), "C"
+      write(ind_name, "(2A)") trim(zooplankton_settings(n)%sname), "C"
       call this%add_tracer_index(ind_name, 'ecosys_base', this%zoo_inds(n)%C_ind, marbl_status_log)
     end do
 

--- a/src/marbl_interface_private_types.F90
+++ b/src/marbl_interface_private_types.F90
@@ -241,16 +241,19 @@ module marbl_interface_private_types
   !*****************************************************************************
 
   type, public :: dissolved_organic_matter_type
-     real (r8) :: DOC_prod         ! production of DOC (mmol C/m^3/sec)
-     real (r8) :: DOC_remin        ! remineralization of DOC (mmol C/m^3/sec)
-     real (r8) :: DOCr_remin       ! remineralization of DOCr
-     real (r8) :: DON_prod         ! production of DON
-     real (r8) :: DON_remin        ! remineralization of DON
-     real (r8) :: DONr_remin       ! remineralization of DONr
-     real (r8) :: DOP_prod         ! production of DOP
-     real (r8) :: DOP_remin        ! remineralization of DOP
-     real (r8) :: DOPr_remin       ! remineralization of DOPr
-     real (r8) :: DOP_loss_P_bal   ! DOP loss, due to P budget balancing
+     real(r8), allocatable :: DOC_prod(:)         ! production of DOC (mmol C/m^3/sec)
+     real(r8), allocatable :: DOC_remin(:)        ! remineralization of DOC (mmol C/m^3/sec)
+     real(r8), allocatable :: DOCr_remin(:)       ! remineralization of DOCr
+     real(r8), allocatable :: DON_prod(:)         ! production of DON
+     real(r8), allocatable :: DON_remin(:)        ! remineralization of DON
+     real(r8), allocatable :: DONr_remin(:)       ! remineralization of DONr
+     real(r8), allocatable :: DOP_prod(:)         ! production of DOP
+     real(r8), allocatable :: DOP_remin(:)        ! remineralization of DOP
+     real(r8), allocatable :: DOPr_remin(:)       ! remineralization of DOPr
+     real(r8), allocatable :: DOP_loss_P_bal(:)   ! DOP loss, due to P budget balancing
+   contains
+     procedure, public :: construct => dissolved_organic_matter_constructor
+     procedure, public :: destruct => dissolved_organic_matter_destructor
   end type dissolved_organic_matter_type
 
   !***********************************************************************
@@ -824,6 +827,45 @@ contains
      call this%dust%destruct()
 
    end subroutine marbl_particulate_share_destructor
+
+   !***********************************************************************
+
+    subroutine dissolved_organic_matter_constructor(this, num_levels)
+
+      class(dissolved_organic_matter_type), intent(inout) :: this
+      integer (int_kind),                   intent(in)    :: num_levels
+
+      allocate(this%DOC_prod(num_levels))
+      allocate(this%DOC_remin(num_levels))
+      allocate(this%DOCr_remin(num_levels))
+      allocate(this%DON_prod(num_levels))
+      allocate(this%DON_remin(num_levels))
+      allocate(this%DONr_remin(num_levels))
+      allocate(this%DOP_prod(num_levels))
+      allocate(this%DOP_remin(num_levels))
+      allocate(this%DOPr_remin(num_levels))
+      allocate(this%DOP_loss_P_bal(num_levels))
+
+    end subroutine dissolved_organic_matter_constructor
+
+    !***********************************************************************
+
+     subroutine dissolved_organic_matter_destructor(this)
+
+       class(dissolved_organic_matter_type), intent(out) :: this
+
+       deallocate(this%DOC_prod)
+       deallocate(this%DOC_remin)
+       deallocate(this%DOCr_remin)
+       deallocate(this%DON_prod)
+       deallocate(this%DON_remin)
+       deallocate(this%DONr_remin)
+       deallocate(this%DOP_prod)
+       deallocate(this%DOP_remin)
+       deallocate(this%DOPr_remin)
+       deallocate(this%DOP_loss_P_bal)
+
+     end subroutine dissolved_organic_matter_destructor
 
   !***********************************************************************
 

--- a/src/marbl_interface_private_types.F90
+++ b/src/marbl_interface_private_types.F90
@@ -33,54 +33,74 @@ module marbl_interface_private_types
   !*****************************************************************************
 
   type, public :: autotroph_secondary_species_type
-     real(r8), allocatable :: thetaC(:,:)          ! current Chl/C ratio (mg Chl/mmol C)
-     real(r8), allocatable :: QCaCO3(:,:)          ! current CaCO3/C ratio (mmol CaCO3/mmol C)
-     real(r8), allocatable :: Qp(:,:)              ! current P/C ratio (mmol P/mmol C)
-     real(r8), allocatable :: gQp(:,:)             ! P/C for growth
-     real(r8), allocatable :: Qfe(:,:)             ! current Fe/C ratio (mmol Fe/mmol C)
-     real(r8), allocatable :: gQfe(:,:)            ! fe/C for growth
-     real(r8), allocatable :: Qsi(:,:)             ! current Si/C ratio (mmol Si/mmol C)
-     real(r8), allocatable :: gQsi(:,:)            ! diatom Si/C ratio for growth (new biomass)
-     real(r8), allocatable :: VNO3(:,:)            ! NH4 uptake rate (non-dim)
-     real(r8), allocatable :: VNH4(:,:)            ! NO3 uptake rate (non-dim)
-     real(r8), allocatable :: VNtot(:,:)           ! total N uptake rate (non-dim)
-     real(r8), allocatable :: NO3_V(:,:)           ! nitrate uptake (mmol NO3/m^3/sec)
-     real(r8), allocatable :: NH4_V(:,:)           ! ammonium uptake (mmol NH4/m^3/sec)
-     real(r8), allocatable :: PO4_V(:,:)           ! PO4 uptake (mmol PO4/m^3/sec)
-     real(r8), allocatable :: DOP_V(:,:)           ! DOP uptake (mmol DOP/m^3/sec)
-     real(r8), allocatable :: VPO4(:,:)            ! C-specific PO4 uptake (non-dim)
-     real(r8), allocatable :: VDOP(:,:)            ! C-specific DOP uptake rate (non-dim)
-     real(r8), allocatable :: VPtot(:,:)           ! total P uptake rate (non-dim)
-     real(r8), allocatable :: f_nut(:,:)           ! nut limitation factor, modifies C fixation (non-dim)
-     real(r8), allocatable :: VFe(:,:)             ! C-specific Fe uptake (non-dim)
-     real(r8), allocatable :: VSiO3(:,:)           ! C-specific SiO3 uptake (non-dim)
-     real(r8), allocatable :: light_lim(:,:)       ! light limitation factor
-     real(r8), allocatable :: PCphoto(:,:)         ! C-specific rate of photosynth. (1/sec)
-     real(r8), allocatable :: photoC(:,:)          ! C-fixation (mmol C/m^3/sec)
-     real(r8), allocatable :: photoFe(:,:)         ! iron uptake
-     real(r8), allocatable :: photoSi(:,:)         ! silicon uptake (mmol Si/m^3/sec)
-     real(r8), allocatable :: photoacc(:,:)        ! Chl synth. term in photoadapt. (GD98) (mg Chl/m^3/sec)
-     real(r8), allocatable :: auto_loss(:,:)       ! autotroph non-grazing mort (mmol C/m^3/sec)
-     real(r8), allocatable :: auto_loss_poc(:,:)   ! auto_loss routed to poc (mmol C/m^3/sec)
-     real(r8), allocatable :: auto_loss_doc(:,:)   ! auto_loss routed to doc (mmol C/m^3/sec)
-     real(r8), allocatable :: auto_loss_dic(:,:)   ! auto_loss routed to dic (mmol C/m^3/sec)
-     real(r8), allocatable :: auto_agg(:,:)        ! autotroph aggregation (mmol C/m^3/sec)
-     real(r8), allocatable :: auto_graze(:,:)      ! autotroph grazing rate (mmol C/m^3/sec)
-     real(r8), allocatable :: auto_graze_zoo(:,:)  ! auto_graze routed to zoo (mmol C/m^3/sec)
-     real(r8), allocatable :: auto_graze_poc(:,:)  ! auto_graze routed to poc (mmol C/m^3/sec)
-     real(r8), allocatable :: auto_graze_doc(:,:)  ! auto_graze routed to doc (mmol C/m^3/sec)
-     real(r8), allocatable :: auto_graze_dic(:,:)  ! auto_graze routed to dic (mmol C/m^3/sec)
-     real(r8), allocatable :: Pprime(:,:)          ! used to limit autotroph mort at low biomass (mmol C/m^3)
-     real(r8), allocatable :: CaCO3_form(:,:)      ! calcification of CaCO3 by small phyto (mmol CaCO3/m^3/sec)
-     real(r8), allocatable :: Nfix(:,:)            ! total Nitrogen fixation (mmol N/m^3/sec)
-     real(r8), allocatable :: Nexcrete(:,:)        ! fixed N excretion
-     real(r8), allocatable :: remaining_P_dop(:,:) ! remaining_P from grazing routed to DOP pool
-     real(r8), allocatable :: remaining_P_pop(:,:) ! remaining_P from grazing routed to POP pool
-     real(r8), allocatable :: remaining_P_dip(:,:) ! remaining_P from grazing routed to remin
+    real(r8), allocatable :: thetaC(:,:)          ! current Chl/C ratio (mg Chl/mmol C)
+    real(r8), allocatable :: QCaCO3(:,:)          ! current CaCO3/C ratio (mmol CaCO3/mmol C)
+    real(r8), allocatable :: Qp(:,:)              ! current P/C ratio (mmol P/mmol C)
+    real(r8), allocatable :: gQp(:,:)             ! P/C for growth
+    real(r8), allocatable :: Qfe(:,:)             ! current Fe/C ratio (mmol Fe/mmol C)
+    real(r8), allocatable :: gQfe(:,:)            ! fe/C for growth
+    real(r8), allocatable :: Qsi(:,:)             ! current Si/C ratio (mmol Si/mmol C)
+    real(r8), allocatable :: gQsi(:,:)            ! diatom Si/C ratio for growth (new biomass)
+    real(r8), allocatable :: VNO3(:,:)            ! NH4 uptake rate (non-dim)
+    real(r8), allocatable :: VNH4(:,:)            ! NO3 uptake rate (non-dim)
+    real(r8), allocatable :: VNtot(:,:)           ! total N uptake rate (non-dim)
+    real(r8), allocatable :: NO3_V(:,:)           ! nitrate uptake (mmol NO3/m^3/sec)
+    real(r8), allocatable :: NH4_V(:,:)           ! ammonium uptake (mmol NH4/m^3/sec)
+    real(r8), allocatable :: PO4_V(:,:)           ! PO4 uptake (mmol PO4/m^3/sec)
+    real(r8), allocatable :: DOP_V(:,:)           ! DOP uptake (mmol DOP/m^3/sec)
+    real(r8), allocatable :: VPO4(:,:)            ! C-specific PO4 uptake (non-dim)
+    real(r8), allocatable :: VDOP(:,:)            ! C-specific DOP uptake rate (non-dim)
+    real(r8), allocatable :: VPtot(:,:)           ! total P uptake rate (non-dim)
+    real(r8), allocatable :: f_nut(:,:)           ! nut limitation factor, modifies C fixation (non-dim)
+    real(r8), allocatable :: VFe(:,:)             ! C-specific Fe uptake (non-dim)
+    real(r8), allocatable :: VSiO3(:,:)           ! C-specific SiO3 uptake (non-dim)
+    real(r8), allocatable :: light_lim(:,:)       ! light limitation factor
+    real(r8), allocatable :: PCphoto(:,:)         ! C-specific rate of photosynth. (1/sec)
+    real(r8), allocatable :: photoC(:,:)          ! C-fixation (mmol C/m^3/sec)
+    real(r8), allocatable :: photoFe(:,:)         ! iron uptake
+    real(r8), allocatable :: photoSi(:,:)         ! silicon uptake (mmol Si/m^3/sec)
+    real(r8), allocatable :: photoacc(:,:)        ! Chl synth. term in photoadapt. (GD98) (mg Chl/m^3/sec)
+    real(r8), allocatable :: auto_loss(:,:)       ! autotroph non-grazing mort (mmol C/m^3/sec)
+    real(r8), allocatable :: auto_loss_poc(:,:)   ! auto_loss routed to poc (mmol C/m^3/sec)
+    real(r8), allocatable :: auto_loss_doc(:,:)   ! auto_loss routed to doc (mmol C/m^3/sec)
+    real(r8), allocatable :: auto_loss_dic(:,:)   ! auto_loss routed to dic (mmol C/m^3/sec)
+    real(r8), allocatable :: auto_agg(:,:)        ! autotroph aggregation (mmol C/m^3/sec)
+    real(r8), allocatable :: auto_graze(:,:)      ! autotroph grazing rate (mmol C/m^3/sec)
+    real(r8), allocatable :: auto_graze_zoo(:,:)  ! auto_graze routed to zoo (mmol C/m^3/sec)
+    real(r8), allocatable :: auto_graze_poc(:,:)  ! auto_graze routed to poc (mmol C/m^3/sec)
+    real(r8), allocatable :: auto_graze_doc(:,:)  ! auto_graze routed to doc (mmol C/m^3/sec)
+    real(r8), allocatable :: auto_graze_dic(:,:)  ! auto_graze routed to dic (mmol C/m^3/sec)
+    real(r8), allocatable :: Pprime(:,:)          ! used to limit autotroph mort at low biomass (mmol C/m^3)
+    real(r8), allocatable :: CaCO3_form(:,:)      ! calcification of CaCO3 by small phyto (mmol CaCO3/m^3/sec)
+    real(r8), allocatable :: Nfix(:,:)            ! total Nitrogen fixation (mmol N/m^3/sec)
+    real(r8), allocatable :: Nexcrete(:,:)        ! fixed N excretion
+    real(r8), allocatable :: remaining_P_dop(:,:) ! remaining_P from grazing routed to DOP pool
+    real(r8), allocatable :: remaining_P_pop(:,:) ! remaining_P from grazing routed to POP pool
+    real(r8), allocatable :: remaining_P_dip(:,:) ! remaining_P from grazing routed to remin
   contains
-     procedure, public :: construct => autotroph_secondary_species_constructor
-     procedure, public :: destruct => autotroph_secondary_species_destructor
+    procedure, public :: construct => autotroph_secondary_species_constructor
+    procedure, public :: destruct => autotroph_secondary_species_destructor
   end type autotroph_secondary_species_type
+
+  !*****************************************************************************
+
+  type, public :: zooplankton_secondary_species_type
+    real(r8), allocatable :: f_zoo_detr(:,:)       ! frac of zoo losses into large detrital pool (non-dim)
+    real(r8), allocatable :: x_graze_zoo(:,:)      ! {auto, zoo}_graze routed to zoo (mmol C/m^3/sec)
+    real(r8), allocatable :: zoo_graze(:,:)        ! zooplankton losses due to grazing (mmol C/m^3/sec)
+    real(r8), allocatable :: zoo_graze_zoo(:,:)    ! grazing of zooplankton routed to zoo (mmol C/m^3/sec)
+    real(r8), allocatable :: zoo_graze_poc(:,:)    ! grazing of zooplankton routed to poc (mmol C/m^3/sec)
+    real(r8), allocatable :: zoo_graze_doc(:,:)    ! grazing of zooplankton routed to doc (mmol C/m^3/sec)
+    real(r8), allocatable :: zoo_graze_dic(:,:)    ! grazing of zooplankton routed to dic (mmol C/m^3/sec)
+    real(r8), allocatable :: zoo_loss(:,:)         ! mortality & higher trophic grazing on zooplankton (mmol C/m^3/sec)
+    real(r8), allocatable :: zoo_loss_poc(:,:)     ! zoo_loss routed to poc (mmol C/m^3/sec)
+    real(r8), allocatable :: zoo_loss_doc(:,:)     ! zoo_loss routed to doc (mmol C/m^3/sec)
+    real(r8), allocatable :: zoo_loss_dic(:,:)     ! zoo_loss routed to dic (mmol C/m^3/sec)
+    real(r8), allocatable :: Zprime(:,:)           ! used to limit zoo mort at low biomass (mmol C/m^3)
+  contains
+    procedure, public :: construct => zooplankton_secondary_species_constructor
+    procedure, public :: destruct => zooplankton_secondary_species_destructor
+  end type zooplankton_secondary_species_type
 
   !****************************************************************************
 
@@ -944,6 +964,50 @@ contains
     deallocate(self%remaining_P_dip)
 
   end subroutine autotroph_secondary_species_destructor
+
+  !***********************************************************************
+
+  subroutine zooplankton_secondary_species_constructor(self, zooplankton_cnt, km)
+
+    class(zooplankton_secondary_species_type), intent(inout) :: self
+    integer,                                   intent(in)    :: zooplankton_cnt
+    integer,                                   intent(in)    :: km
+
+    allocate(self%f_zoo_detr(zooplankton_cnt, km))
+    allocate(self%x_graze_zoo(zooplankton_cnt, km))
+    allocate(self%zoo_graze(zooplankton_cnt, km))
+    allocate(self%zoo_graze_zoo(zooplankton_cnt, km))
+    allocate(self%zoo_graze_poc(zooplankton_cnt, km))
+    allocate(self%zoo_graze_doc(zooplankton_cnt, km))
+    allocate(self%zoo_graze_dic(zooplankton_cnt, km))
+    allocate(self%zoo_loss(zooplankton_cnt, km))
+    allocate(self%zoo_loss_poc(zooplankton_cnt, km))
+    allocate(self%zoo_loss_doc(zooplankton_cnt, km))
+    allocate(self%zoo_loss_dic(zooplankton_cnt, km))
+    allocate(self%Zprime(zooplankton_cnt, km))
+
+  end subroutine zooplankton_secondary_species_constructor
+
+  !***********************************************************************
+
+  subroutine zooplankton_secondary_species_destructor(self)
+
+    class(zooplankton_secondary_species_type), intent(inout) :: self
+
+    deallocate(self%f_zoo_detr)
+    deallocate(self%x_graze_zoo)
+    deallocate(self%zoo_graze)
+    deallocate(self%zoo_graze_zoo)
+    deallocate(self%zoo_graze_poc)
+    deallocate(self%zoo_graze_doc)
+    deallocate(self%zoo_graze_dic)
+    deallocate(self%zoo_loss)
+    deallocate(self%zoo_loss_poc)
+    deallocate(self%zoo_loss_doc)
+    deallocate(self%zoo_loss_dic)
+    deallocate(self%Zprime)
+
+  end subroutine zooplankton_secondary_species_destructor
 
   !*****************************************************************************
 

--- a/src/marbl_interior_tendency_mod.F90
+++ b/src/marbl_interior_tendency_mod.F90
@@ -1321,7 +1321,6 @@ contains
          ! current Chl/C ratio (mg Chl / mmol C)
          thetaC    => autotroph_derived_terms%thetaC(:,:),    &
          f_nut     => autotroph_derived_terms%f_nut(:,:),     &
-         VNtot     => autotroph_derived_terms%VNtot(:,:),     &
          light_lim => autotroph_derived_terms%light_lim(:,:), &
          PCPhoto   => autotroph_derived_terms%PCPhoto(:,:),   &
          photoC    => autotroph_derived_terms%photoC(:,:),    &

--- a/src/marbl_interior_tendency_mod.F90
+++ b/src/marbl_interior_tendency_mod.F90
@@ -326,9 +326,9 @@ contains
 
     call compute_autotroph_calcification(km, autotroph_local, temperature, autotroph_derived_terms)
 
-    do k = 1, km
+    call compute_autotroph_nfixation(km, autotroph_derived_terms)
 
-       call compute_autotroph_nfixation(k, autotroph_derived_terms)
+    do k = 1, km
 
        call compute_autotroph_loss(k, Tfunc(k), autotroph_derived_terms)
 
@@ -1517,44 +1517,48 @@ contains
 
   !***********************************************************************
 
-   subroutine compute_autotroph_nfixation(k, autotroph_derived_terms)
+  subroutine compute_autotroph_nfixation(km, autotroph_derived_terms)
 
-     !-----------------------------------------------------------------------
-     !  Get N fixation by diazotrophs based on C fixation,
-     !  Diazotrophs fix more than they need then 20% is excreted
-     !-----------------------------------------------------------------------
+    !-----------------------------------------------------------------------
+    !  Get N fixation by diazotrophs based on C fixation,
+    !  Diazotrophs fix more than they need then 20% is excreted
+    !-----------------------------------------------------------------------
 
-     use marbl_settings_mod, only : Q
-     use marbl_settings_mod, only : r_Nfix_photo
+    use marbl_settings_mod, only : Q
+    use marbl_settings_mod, only : r_Nfix_photo
 
-     integer,                            intent(in)    :: k
-     type(autotroph_derived_terms_type), intent(inout) :: autotroph_derived_terms
+    integer,                            intent(in)    :: km
+    type(autotroph_derived_terms_type), intent(inout) :: autotroph_derived_terms
 
-     !-----------------------------------------------------------------------
-     !  local variables
-     !-----------------------------------------------------------------------
-     integer  :: auto_ind
-     real(r8) :: work1
-     !-----------------------------------------------------------------------
+    !-----------------------------------------------------------------------
+    !  local variables
+    !-----------------------------------------------------------------------
+    integer  :: k,auto_ind
+    real(r8) :: work1
+    !-----------------------------------------------------------------------
 
-     associate(                                              &
-          photoC   => autotroph_derived_terms%photoC(:, k),  & ! input
-          NO3_V    => autotroph_derived_terms%NO3_V(:, k),   & ! input
-          NH4_V    => autotroph_derived_terms%NH4_V(:, k),   & ! input
-          Nfix     => autotroph_derived_terms%Nfix(:, k),    & ! output total Nitrogen fixation (mmol N/m^3/sec)
-          Nexcrete => autotroph_derived_terms%Nexcrete(:, k) & ! output fixed N excretion
-          )
+    associate(                                              &
+         photoC   => autotroph_derived_terms%photoC(:, :),  & ! input
+         NO3_V    => autotroph_derived_terms%NO3_V(:, :),   & ! input
+         NH4_V    => autotroph_derived_terms%NH4_V(:, :),   & ! input
+         Nfix     => autotroph_derived_terms%Nfix(:, :),    & ! output total Nitrogen fixation (mmol N/m^3/sec)
+         Nexcrete => autotroph_derived_terms%Nexcrete(:, :) & ! output fixed N excretion
+         )
 
-     do auto_ind = 1, autotroph_cnt
-        if (autotroph_settings(auto_ind)%Nfixer) then
-           work1 = photoC(auto_ind) * Q
-           Nfix(auto_ind) = (work1 * r_Nfix_photo) - NO3_V(auto_ind) - NH4_V(auto_ind)
-           Nexcrete(auto_ind) = Nfix(auto_ind) + NO3_V(auto_ind) + NH4_V(auto_ind) - work1
-        endif
-     end do
+      do k=1,km
+        do auto_ind = 1, autotroph_cnt
+          if (autotroph_settings(auto_ind)%Nfixer) then
+            work1 = photoC(auto_ind,k) * Q
+            Nfix(auto_ind,k) = (work1 * r_Nfix_photo) - NO3_V(auto_ind,k) - NH4_V(auto_ind,k)
+            Nexcrete(auto_ind,k) = Nfix(auto_ind,k) + NO3_V(auto_ind,k) + NH4_V(auto_ind,k) - work1
+          endif
 
-     end associate
-   end subroutine compute_autotroph_nfixation
+        end do
+      end do
+
+    end associate
+
+  end subroutine compute_autotroph_nfixation
 
   !***********************************************************************
 

--- a/src/marbl_interior_tendency_mod.F90
+++ b/src/marbl_interior_tendency_mod.F90
@@ -20,6 +20,7 @@ module marbl_interior_tendency_mod
   use marbl_interface_private_types, only : autotroph_local_type
   use marbl_interface_private_types, only : zooplankton_derived_terms_type
   use marbl_interface_private_types, only : zooplankton_local_type
+  use marbl_interface_private_types, only : zooplankton_share_type
   use marbl_interface_private_types, only : marbl_surface_flux_forcing_indexing_type
   use marbl_interface_private_types, only : marbl_interior_tendency_forcing_indexing_type
   use marbl_interface_private_types, only : marbl_tracer_index_type
@@ -75,7 +76,6 @@ module marbl_interior_tendency_mod
   use marbl_settings_mod, only : phhi_3d_init
   use marbl_settings_mod, only : phlo_3d_init
 
-  use marbl_pft_mod, only : marbl_zooplankton_share_type
   use marbl_pft_mod, only : Qp_zoo
 
   implicit none
@@ -104,6 +104,7 @@ contains
        autotroph_local,                       &
        zooplankton_derived_terms,             &
        zooplankton_local,                     &
+       zooplankton_share,                     &
        saved_state,                           &
        marbl_timers,                          &
        interior_tendency_share,               &
@@ -143,6 +144,7 @@ contains
     type(autotroph_local_type),                              intent(inout) :: autotroph_local
     type(zooplankton_derived_terms_type),                    intent(inout) :: zooplankton_derived_terms
     type(zooplankton_local_type),                            intent(inout) :: zooplankton_local
+    type(zooplankton_share_type),                            intent(inout) :: zooplankton_share
     type(marbl_saved_state_type),                            intent(inout) :: saved_state
     type(marbl_internal_timers_type),                        intent(inout) :: marbl_timers
     type(marbl_interior_tendency_share_type),                intent(inout) :: interior_tendency_share
@@ -159,8 +161,6 @@ contains
 
     real(r8), dimension(size(tracers,1), domain%km) :: interior_restore
     real(r8), dimension(size(tracers,1), domain%km) :: tracer_local
-
-    type(marbl_zooplankton_share_type)       :: marbl_zooplankton_share(domain%km)
 
     integer (int_kind) :: k         ! vertical level index
 
@@ -451,14 +451,14 @@ contains
 
     do k=1, km
        call marbl_interior_tendency_share_export_zooplankton(k, zooplankton_local, &
-            zooplankton_derived_terms, marbl_zooplankton_share(k))
+            zooplankton_derived_terms, zooplankton_share)
     end do ! k
 
     ! call marbl_ciso_interior_tendency_compute()
     call marbl_ciso_interior_tendency_compute(                  &
          marbl_domain            = domain,                      &
          interior_tendency_share = interior_tendency_share,     &
-         marbl_zooplankton_share = marbl_zooplankton_share,     &
+         zooplankton_share = zooplankton_share,                 &
          marbl_particulate_share = marbl_particulate_share,     &
          autotroph_derived_terms = autotroph_derived_terms,     &
          tracer_local            = tracer_local,                &

--- a/src/marbl_interior_tendency_mod.F90
+++ b/src/marbl_interior_tendency_mod.F90
@@ -1382,7 +1382,7 @@ contains
     !-----------------------------------------------------------------------
     !  local variables
     !-----------------------------------------------------------------------
-    integer  :: k, auto_ind
+    integer  :: auto_ind
     !-----------------------------------------------------------------------
 
     associate(                                                 &
@@ -1391,24 +1391,22 @@ contains
          CaCO3_form => autotroph_derived_terms%CaCO3_form(:,:) & ! output
          )
 
-      do k=1, km
-        do auto_ind = 1, autotroph_cnt
-          if (autotroph_settings(auto_ind)%imp_calcifier) then
-            CaCO3_form(auto_ind,k) = parm_f_prod_sp_CaCO3 * photoC(auto_ind,k)
-            CaCO3_form(auto_ind,k) = CaCO3_form(auto_ind,k) * f_nut(auto_ind,k) * f_nut(auto_ind,k)
+      do auto_ind = 1, autotroph_cnt
+        if (autotroph_settings(auto_ind)%imp_calcifier) then
+          CaCO3_form(auto_ind,:) = parm_f_prod_sp_CaCO3 * photoC(auto_ind,:)
+          CaCO3_form(auto_ind,:) = CaCO3_form(auto_ind,:) * f_nut(auto_ind,:) * f_nut(auto_ind,:)
 
-            if (temperature(k) < CaCO3_temp_thres1)  then
-              CaCO3_form(auto_ind,k) = CaCO3_form(auto_ind,k) * max((temperature(k) - CaCO3_temp_thres2), c0) / &
-                   (CaCO3_temp_thres1-CaCO3_temp_thres2)
-            end if
+          where (temperature(:) < CaCO3_temp_thres1)
+            CaCO3_form(auto_ind,:) = CaCO3_form(auto_ind,:) * max((temperature(:) - CaCO3_temp_thres2), c0) / &
+                 (CaCO3_temp_thres1-CaCO3_temp_thres2)
+          end where
 
-            if (autotroph_local%C(auto_ind,k) > CaCO3_sp_thres) then
-              CaCO3_form(auto_ind,k) = min((CaCO3_form(auto_ind,k) * autotroph_local%C(auto_ind,k) / CaCO3_sp_thres), &
-                   (f_photosp_CaCO3 * photoC(auto_ind,k)))
-            end if
-          end if
+          where (autotroph_local%C(auto_ind,:) > CaCO3_sp_thres)
+            CaCO3_form(auto_ind,:) = min((CaCO3_form(auto_ind,:) * autotroph_local%C(auto_ind,:) / CaCO3_sp_thres), &
+                 (f_photosp_CaCO3 * photoC(auto_ind,:)))
+          end where
+        end if
 
-        end do
       end do
 
     end associate

--- a/src/marbl_interior_tendency_mod.F90
+++ b/src/marbl_interior_tendency_mod.F90
@@ -324,7 +324,7 @@ contains
 
     do k = 1, km
 
-       call compute_autotroph_phyto_diatoms(k, marbl_tracer_indices, autotroph_derived_terms)
+       call compute_autotroph_nutrient_uptake(k, marbl_tracer_indices, autotroph_derived_terms)
 
        call compute_autotroph_calcification(k, autotroph_local, temperature(k), &
             autotroph_derived_terms)
@@ -1555,7 +1555,7 @@ contains
 
    !***********************************************************************
 
-   subroutine compute_autotroph_phyto_diatoms(k, marbl_tracer_indices, autotroph_derived_terms)
+   subroutine compute_autotroph_nutrient_uptake(k, marbl_tracer_indices, autotroph_derived_terms)
 
      !-----------------------------------------------------------------------
      !  Get nutrient uptakes by small phyto based on calculated C fixation
@@ -1624,7 +1624,7 @@ contains
 
      end associate
 
-   end subroutine compute_autotroph_phyto_diatoms
+   end subroutine compute_autotroph_nutrient_uptake
 
    !***********************************************************************
 

--- a/src/marbl_interior_tendency_mod.F90
+++ b/src/marbl_interior_tendency_mod.F90
@@ -287,9 +287,8 @@ contains
     !  create local copies of model tracers
     !-----------------------------------------------------------------------
 
-    call setup_local_tracers(kmt, marbl_tracer_indices, &
-         tracers(:,:), tracer_local(:,:), zooplankton_local(:,:), &
-         autotroph_local, totalChl_local)
+    call setup_local_tracers(kmt, marbl_tracer_indices, tracers(:,:), autotroph_local, &
+         tracer_local(:,:), zooplankton_local(:,:), totalChl_local)
 
     call set_surface_particulate_terms(surface_flux_forcing_indices, POC, POP, P_CaCO3, &
          P_CaCO3_ALT_CO2, P_SiO2, dust, P_iron, QA_dust_def(:), dust_flux_in)
@@ -698,20 +697,20 @@ contains
    !***********************************************************************
 
    subroutine setup_local_tracers(column_kmt, marbl_tracer_indices, tracers, &
-              tracer_local, zooplankton_local, autotroph_local, totalChl_local)
+              autotroph_local, tracer_local, zooplankton_local, totalChl_local)
 
      !-----------------------------------------------------------------------
      !  create local copies of model tracers
      !  treat negative values as zero,  apply mask to local copies
      !-----------------------------------------------------------------------
 
-     integer(int_kind)            , intent(in)  :: column_kmt
-     type(marbl_tracer_index_type), intent(in)  :: marbl_tracer_indices
-     real (r8)                    , intent(in)  :: tracers(:,:)
-     real (r8)                    , intent(out) :: tracer_local(:,:)
-     type(zooplankton_local_type) , intent(out) :: zooplankton_local(:,:)
-     type(autotroph_local_type)   , intent(out) :: autotroph_local
-     real (r8)                    , intent(out) :: totalChl_local(:)
+     integer(int_kind)            , intent(in)    :: column_kmt
+     type(marbl_tracer_index_type), intent(in)    :: marbl_tracer_indices
+     real (r8)                    , intent(in)    :: tracers(:,:)
+     type(autotroph_local_type)   , intent(inout) :: autotroph_local
+     real (r8)                    , intent(out)   :: tracer_local(:,:)
+     type(zooplankton_local_type) , intent(out)   :: zooplankton_local(:,:)
+     real (r8)                    , intent(out)   :: totalChl_local(:)
 
      !-----------------------------------------------------------------------
      !  local variables

--- a/src/marbl_interior_tendency_mod.F90
+++ b/src/marbl_interior_tendency_mod.F90
@@ -1624,7 +1624,7 @@ contains
     !-----------------------------------------------------------------------
     !  local variables
     !-----------------------------------------------------------------------
-    integer  :: k, auto_ind
+    integer  :: auto_ind
     !-----------------------------------------------------------------------
 
     associate(                                                         &
@@ -1637,34 +1637,32 @@ contains
          auto_agg      => autotroph_derived_terms%auto_agg(:, :)       & ! output
          )
 
-      do k=1,km
-        do auto_ind = 1, autotroph_cnt
-          !-----------------------------------------------------------------------
-          !  get autotroph loss (in C units)
-          !  autotroph agg loss
-          !-----------------------------------------------------------------------
+      do auto_ind = 1, autotroph_cnt
+        !-----------------------------------------------------------------------
+        !  get autotroph loss (in C units)
+        !  autotroph agg loss
+        !-----------------------------------------------------------------------
 
-          auto_loss(auto_ind,k) = autotroph_settings(auto_ind)%mort * Pprime(auto_ind,k) * Tfunc(k)
+        auto_loss(auto_ind,:) = autotroph_settings(auto_ind)%mort * Pprime(auto_ind,:) * Tfunc(:)
 
-          auto_agg(auto_ind,k) = min((autotroph_settings(auto_ind)%agg_rate_max * dps) * Pprime(auto_ind,k), &
-                                     autotroph_settings(auto_ind)%mort2 * Pprime(auto_ind,k)**1.75_r8)
-          auto_agg(auto_ind,k) = max((autotroph_settings(auto_ind)%agg_rate_min * dps) * Pprime(auto_ind,k), &
-                                     auto_agg(auto_ind,k))
+        auto_agg(auto_ind,:) = min((autotroph_settings(auto_ind)%agg_rate_max * dps) * Pprime(auto_ind,:), &
+                                   autotroph_settings(auto_ind)%mort2 * Pprime(auto_ind,:)**1.75_r8)
+        auto_agg(auto_ind,:) = max((autotroph_settings(auto_ind)%agg_rate_min * dps) * Pprime(auto_ind,:), &
+                                   auto_agg(auto_ind,:))
 
-          !-----------------------------------------------------------------------
-          !  routing of loss terms
-          !  all aggregation goes to POM
-          !  min.%C routed from sp_loss = 0.59 * QCaCO3, or P_CaCO3%rho
-          !-----------------------------------------------------------------------
+        !-----------------------------------------------------------------------
+        !  routing of loss terms
+        !  all aggregation goes to POM
+        !  min.%C routed from sp_loss = 0.59 * QCaCO3, or P_CaCO3%rho
+        !-----------------------------------------------------------------------
 
-          if (autotroph_settings(auto_ind)%imp_calcifier) then
-            auto_loss_poc(auto_ind,k) = QCaCO3(auto_ind,k) * auto_loss(auto_ind,k)
-          else
-            auto_loss_poc(auto_ind,k) = autotroph_settings(auto_ind)%loss_poc * auto_loss(auto_ind,k)
-          endif
-          auto_loss_doc(auto_ind,k) = (c1 - parm_labile_ratio) * (auto_loss(auto_ind,k) - auto_loss_poc(auto_ind,k))
-          auto_loss_dic(auto_ind,k) = parm_labile_ratio * (auto_loss(auto_ind,k) - auto_loss_poc(auto_ind,k))
-        end do  ! auto_ind = 1, autotroph_cnt
+        if (autotroph_settings(auto_ind)%imp_calcifier) then
+          auto_loss_poc(auto_ind,:) = QCaCO3(auto_ind,:) * auto_loss(auto_ind,:)
+        else
+          auto_loss_poc(auto_ind,:) = autotroph_settings(auto_ind)%loss_poc * auto_loss(auto_ind,:)
+        endif
+        auto_loss_doc(auto_ind,:) = (c1 - parm_labile_ratio) * (auto_loss(auto_ind,:) - auto_loss_poc(auto_ind,:))
+        auto_loss_dic(auto_ind,:) = parm_labile_ratio * (auto_loss(auto_ind,:) - auto_loss_poc(auto_ind,:))
       end do
 
     end associate

--- a/src/marbl_interior_tendency_mod.F90
+++ b/src/marbl_interior_tendency_mod.F90
@@ -338,11 +338,13 @@ contains
 
     call compute_routing(km, zooplankton_derived_terms, autotroph_derived_terms)
 
-    call compute_dissolved_organic_matter (km, marbl_tracer_indices, num_PAR_subcols, &
-         PAR, zooplankton_derived_terms, autotroph_derived_terms,   &
-         delta_z1, tracer_local(:, :), dissolved_organic_matter)
-
     do k = 1, km
+
+       call compute_dissolved_organic_matter (k, num_PAR_subcols, &
+            zooplankton_derived_terms, autotroph_derived_terms,   &
+            PAR%col_frac(:), PAR%interface(k-1,:), PAR%avg(k,:),  &
+            delta_z1, tracer_local(:, k), marbl_tracer_indices,   &
+            dissolved_organic_matter)
 
        call compute_scavenging(k, km, marbl_tracer_indices, tracer_local(:,:), &
             POC, P_CaCO3, P_SiO2, dust, Fefree(:), Fe_scavenge_rate(:), &
@@ -2036,10 +2038,10 @@ contains
 
   !***********************************************************************
 
-  subroutine compute_dissolved_organic_matter (km, marbl_tracer_indices, &
-             PAR_nsubcols, PAR, &
-             zooplankton_derived_terms, autotroph_derived_terms, &
-             dz1, tracer_local, dissolved_organic_matter)
+  subroutine compute_dissolved_organic_matter (k, &
+             PAR_nsubcols, zooplankton_derived_terms, &
+             autotroph_derived_terms, PAR_col_frac, PAR_in, PAR_avg, &
+             dz1, tracer_local, marbl_tracer_indices, dissolved_organic_matter)
 
     use marbl_settings_mod, only : Q
     use marbl_settings_mod, only : DOC_reminR_light
@@ -2053,20 +2055,22 @@ contains
     use marbl_settings_mod, only : DOPr_reminR0
     use marbl_settings_mod, only : DOMr_reminR_photo
 
-    integer(int_kind),                    intent(in)    :: km
-    type(marbl_tracer_index_type),        intent(in)    :: marbl_tracer_indices
+    integer(int_kind),                    intent(in)    :: k
     integer(int_kind),                    intent(in)    :: PAR_nsubcols
-    type(marbl_PAR_type),                 intent(in)    :: PAR
     type(zooplankton_derived_terms_type), intent(in)    :: zooplankton_derived_terms
     type(autotroph_derived_terms_type),   intent(in)    :: autotroph_derived_terms
+    real(r8),                             intent(in)    :: PAR_col_frac(:)
+    real(r8),                             intent(in)    :: PAR_in(:)
+    real(r8),                             intent(in)    :: PAR_avg(:)
     real(r8),                             intent(in)    :: dz1
-    real(r8),                             intent(in)    :: tracer_local(marbl_tracer_indices%total_cnt,km)
+    real(r8),                             intent(in)    :: tracer_local(:)
+    type(marbl_tracer_index_type),        intent(in)    :: marbl_tracer_indices
     type(dissolved_organic_matter_type),  intent(inout) :: dissolved_organic_matter
 
     !-----------------------------------------------------------------------
     !  local variables
     !-----------------------------------------------------------------------
-    integer  :: k, subcol_ind
+    integer  :: subcol_ind
     real(r8) :: work
     real(r8) :: DOC_reminR        ! remineralization rate (1/sec)
     real(r8) :: DON_reminR        ! remineralization rate (1/sec)
@@ -2077,95 +2081,87 @@ contains
     !-----------------------------------------------------------------------
 
     associate(                                                           &
-         DOC_loc         => tracer_local(marbl_tracer_indices%doc_ind,:),  &
-         DON_loc         => tracer_local(marbl_tracer_indices%don_ind,:),  &
-         DOP_loc         => tracer_local(marbl_tracer_indices%dop_ind,:),  &
-         DONr_loc        => tracer_local(marbl_tracer_indices%donr_ind,:), &
-         DOPr_loc        => tracer_local(marbl_tracer_indices%dopr_ind,:), &
-         DOCr_loc        => tracer_local(marbl_tracer_indices%docr_ind,:), &
+         DOC_loc         => tracer_local(marbl_tracer_indices%doc_ind),  &
+         DON_loc         => tracer_local(marbl_tracer_indices%don_ind),  &
+         DOP_loc         => tracer_local(marbl_tracer_indices%dop_ind),  &
+         DONr_loc        => tracer_local(marbl_tracer_indices%donr_ind), &
+         DOPr_loc        => tracer_local(marbl_tracer_indices%dopr_ind), &
+         DOCr_loc        => tracer_local(marbl_tracer_indices%docr_ind), &
 
-         PAR_col_frac    => PAR%col_frac(:),    &
-         PAR_in          => PAR%interface(:,:), &
-         PAR_avg         => PAR%avg(:,:),       &
+         Qfe             => autotroph_derived_terms%Qfe(:,k),             & ! input
+         remaining_P_dop => autotroph_derived_terms%remaining_P_dop(:,k), & ! input
+         auto_loss_doc   => autotroph_derived_terms%auto_loss_doc(:,k),   & ! input
+         auto_graze_doc  => autotroph_derived_terms%auto_graze_doc(:,k),  & ! input
 
-         remaining_P_dop => autotroph_derived_terms%remaining_P_dop(:,:), & ! input
-         auto_loss_doc   => autotroph_derived_terms%auto_loss_doc(:,:),   & ! input
-         auto_graze_doc  => autotroph_derived_terms%auto_graze_doc(:,:),  & ! input
+         zoo_loss_doc    => zooplankton_derived_terms%zoo_loss_doc(:,k),  & ! input
+         zoo_graze_doc   => zooplankton_derived_terms%zoo_graze_doc(:,k), & ! input
 
-         zoo_loss_doc    => zooplankton_derived_terms%zoo_loss_doc(:,:),  & ! input
-         zoo_graze_doc   => zooplankton_derived_terms%zoo_graze_doc(:,:), & ! input
-
-         DOC_prod        => dissolved_organic_matter%DOC_prod(:),   & ! output production of DOC (mmol C/m^3/sec)
-         DOC_remin       => dissolved_organic_matter%DOC_remin(:),  & ! output remineralization of DOC (mmol C/m^3/sec)
-         DOCr_remin      => dissolved_organic_matter%DOCr_remin(:), & ! output remineralization of DOCr
-         DON_prod        => dissolved_organic_matter%DON_prod(:),   & ! output production of DON
-         DON_remin       => dissolved_organic_matter%DON_remin(:),  & ! output remineralization of DON
-         DONr_remin      => dissolved_organic_matter%DONr_remin(:), & ! output remineralization of DONr
-         DOP_prod        => dissolved_organic_matter%DOP_prod(:),   & ! output production of DOP
-         DOP_remin       => dissolved_organic_matter%DOP_remin(:),  & ! output remineralization of DOP
-         DOPr_remin      => dissolved_organic_matter%DOPr_remin(:)  & ! output remineralization of DOPr
+         DOC_prod        => dissolved_organic_matter%DOC_prod(k),   & ! output production of DOC (mmol C/m^3/sec)
+         DOC_remin       => dissolved_organic_matter%DOC_remin(k),  & ! output remineralization of DOC (mmol C/m^3/sec)
+         DOCr_remin      => dissolved_organic_matter%DOCr_remin(k), & ! output remineralization of DOCr
+         DON_prod        => dissolved_organic_matter%DON_prod(k),   & ! output production of DON
+         DON_remin       => dissolved_organic_matter%DON_remin(k),  & ! output remineralization of DON
+         DONr_remin      => dissolved_organic_matter%DONr_remin(k), & ! output remineralization of DONr
+         DOP_prod        => dissolved_organic_matter%DOP_prod(k),   & ! output production of DOP
+         DOP_remin       => dissolved_organic_matter%DOP_remin(k),  & ! output remineralization of DOP
+         DOPr_remin      => dissolved_organic_matter%DOPr_remin(k)  & ! output remineralization of DOPr
          )
 
       !-----------------------------------------------------------------------
       !  compute terms for DOM
       !-----------------------------------------------------------------------
 
-      DOC_prod(:) = sum(zoo_loss_doc(:,:), dim=1) + sum(auto_loss_doc(:,:), dim=1) &
-                  + sum(auto_graze_doc(:,:), dim=1) + sum(zoo_graze_doc(:,:), dim=1)
-      DON_prod(:) = Q * DOC_prod(:) * f_toDON
-      DOP_prod(:) = Qp_zoo * (sum(zoo_loss_doc(:,:), dim=1) + sum(zoo_graze_doc(:,:), dim=1)) &
-                  + sum(remaining_P_dop(:,:), dim=1)
+      DOC_prod = sum(zoo_loss_doc(:)) + sum(auto_loss_doc(:)) + sum(auto_graze_doc(:)) + sum(zoo_graze_doc(:))
+      DON_prod = Q * DOC_prod * f_toDON
+      DOP_prod = Qp_zoo * (sum(zoo_loss_doc(:)) + sum(zoo_graze_doc(:))) + sum(remaining_P_dop(:))
 
-      do k=1, km
-        !-----------------------------------------------------------------------
-        !  Different remin rates in light and dark for semi-labile pools
-        !-----------------------------------------------------------------------
+      !-----------------------------------------------------------------------
+      !  Different remin rates in light and dark for semi-labile pools
+      !-----------------------------------------------------------------------
 
-        DOC_reminR = c0
-        DON_reminR = c0
-        DOP_reminR = c0
+      DOC_reminR = c0
+      DON_reminR = c0
+      DOP_reminR = c0
 
+      do subcol_ind = 1, PAR_nsubcols
+        if (PAR_col_frac(subcol_ind) > c0) then
+          if (PAR_avg(subcol_ind) > 1.0_r8) then
+            DOC_reminR = DOC_reminR + PAR_col_frac(subcol_ind) * DOC_reminR_light
+            DON_reminR = DON_reminR + PAR_col_frac(subcol_ind) * DON_reminR_light
+            DOP_reminR = DOP_reminR + PAR_col_frac(subcol_ind) * DOP_reminR_light
+          else
+            DOC_reminR = DOC_reminR + PAR_col_frac(subcol_ind) * DOC_reminR_dark
+            DON_reminR = DON_reminR + PAR_col_frac(subcol_ind) * DON_reminR_dark
+            DOP_reminR = DOP_reminR + PAR_col_frac(subcol_ind) * DOP_reminR_dark
+          endif
+        endif
+      end do
+
+      !-----------------------------------------------------------------------
+      !  Refractory remin increased in top layer from photodegradation due to UV
+      !-----------------------------------------------------------------------
+
+      DOCr_reminR = DOCr_reminR0
+      DONr_reminR = DONr_reminR0
+      DOPr_reminR = DOPr_reminR0
+
+      if (k == 1) then
         do subcol_ind = 1, PAR_nsubcols
-          if (PAR_col_frac(subcol_ind) > c0) then
-            if (PAR_avg(k,subcol_ind) > 1.0_r8) then
-              DOC_reminR = DOC_reminR + PAR_col_frac(subcol_ind) * DOC_reminR_light
-              DON_reminR = DON_reminR + PAR_col_frac(subcol_ind) * DON_reminR_light
-              DOP_reminR = DOP_reminR + PAR_col_frac(subcol_ind) * DOP_reminR_light
-            else
-              DOC_reminR = DOC_reminR + PAR_col_frac(subcol_ind) * DOC_reminR_dark
-              DON_reminR = DON_reminR + PAR_col_frac(subcol_ind) * DON_reminR_dark
-              DOP_reminR = DOP_reminR + PAR_col_frac(subcol_ind) * DOP_reminR_dark
-            endif
+          if ((PAR_col_frac(subcol_ind) > c0) .and. (PAR_in(subcol_ind) > 1.0_r8)) then
+            work = PAR_col_frac(subcol_ind) * (log(PAR_in(subcol_ind))*0.4373_r8) * (10.0e2_r8/dz1)
+            DOCr_reminR = DOCr_reminR + work * DOMr_reminR_photo
+            DONr_reminR = DONr_reminR + work * DOMr_reminR_photo
+            DOPr_reminR = DOPr_reminR + work * DOMr_reminR_photo
           endif
         end do
+      endif
 
-        !-----------------------------------------------------------------------
-        !  Refractory remin increased in top layer from photodegradation due to UV
-        !-----------------------------------------------------------------------
-
-        DOCr_reminR = DOCr_reminR0
-        DONr_reminR = DONr_reminR0
-        DOPr_reminR = DOPr_reminR0
-
-        if (k == 1) then
-          do subcol_ind = 1, PAR_nsubcols
-            if ((PAR_col_frac(subcol_ind) > c0) .and. (PAR_in(0, subcol_ind) > 1.0_r8)) then
-              work = PAR_col_frac(subcol_ind) * (log(PAR_in(0, subcol_ind))*0.4373_r8) * (10.0e2_r8/dz1)
-              DOCr_reminR = DOCr_reminR + work * DOMr_reminR_photo
-              DONr_reminR = DONr_reminR + work * DOMr_reminR_photo
-              DOPr_reminR = DOPr_reminR + work * DOMr_reminR_photo
-            endif
-          end do
-        endif
-
-        DOC_remin(k)  = DOC_loc(k)  * DOC_reminR
-        DON_remin(k)  = DON_loc(k)  * DON_reminR
-        DOP_remin(k)  = DOP_loc(k)  * DOP_reminR
-        DOCr_remin(k) = DOCr_loc(k) * DOCr_reminR
-        DONr_remin(k) = DONr_loc(k) * DONr_reminR
-        DOPr_remin(k) = DOPr_loc(k) * DOPr_reminR
-
-      end do
+      DOC_remin  = DOC_loc  * DOC_reminR
+      DON_remin  = DON_loc  * DON_reminR
+      DOP_remin  = DOP_loc  * DOP_reminR
+      DOCr_remin = DOCr_loc * DOCr_reminR
+      DONr_remin = DONr_loc * DONr_reminR
+      DOPr_remin = DOPr_loc * DOPr_reminR
 
     end associate
 

--- a/src/marbl_interior_tendency_mod.F90
+++ b/src/marbl_interior_tendency_mod.F90
@@ -41,7 +41,7 @@ module marbl_interior_tendency_mod
   use marbl_settings_mod, only : lsource_sink
   use marbl_settings_mod, only : ladjust_bury_coeff
   use marbl_settings_mod, only : autotroph_settings
-  use marbl_settings_mod, only : zooplankton
+  use marbl_settings_mod, only : zooplankton_settings
   use marbl_settings_mod, only : dust_to_Fe
   use marbl_settings_mod, only : denitrif_C_N
   use marbl_settings_mod, only : parm_Red_Fe_C
@@ -68,7 +68,7 @@ module marbl_interior_tendency_mod
   use marbl_settings_mod, only : QCaCO3_max
   use marbl_settings_mod, only : Qfe_zoo
   use marbl_settings_mod, only : spc_poc_fac
-  use marbl_settings_mod, only : grazing
+  use marbl_settings_mod, only : grazer_settings
   use marbl_settings_mod, only : PON_bury_coeff
   use marbl_settings_mod, only : del_ph
   use marbl_settings_mod, only : phhi_3d_init
@@ -1736,11 +1736,11 @@ contains
      endif
 
      do zoo_ind = 1, zooplankton_cnt
-        C_loss_thres = f_loss_thres * zooplankton(zoo_ind)%loss_thres
+        C_loss_thres = f_loss_thres * zooplankton_settings(zoo_ind)%loss_thres
         Zprime(zoo_ind) = max(zooC(zoo_ind) - C_loss_thres, c0)
 
-        zoo_loss(zoo_ind) = ( zooplankton(zoo_ind)%z_mort2_0 * Zprime(zoo_ind)**1.5_r8 + &
-             zooplankton(zoo_ind)%z_mort_0  * Zprime(zoo_ind)) * Tfunc
+        zoo_loss(zoo_ind) = ( zooplankton_settings(zoo_ind)%z_mort2_0 * Zprime(zoo_ind)**1.5_r8 + &
+             zooplankton_settings(zoo_ind)%z_mort_0  * Zprime(zoo_ind)) * Tfunc
      end do
 
      end associate
@@ -1828,32 +1828,32 @@ contains
            !  compute sum of carbon in the grazee class, both autotrophs and zoop
            !-----------------------------------------------------------------------
            work1 = c0 ! biomass in prey class prey_ind
-           do auto_ind2 = 1, grazing(prey_ind, pred_ind)%auto_ind_cnt
-              auto_ind = grazing(prey_ind, pred_ind)%auto_ind(auto_ind2)
+           do auto_ind2 = 1, grazer_settings(prey_ind, pred_ind)%auto_ind_cnt
+              auto_ind = grazer_settings(prey_ind, pred_ind)%auto_ind(auto_ind2)
               work1 = work1 + Pprime(auto_ind)
            end do
 
-           do zoo_ind2 = 1, grazing(prey_ind, pred_ind)%zoo_ind_cnt
-              zoo_ind = grazing(prey_ind, pred_ind)%zoo_ind(zoo_ind2)
+           do zoo_ind2 = 1, grazer_settings(prey_ind, pred_ind)%zoo_ind_cnt
+              zoo_ind = grazer_settings(prey_ind, pred_ind)%zoo_ind(zoo_ind2)
               work1 = work1 + Zprime(zoo_ind)
            end do
 
            ! compute grazing rate
            graze_rate = c0
-           select case (grazing(prey_ind, pred_ind)%grazing_function)
+           select case (grazer_settings(prey_ind, pred_ind)%grazing_function)
 
            case (grz_fnc_michaelis_menten)
 
               if (work1 > c0) then
-                 graze_rate = grazing(prey_ind, pred_ind)%z_umax_0 * Tfunc * zooplankton_loc(pred_ind)%C &
-                      * ( work1 / (work1 + grazing(prey_ind, pred_ind)%z_grz) )
+                 graze_rate = grazer_settings(prey_ind, pred_ind)%z_umax_0 * Tfunc * zooplankton_loc(pred_ind)%C &
+                      * ( work1 / (work1 + grazer_settings(prey_ind, pred_ind)%z_grz) )
               end if
 
            case (grz_fnc_sigmoidal)
 
               if (work1 > c0) then
-                 graze_rate = grazing(prey_ind, pred_ind)%z_umax_0 * Tfunc * zooplankton_loc(pred_ind)%C &
-                      * ( work1**2 / (work1**2 + grazing(prey_ind, pred_ind)%z_grz**2) )
+                 graze_rate = grazer_settings(prey_ind, pred_ind)%z_umax_0 * Tfunc * zooplankton_loc(pred_ind)%C &
+                      * ( work1**2 / (work1**2 + grazer_settings(prey_ind, pred_ind)%z_grz**2) )
               end if
 
            end select
@@ -1862,8 +1862,8 @@ contains
            !  autotroph prey
            !-----------------------------------------------------------------------
 
-           do auto_ind2 = 1, grazing(prey_ind, pred_ind)%auto_ind_cnt
-              auto_ind = grazing(prey_ind, pred_ind)%auto_ind(auto_ind2)
+           do auto_ind2 = 1, grazer_settings(prey_ind, pred_ind)%auto_ind_cnt
+              auto_ind = grazer_settings(prey_ind, pred_ind)%auto_ind(auto_ind2)
 
               ! scale by biomass from autotroph pool
               if (work1 > c0) then
@@ -1874,8 +1874,8 @@ contains
               auto_graze(auto_ind) = auto_graze(auto_ind) + work2
 
               ! routed to zooplankton
-              auto_graze_zoo(auto_ind) = auto_graze_zoo(auto_ind) + grazing(prey_ind, pred_ind)%graze_zoo * work2
-              x_graze_zoo(pred_ind)    = x_graze_zoo(pred_ind)    + grazing(prey_ind, pred_ind)%graze_zoo * work2
+              auto_graze_zoo(auto_ind) = auto_graze_zoo(auto_ind) + grazer_settings(prey_ind, pred_ind)%graze_zoo * work2
+              x_graze_zoo(pred_ind)    = x_graze_zoo(pred_ind)    + grazer_settings(prey_ind, pred_ind)%graze_zoo * work2
 
               ! routed to POC
               if (autotroph_settings(auto_ind)%imp_calcifier) then
@@ -1884,14 +1884,14 @@ contains
                       min(spc_poc_fac * (Pprime(auto_ind)+0.6_r8)**1.6_r8,    &
                       f_graze_sp_poc_lim))
               else
-                 auto_graze_poc(auto_ind) = auto_graze_poc(auto_ind) + grazing(prey_ind, pred_ind)%graze_poc * work2
+                 auto_graze_poc(auto_ind) = auto_graze_poc(auto_ind) + grazer_settings(prey_ind, pred_ind)%graze_poc * work2
               endif
 
               ! routed to DOC
-              auto_graze_doc(auto_ind) = auto_graze_doc(auto_ind) + grazing(prey_ind, pred_ind)%graze_doc * work2
+              auto_graze_doc(auto_ind) = auto_graze_doc(auto_ind) + grazer_settings(prey_ind, pred_ind)%graze_doc * work2
 
               !  get fractional factor for routing of zoo losses, based on food supply
-              work3 = work3 + grazing(prey_ind, pred_ind)%f_zoo_detr * (work2 + epsC * epsTinv)
+              work3 = work3 + grazer_settings(prey_ind, pred_ind)%f_zoo_detr * (work2 + epsC * epsTinv)
               work4 = work4 + (work2 + epsC * epsTinv)
 
            end do
@@ -1899,8 +1899,8 @@ contains
            !-----------------------------------------------------------------------
            !  Zooplankton prey
            !-----------------------------------------------------------------------
-           do zoo_ind2 = 1, grazing(prey_ind, pred_ind)%zoo_ind_cnt
-              zoo_ind = grazing(prey_ind, pred_ind)%zoo_ind(zoo_ind2)
+           do zoo_ind2 = 1, grazer_settings(prey_ind, pred_ind)%zoo_ind_cnt
+              zoo_ind = grazer_settings(prey_ind, pred_ind)%zoo_ind(zoo_ind2)
 
               ! scale by biomass from zooplankton pool
               if (work1 > c0) then
@@ -1913,15 +1913,15 @@ contains
               zoo_graze(zoo_ind) = zoo_graze(zoo_ind) + work2
 
               ! routed to zooplankton
-              zoo_graze_zoo(zoo_ind) = zoo_graze_zoo(zoo_ind) + grazing(prey_ind, pred_ind)%graze_zoo * work2
-              x_graze_zoo(pred_ind) = x_graze_zoo(pred_ind)   + grazing(prey_ind, pred_ind)%graze_zoo * work2
+              zoo_graze_zoo(zoo_ind) = zoo_graze_zoo(zoo_ind) + grazer_settings(prey_ind, pred_ind)%graze_zoo * work2
+              x_graze_zoo(pred_ind) = x_graze_zoo(pred_ind)   + grazer_settings(prey_ind, pred_ind)%graze_zoo * work2
 
               ! routed to POC/DOC
-              zoo_graze_poc(zoo_ind) = zoo_graze_poc(zoo_ind) + grazing(prey_ind, pred_ind)%graze_poc * work2
-              zoo_graze_doc(zoo_ind) = zoo_graze_doc(zoo_ind) + grazing(prey_ind, pred_ind)%graze_doc * work2
+              zoo_graze_poc(zoo_ind) = zoo_graze_poc(zoo_ind) + grazer_settings(prey_ind, pred_ind)%graze_poc * work2
+              zoo_graze_doc(zoo_ind) = zoo_graze_doc(zoo_ind) + grazer_settings(prey_ind, pred_ind)%graze_doc * work2
 
               !  get fractional factor for routing of zoo losses, based on food supply
-              work3 = work3 + grazing(prey_ind, pred_ind)%f_zoo_detr * (work2 + epsC * epsTinv)
+              work3 = work3 + grazer_settings(prey_ind, pred_ind)%f_zoo_detr * (work2 + epsC * epsTinv)
               work4 = work4 + (work2 + epsC * epsTinv)
 
            end do

--- a/src/marbl_interior_tendency_mod.F90
+++ b/src/marbl_interior_tendency_mod.F90
@@ -338,13 +338,11 @@ contains
 
     call compute_routing(km, zooplankton_derived_terms, autotroph_derived_terms)
 
-    do k = 1, km
+    call compute_dissolved_organic_matter (km, marbl_tracer_indices, num_PAR_subcols, &
+         PAR, zooplankton_derived_terms, autotroph_derived_terms,   &
+         delta_z1, tracer_local(:, :), dissolved_organic_matter)
 
-       call compute_dissolved_organic_matter (k, num_PAR_subcols, &
-            zooplankton_derived_terms, autotroph_derived_terms,   &
-            PAR%col_frac(:), PAR%interface(k-1,:), PAR%avg(k,:),  &
-            delta_z1, tracer_local(:, k), marbl_tracer_indices,   &
-            dissolved_organic_matter)
+    do k = 1, km
 
        call compute_scavenging(k, tracer_local(fe_ind, k),                   &
             tracer_local(lig_ind, k), POC, P_CaCO3, P_SiO2, dust,            &
@@ -2053,10 +2051,10 @@ contains
 
   !***********************************************************************
 
-  subroutine compute_dissolved_organic_matter (k, &
-             PAR_nsubcols, zooplankton_derived_terms, &
-             autotroph_derived_terms, PAR_col_frac, PAR_in, PAR_avg, &
-             dz1, tracer_local, marbl_tracer_indices, dissolved_organic_matter)
+  subroutine compute_dissolved_organic_matter (km, marbl_tracer_indices, &
+             PAR_nsubcols, PAR, &
+             zooplankton_derived_terms, autotroph_derived_terms, &
+             dz1, tracer_local, dissolved_organic_matter)
 
     use marbl_settings_mod, only : Q
     use marbl_settings_mod, only : DOC_reminR_light
@@ -2070,22 +2068,20 @@ contains
     use marbl_settings_mod, only : DOPr_reminR0
     use marbl_settings_mod, only : DOMr_reminR_photo
 
-    integer(int_kind),                    intent(in)    :: k
+    integer(int_kind),                    intent(in)    :: km
+    type(marbl_tracer_index_type),        intent(in)    :: marbl_tracer_indices
     integer(int_kind),                    intent(in)    :: PAR_nsubcols
+    type(marbl_PAR_type),                 intent(in)    :: PAR
     type(zooplankton_derived_terms_type), intent(in)    :: zooplankton_derived_terms
     type(autotroph_derived_terms_type),   intent(in)    :: autotroph_derived_terms
-    real(r8),                             intent(in)    :: PAR_col_frac(:)
-    real(r8),                             intent(in)    :: PAR_in(:)
-    real(r8),                             intent(in)    :: PAR_avg(:)
     real(r8),                             intent(in)    :: dz1
-    real(r8),                             intent(in)    :: tracer_local(:)
-    type(marbl_tracer_index_type),        intent(in)    :: marbl_tracer_indices
+    real(r8),                             intent(in)    :: tracer_local(marbl_tracer_indices%total_cnt,km)
     type(dissolved_organic_matter_type),  intent(inout) :: dissolved_organic_matter
 
     !-----------------------------------------------------------------------
     !  local variables
     !-----------------------------------------------------------------------
-    integer  :: subcol_ind
+    integer  :: k, subcol_ind
     real(r8) :: work
     real(r8) :: DOC_reminR        ! remineralization rate (1/sec)
     real(r8) :: DON_reminR        ! remineralization rate (1/sec)
@@ -2096,87 +2092,95 @@ contains
     !-----------------------------------------------------------------------
 
     associate(                                                           &
-         DOC_loc         => tracer_local(marbl_tracer_indices%doc_ind),  &
-         DON_loc         => tracer_local(marbl_tracer_indices%don_ind),  &
-         DOP_loc         => tracer_local(marbl_tracer_indices%dop_ind),  &
-         DONr_loc        => tracer_local(marbl_tracer_indices%donr_ind), &
-         DOPr_loc        => tracer_local(marbl_tracer_indices%dopr_ind), &
-         DOCr_loc        => tracer_local(marbl_tracer_indices%docr_ind), &
+         DOC_loc         => tracer_local(marbl_tracer_indices%doc_ind,:),  &
+         DON_loc         => tracer_local(marbl_tracer_indices%don_ind,:),  &
+         DOP_loc         => tracer_local(marbl_tracer_indices%dop_ind,:),  &
+         DONr_loc        => tracer_local(marbl_tracer_indices%donr_ind,:), &
+         DOPr_loc        => tracer_local(marbl_tracer_indices%dopr_ind,:), &
+         DOCr_loc        => tracer_local(marbl_tracer_indices%docr_ind,:), &
 
-         Qfe             => autotroph_derived_terms%Qfe(:,k),             & ! input
-         remaining_P_dop => autotroph_derived_terms%remaining_P_dop(:,k), & ! input
-         auto_loss_doc   => autotroph_derived_terms%auto_loss_doc(:,k),   & ! input
-         auto_graze_doc  => autotroph_derived_terms%auto_graze_doc(:,k),  & ! input
+         PAR_col_frac    => PAR%col_frac(:),    &
+         PAR_in          => PAR%interface(:,:), &
+         PAR_avg         => PAR%avg(:,:),       &
 
-         zoo_loss_doc    => zooplankton_derived_terms%zoo_loss_doc(:,k),  & ! input
-         zoo_graze_doc   => zooplankton_derived_terms%zoo_graze_doc(:,k), & ! input
+         remaining_P_dop => autotroph_derived_terms%remaining_P_dop(:,:), & ! input
+         auto_loss_doc   => autotroph_derived_terms%auto_loss_doc(:,:),   & ! input
+         auto_graze_doc  => autotroph_derived_terms%auto_graze_doc(:,:),  & ! input
 
-         DOC_prod        => dissolved_organic_matter%DOC_prod(k),   & ! output production of DOC (mmol C/m^3/sec)
-         DOC_remin       => dissolved_organic_matter%DOC_remin(k),  & ! output remineralization of DOC (mmol C/m^3/sec)
-         DOCr_remin      => dissolved_organic_matter%DOCr_remin(k), & ! output remineralization of DOCr
-         DON_prod        => dissolved_organic_matter%DON_prod(k),   & ! output production of DON
-         DON_remin       => dissolved_organic_matter%DON_remin(k),  & ! output remineralization of DON
-         DONr_remin      => dissolved_organic_matter%DONr_remin(k), & ! output remineralization of DONr
-         DOP_prod        => dissolved_organic_matter%DOP_prod(k),   & ! output production of DOP
-         DOP_remin       => dissolved_organic_matter%DOP_remin(k),  & ! output remineralization of DOP
-         DOPr_remin      => dissolved_organic_matter%DOPr_remin(k)  & ! output remineralization of DOPr
+         zoo_loss_doc    => zooplankton_derived_terms%zoo_loss_doc(:,:),  & ! input
+         zoo_graze_doc   => zooplankton_derived_terms%zoo_graze_doc(:,:), & ! input
+
+         DOC_prod        => dissolved_organic_matter%DOC_prod(:),   & ! output production of DOC (mmol C/m^3/sec)
+         DOC_remin       => dissolved_organic_matter%DOC_remin(:),  & ! output remineralization of DOC (mmol C/m^3/sec)
+         DOCr_remin      => dissolved_organic_matter%DOCr_remin(:), & ! output remineralization of DOCr
+         DON_prod        => dissolved_organic_matter%DON_prod(:),   & ! output production of DON
+         DON_remin       => dissolved_organic_matter%DON_remin(:),  & ! output remineralization of DON
+         DONr_remin      => dissolved_organic_matter%DONr_remin(:), & ! output remineralization of DONr
+         DOP_prod        => dissolved_organic_matter%DOP_prod(:),   & ! output production of DOP
+         DOP_remin       => dissolved_organic_matter%DOP_remin(:),  & ! output remineralization of DOP
+         DOPr_remin      => dissolved_organic_matter%DOPr_remin(:)  & ! output remineralization of DOPr
          )
 
       !-----------------------------------------------------------------------
       !  compute terms for DOM
       !-----------------------------------------------------------------------
 
-      DOC_prod = sum(zoo_loss_doc(:)) + sum(auto_loss_doc(:)) + sum(auto_graze_doc(:)) + sum(zoo_graze_doc(:))
-      DON_prod = Q * DOC_prod * f_toDON
-      DOP_prod = Qp_zoo * (sum(zoo_loss_doc(:)) + sum(zoo_graze_doc(:))) + sum(remaining_P_dop(:))
+      DOC_prod(:) = sum(zoo_loss_doc(:,:), dim=1) + sum(auto_loss_doc(:,:), dim=1) &
+                  + sum(auto_graze_doc(:,:), dim=1) + sum(zoo_graze_doc(:,:), dim=1)
+      DON_prod(:) = Q * DOC_prod(:) * f_toDON
+      DOP_prod(:) = Qp_zoo * (sum(zoo_loss_doc(:,:), dim=1) + sum(zoo_graze_doc(:,:), dim=1)) &
+                  + sum(remaining_P_dop(:,:), dim=1)
 
-      !-----------------------------------------------------------------------
-      !  Different remin rates in light and dark for semi-labile pools
-      !-----------------------------------------------------------------------
+      do k=1, km
+        !-----------------------------------------------------------------------
+        !  Different remin rates in light and dark for semi-labile pools
+        !-----------------------------------------------------------------------
 
-      DOC_reminR = c0
-      DON_reminR = c0
-      DOP_reminR = c0
+        DOC_reminR = c0
+        DON_reminR = c0
+        DOP_reminR = c0
 
-      do subcol_ind = 1, PAR_nsubcols
-        if (PAR_col_frac(subcol_ind) > c0) then
-          if (PAR_avg(subcol_ind) > 1.0_r8) then
-            DOC_reminR = DOC_reminR + PAR_col_frac(subcol_ind) * DOC_reminR_light
-            DON_reminR = DON_reminR + PAR_col_frac(subcol_ind) * DON_reminR_light
-            DOP_reminR = DOP_reminR + PAR_col_frac(subcol_ind) * DOP_reminR_light
-          else
-            DOC_reminR = DOC_reminR + PAR_col_frac(subcol_ind) * DOC_reminR_dark
-            DON_reminR = DON_reminR + PAR_col_frac(subcol_ind) * DON_reminR_dark
-            DOP_reminR = DOP_reminR + PAR_col_frac(subcol_ind) * DOP_reminR_dark
-          endif
-        endif
-      end do
-
-      !-----------------------------------------------------------------------
-      !  Refractory remin increased in top layer from photodegradation due to UV
-      !-----------------------------------------------------------------------
-
-      DOCr_reminR = DOCr_reminR0
-      DONr_reminR = DONr_reminR0
-      DOPr_reminR = DOPr_reminR0
-
-      if (k == 1) then
         do subcol_ind = 1, PAR_nsubcols
-          if ((PAR_col_frac(subcol_ind) > c0) .and. (PAR_in(subcol_ind) > 1.0_r8)) then
-            work = PAR_col_frac(subcol_ind) * (log(PAR_in(subcol_ind))*0.4373_r8) * (10.0e2_r8/dz1)
-            DOCr_reminR = DOCr_reminR + work * DOMr_reminR_photo
-            DONr_reminR = DONr_reminR + work * DOMr_reminR_photo
-            DOPr_reminR = DOPr_reminR + work * DOMr_reminR_photo
+          if (PAR_col_frac(subcol_ind) > c0) then
+            if (PAR_avg(k,subcol_ind) > 1.0_r8) then
+              DOC_reminR = DOC_reminR + PAR_col_frac(subcol_ind) * DOC_reminR_light
+              DON_reminR = DON_reminR + PAR_col_frac(subcol_ind) * DON_reminR_light
+              DOP_reminR = DOP_reminR + PAR_col_frac(subcol_ind) * DOP_reminR_light
+            else
+              DOC_reminR = DOC_reminR + PAR_col_frac(subcol_ind) * DOC_reminR_dark
+              DON_reminR = DON_reminR + PAR_col_frac(subcol_ind) * DON_reminR_dark
+              DOP_reminR = DOP_reminR + PAR_col_frac(subcol_ind) * DOP_reminR_dark
+            endif
           endif
         end do
-      endif
 
-      DOC_remin  = DOC_loc  * DOC_reminR
-      DON_remin  = DON_loc  * DON_reminR
-      DOP_remin  = DOP_loc  * DOP_reminR
-      DOCr_remin = DOCr_loc * DOCr_reminR
-      DONr_remin = DONr_loc * DONr_reminR
-      DOPr_remin = DOPr_loc * DOPr_reminR
+        !-----------------------------------------------------------------------
+        !  Refractory remin increased in top layer from photodegradation due to UV
+        !-----------------------------------------------------------------------
+
+        DOCr_reminR = DOCr_reminR0
+        DONr_reminR = DONr_reminR0
+        DOPr_reminR = DOPr_reminR0
+
+        if (k == 1) then
+          do subcol_ind = 1, PAR_nsubcols
+            if ((PAR_col_frac(subcol_ind) > c0) .and. (PAR_in(0, subcol_ind) > 1.0_r8)) then
+              work = PAR_col_frac(subcol_ind) * (log(PAR_in(0, subcol_ind))*0.4373_r8) * (10.0e2_r8/dz1)
+              DOCr_reminR = DOCr_reminR + work * DOMr_reminR_photo
+              DONr_reminR = DONr_reminR + work * DOMr_reminR_photo
+              DOPr_reminR = DOPr_reminR + work * DOMr_reminR_photo
+            endif
+          end do
+        endif
+
+        DOC_remin(k)  = DOC_loc(k)  * DOC_reminR
+        DON_remin(k)  = DON_loc(k)  * DON_reminR
+        DOP_remin(k)  = DOP_loc(k)  * DOP_reminR
+        DOCr_remin(k) = DOCr_loc(k) * DOCr_reminR
+        DONr_remin(k) = DONr_loc(k) * DONr_reminR
+        DOPr_remin(k) = DOPr_loc(k) * DOPr_reminR
+
+      end do
 
     end associate
 

--- a/src/marbl_interior_tendency_mod.F90
+++ b/src/marbl_interior_tendency_mod.F90
@@ -105,6 +105,7 @@ contains
        zooplankton_local,                     &
        saved_state,                           &
        marbl_timers,                          &
+       interior_tendency_share,               &
        marbl_particulate_share,               &
        interior_tendency_diags,               &
        interior_tendencies,                   &
@@ -142,6 +143,7 @@ contains
     type(zooplankton_local_type),                            intent(inout) :: zooplankton_local
     type(marbl_saved_state_type),                            intent(inout) :: saved_state
     type(marbl_internal_timers_type),                        intent(inout) :: marbl_timers
+    type(marbl_interior_tendency_share_type),                intent(inout) :: interior_tendency_share
     type(marbl_particulate_share_type),                      intent(inout) :: marbl_particulate_share
     type(marbl_diagnostics_type),                            intent(inout) :: interior_tendency_diags
     real(r8),                                                intent(out)   :: interior_tendencies(:,:)          ! (tracer_cnt, km) computed source/sink terms
@@ -156,7 +158,6 @@ contains
     real(r8), dimension(size(tracers,1), domain%km) :: interior_restore
     real(r8), dimension(size(tracers,1), domain%km) :: tracer_local
 
-    type(marbl_interior_tendency_share_type) :: marbl_interior_tendency_share(domain%km)
     type(marbl_zooplankton_share_type)       :: marbl_zooplankton_share(domain%km)
 
     integer (int_kind) :: k         ! vertical level index
@@ -413,7 +414,7 @@ contains
        !            of compute_particulate_terms!
        call marbl_interior_tendency_share_export_variables(k, tracer_local(:, k), &
             marbl_tracer_indices, carbonate(k), dissolved_organic_matter,   &
-            QA_dust_def(k), marbl_interior_tendency_share(k))
+            QA_dust_def(k), interior_tendency_share)
 
        call marbl_interior_tendency_share_export_zooplankton(k, zooplankton_local, &
             zooplankton_derived_terms, marbl_zooplankton_share(k))
@@ -451,19 +452,19 @@ contains
     end if
 
     !  Compute time derivatives for ecosystem carbon isotope state variables
-    call marbl_ciso_interior_tendency_compute(                       &
-         marbl_domain                 = domain,                      &
-         marbl_interior_tendency_share = marbl_interior_tendency_share, &
-         marbl_zooplankton_share      = marbl_zooplankton_share,     &
-         marbl_particulate_share      = marbl_particulate_share,     &
-         autotroph_derived_terms      = autotroph_derived_terms,     &
-         tracer_local                 = tracer_local,                &
-         autotroph_local              = autotroph_local,             &
-         temperature                  = temperature,                 &
-         marbl_tracer_indices         = marbl_tracer_indices,        &
-         interior_tendencies          = interior_tendencies,         &
-         marbl_interior_diags         = interior_tendency_diags,     &
-         marbl_status_log             = marbl_status_log)
+    call marbl_ciso_interior_tendency_compute(                  &
+         marbl_domain            = domain,                      &
+         interior_tendency_share = interior_tendency_share,     &
+         marbl_zooplankton_share = marbl_zooplankton_share,     &
+         marbl_particulate_share = marbl_particulate_share,     &
+         autotroph_derived_terms = autotroph_derived_terms,     &
+         tracer_local            = tracer_local,                &
+         autotroph_local         = autotroph_local,             &
+         temperature             = temperature,                 &
+         marbl_tracer_indices    = marbl_tracer_indices,        &
+         interior_tendencies     = interior_tendencies,         &
+         marbl_interior_diags    = interior_tendency_diags,     &
+         marbl_status_log        = marbl_status_log)
 
     if (marbl_status_log%labort_marbl) then
        call marbl_status_log%log_error_trace(&

--- a/src/marbl_interior_tendency_mod.F90
+++ b/src/marbl_interior_tendency_mod.F90
@@ -376,6 +376,11 @@ contains
           return
        end if
 
+       if  (k < km) then
+          call update_particulate_terms_from_prior_level(k+1, POC, POP, P_CaCO3, &
+               P_CaCO3_ALT_CO2, P_SiO2, dust, P_iron, QA_dust_def(:))
+       endif
+
        call compute_Lig_terms(k, POC%remin(k), dissolved_organic_matter(k)%DOC_prod, &
             num_PAR_subcols, PAR%col_frac(:), PAR%interface(k-1,:), delta_z1, &
             tracer_local(lig_ind,k), Lig_scavenge(k), &
@@ -413,11 +418,6 @@ contains
 
        call marbl_interior_tendency_share_export_zooplankton(k, zooplankton_local, &
             zooplankton_derived_terms, marbl_zooplankton_share(k))
-
-       if  (k < km) then
-          call update_particulate_terms_from_prior_level(k+1, POC, POP, P_CaCO3, &
-               P_CaCO3_ALT_CO2, P_SiO2, dust, P_iron, QA_dust_def(:))
-       endif
 
     end do ! k
 

--- a/src/marbl_interior_tendency_mod.F90
+++ b/src/marbl_interior_tendency_mod.F90
@@ -1311,8 +1311,8 @@ contains
          alphaPI   => autotroph_settings(:)%alphaPI           &
          )
 
-      do k=1,km
-        do auto_ind = 1, autotroph_cnt
+      do auto_ind = 1, autotroph_cnt
+        do k=1,km
 
           if (temperature(k) < autotroph_settings(auto_ind)%temp_thres) then
             PCmax = c0

--- a/src/marbl_interior_tendency_mod.F90
+++ b/src/marbl_interior_tendency_mod.F90
@@ -1513,8 +1513,8 @@ contains
     !-----------------------------------------------------------------------
     !  local variables
     !-----------------------------------------------------------------------
-    integer  :: k,auto_ind
-    real(r8) :: work1
+    integer  :: auto_ind
+    real(r8) :: work1(km)
     !-----------------------------------------------------------------------
 
     associate(                                              &
@@ -1525,15 +1525,12 @@ contains
          Nexcrete => autotroph_derived_terms%Nexcrete(:, :) & ! output fixed N excretion
          )
 
-      do k=1,km
-        do auto_ind = 1, autotroph_cnt
-          if (autotroph_settings(auto_ind)%Nfixer) then
-            work1 = photoC(auto_ind,k) * Q
-            Nfix(auto_ind,k) = (work1 * r_Nfix_photo) - NO3_V(auto_ind,k) - NH4_V(auto_ind,k)
-            Nexcrete(auto_ind,k) = Nfix(auto_ind,k) + NO3_V(auto_ind,k) + NH4_V(auto_ind,k) - work1
-          endif
-
-        end do
+      do auto_ind = 1, autotroph_cnt
+        if (autotroph_settings(auto_ind)%Nfixer) then
+          work1(:) = photoC(auto_ind,:) * Q
+          Nfix(auto_ind,:) = (work1(:) * r_Nfix_photo) - NO3_V(auto_ind,:) - NH4_V(auto_ind,:)
+          Nexcrete(auto_ind,:) = Nfix(auto_ind,:) + NO3_V(auto_ind,:) + NH4_V(auto_ind,:) - work1(:)
+        endif
       end do
 
     end associate

--- a/src/marbl_interior_tendency_mod.F90
+++ b/src/marbl_interior_tendency_mod.F90
@@ -1425,7 +1425,7 @@ contains
     !-----------------------------------------------------------------------
     !  local variables
     !-----------------------------------------------------------------------
-    integer  :: k, auto_ind
+    integer  :: auto_ind
     !-----------------------------------------------------------------------
 
     !-----------------------------------------------------------------------
@@ -1462,35 +1462,33 @@ contains
               VSiO3 => autotroph_derived_terms%VSiO3(:,:)  &
               )
 
-      do k=1,km
-        do auto_ind = 1, autotroph_cnt
+      do auto_ind = 1, autotroph_cnt
 
-          VNO3(auto_ind,k) = (NO3_loc(k) / kNO3(auto_ind)) &
-                           / (c1 + (NO3_loc(k) / kNO3(auto_ind)) + (NH4_loc(k) / kNH4(auto_ind)))
-          VNH4(auto_ind,k) = (NH4_loc(k) / kNH4(auto_ind)) &
-                           / (c1 + (NO3_loc(k) / kNO3(auto_ind)) + (NH4_loc(k) / kNH4(auto_ind)))
-          if (Nfixer(auto_ind)) then
-            VNtot(auto_ind,k) = c1
-          else
-            VNtot(auto_ind,k) = VNO3(auto_ind,k) + VNH4(auto_ind,k)
-          end if
+        VNO3(auto_ind,:) = (NO3_loc(:) / kNO3(auto_ind)) &
+                         / (c1 + (NO3_loc(:) / kNO3(auto_ind)) + (NH4_loc(:) / kNH4(auto_ind)))
+        VNH4(auto_ind,:) = (NH4_loc(:) / kNH4(auto_ind)) &
+                         / (c1 + (NO3_loc(:) / kNO3(auto_ind)) + (NH4_loc(:) / kNH4(auto_ind)))
+        if (Nfixer(auto_ind)) then
+          VNtot(auto_ind,:) = c1
+        else
+          VNtot(auto_ind,:) = VNO3(auto_ind,:) + VNH4(auto_ind,:)
+        end if
 
-          VFe(auto_ind, k) = Fe_loc(k) / (Fe_loc(k) + kFe(auto_ind))
-          f_nut(auto_ind, k) = min(VNtot(auto_ind, k), VFe(auto_ind, k))
+        VFe(auto_ind, :) = Fe_loc(:) / (Fe_loc(:) + kFe(auto_ind))
+        f_nut(auto_ind, :) = min(VNtot(auto_ind, :), VFe(auto_ind, :))
 
-          VPO4(auto_ind, k) = (PO4_loc(k) / kPO4(auto_ind)) &
-                            / (c1 + (PO4_loc(k) / kPO4(auto_ind)) + (DOP_loc(k) / kDOP(auto_ind)))
-          VDOP(auto_ind, k) = (DOP_loc(k) / kDOP(auto_ind)) &
-                            / (c1 + (PO4_loc(k) / kPO4(auto_ind)) + (DOP_loc(k) / kDOP(auto_ind)))
-          VPtot(auto_ind, k) = VPO4(auto_ind, k) + VDOP(auto_ind, k)
-          f_nut(auto_ind, k) = min(f_nut(auto_ind, k), VPtot(auto_ind, k))
+        VPO4(auto_ind, :) = (PO4_loc(:) / kPO4(auto_ind)) &
+                          / (c1 + (PO4_loc(:) / kPO4(auto_ind)) + (DOP_loc(:) / kDOP(auto_ind)))
+        VDOP(auto_ind, :) = (DOP_loc(:) / kDOP(auto_ind)) &
+                          / (c1 + (PO4_loc(:) / kPO4(auto_ind)) + (DOP_loc(:) / kDOP(auto_ind)))
+        VPtot(auto_ind, :) = VPO4(auto_ind, :) + VDOP(auto_ind, :)
+        f_nut(auto_ind, :) = min(f_nut(auto_ind, :), VPtot(auto_ind, :))
 
-          if (silicifier(auto_ind)) then
-            VSiO3(auto_ind, k) = SiO3_loc(k) / (SiO3_loc(k) + kSiO3(auto_ind))
-            f_nut(auto_ind, k) = min(f_nut(auto_ind, k), VSiO3(auto_ind, k))
-          endif
+        if (silicifier(auto_ind)) then
+          VSiO3(auto_ind, :) = SiO3_loc(:) / (SiO3_loc(:) + kSiO3(auto_ind))
+          f_nut(auto_ind, :) = min(f_nut(auto_ind, :), VSiO3(auto_ind, :))
+        endif
 
-        end do
       end do
 
     end associate

--- a/src/marbl_interior_tendency_mod.F90
+++ b/src/marbl_interior_tendency_mod.F90
@@ -406,7 +406,9 @@ contains
             o2_consumption_scalef(k), &
             o2_production(k), o2_consumption(k), &
             interior_tendencies(:, k), marbl_tracer_indices )
+    end do ! k
 
+    do k=1, km
        ! Store any variables needed in other tracer modules
        ! FIXME #28: need to pull particulate share out
        !            of compute_particulate_terms!

--- a/src/marbl_interior_tendency_mod.F90
+++ b/src/marbl_interior_tendency_mod.F90
@@ -408,19 +408,6 @@ contains
          o2_production(:), o2_consumption(:), &
          interior_tendencies(:,:))
 
-    do k=1, km
-       ! Store any variables needed in other tracer modules
-       ! FIXME #28: need to pull particulate share out
-       !            of compute_particulate_terms!
-       call marbl_interior_tendency_share_export_variables(k, marbl_tracer_indices, &
-            tracer_local(:, k), carbonate, dissolved_organic_matter,                &
-            QA_dust_def(k), interior_tendency_share)
-
-       call marbl_interior_tendency_share_export_zooplankton(k, zooplankton_local, &
-            zooplankton_derived_terms, marbl_zooplankton_share(k))
-
-    end do ! k
-
     ! Compute interior diagnostics
     call marbl_diagnostics_interior_tendency_compute(       &
          domain,                                            &
@@ -451,7 +438,23 @@ contains
        return
     end if
 
+    !-----------------------------------------------------------------------
     !  Compute time derivatives for ecosystem carbon isotope state variables
+    !-----------------------------------------------------------------------
+
+    ! Store any variables needed in other tracer modules
+    ! FIXME #28: need to pull particulate share out
+    !            of compute_particulate_terms!
+    call marbl_interior_tendency_share_export_variables(km, marbl_tracer_indices, &
+        tracer_local(:,:), carbonate, dissolved_organic_matter,                   &
+        QA_dust_def(:), interior_tendency_share)
+
+    do k=1, km
+       call marbl_interior_tendency_share_export_zooplankton(k, zooplankton_local, &
+            zooplankton_derived_terms, marbl_zooplankton_share(k))
+    end do ! k
+
+    ! call marbl_ciso_interior_tendency_compute()
     call marbl_ciso_interior_tendency_compute(                  &
          marbl_domain            = domain,                      &
          interior_tendency_share = interior_tendency_share,     &

--- a/src/marbl_interior_tendency_mod.F90
+++ b/src/marbl_interior_tendency_mod.F90
@@ -449,10 +449,8 @@ contains
         tracer_local(:,:), carbonate, dissolved_organic_matter,                   &
         QA_dust_def(:), interior_tendency_share)
 
-    do k=1, km
-       call marbl_interior_tendency_share_export_zooplankton(k, zooplankton_local, &
-            zooplankton_derived_terms, zooplankton_share)
-    end do ! k
+    call marbl_interior_tendency_share_export_zooplankton(zooplankton_local, &
+         zooplankton_derived_terms, zooplankton_share)
 
     ! call marbl_ciso_interior_tendency_compute()
     call marbl_ciso_interior_tendency_compute(                  &

--- a/src/marbl_interior_tendency_mod.F90
+++ b/src/marbl_interior_tendency_mod.F90
@@ -70,7 +70,7 @@ module marbl_interior_tendency_mod
   use marbl_settings_mod, only : QCaCO3_max
   use marbl_settings_mod, only : Qfe_zoo
   use marbl_settings_mod, only : spc_poc_fac
-  use marbl_settings_mod, only : grazer_settings
+  use marbl_settings_mod, only : grazing_relationship_settings
   use marbl_settings_mod, only : PON_bury_coeff
   use marbl_settings_mod, only : del_ph
   use marbl_settings_mod, only : phhi_3d_init
@@ -1815,32 +1815,34 @@ contains
             !  compute sum of carbon in the grazee class, both autotrophs and zoop
             !-----------------------------------------------------------------------
             work1 = c0 ! biomass in prey class prey_ind
-            do auto_ind2 = 1, grazer_settings(prey_ind, pred_ind)%auto_ind_cnt
-              auto_ind = grazer_settings(prey_ind, pred_ind)%auto_ind(auto_ind2)
+            do auto_ind2 = 1, grazing_relationship_settings(prey_ind, pred_ind)%auto_ind_cnt
+              auto_ind = grazing_relationship_settings(prey_ind, pred_ind)%auto_ind(auto_ind2)
               work1 = work1 + Pprime(auto_ind,k)
             end do
 
-            do zoo_ind2 = 1, grazer_settings(prey_ind, pred_ind)%zoo_ind_cnt
-              zoo_ind = grazer_settings(prey_ind, pred_ind)%zoo_ind(zoo_ind2)
+            do zoo_ind2 = 1, grazing_relationship_settings(prey_ind, pred_ind)%zoo_ind_cnt
+              zoo_ind = grazing_relationship_settings(prey_ind, pred_ind)%zoo_ind(zoo_ind2)
               work1 = work1 + Zprime(zoo_ind,k)
             end do
 
             ! compute grazing rate
             graze_rate = c0
-            select case (grazer_settings(prey_ind, pred_ind)%grazing_function)
+            select case (grazing_relationship_settings(prey_ind, pred_ind)%grazing_function)
 
               case (grz_fnc_michaelis_menten)
 
                 if (work1 > c0) then
-                  graze_rate = grazer_settings(prey_ind, pred_ind)%z_umax_0 * Tfunc(k) * zooplankton_local%C(pred_ind,k) &
-                             * ( work1 / (work1 + grazer_settings(prey_ind, pred_ind)%z_grz) )
+                  graze_rate = grazing_relationship_settings(prey_ind, pred_ind)%z_umax_0 * Tfunc(k) &
+                             * zooplankton_local%C(pred_ind,k) &
+                             * ( work1 / (work1 + grazing_relationship_settings(prey_ind, pred_ind)%z_grz) )
                 end if
 
               case (grz_fnc_sigmoidal)
 
                 if (work1 > c0) then
-                  graze_rate = grazer_settings(prey_ind, pred_ind)%z_umax_0 * Tfunc(k) * zooplankton_local%C(pred_ind,k) &
-                             * ( work1**2 / (work1**2 + grazer_settings(prey_ind, pred_ind)%z_grz**2) )
+                  graze_rate = grazing_relationship_settings(prey_ind, pred_ind)%z_umax_0 * Tfunc(k) &
+                             * zooplankton_local%C(pred_ind,k) &
+                             * ( work1**2 / (work1**2 + grazing_relationship_settings(prey_ind, pred_ind)%z_grz**2) )
                 end if
 
             end select
@@ -1849,8 +1851,8 @@ contains
             !  autotroph prey
             !-----------------------------------------------------------------------
 
-            do auto_ind2 = 1, grazer_settings(prey_ind, pred_ind)%auto_ind_cnt
-              auto_ind = grazer_settings(prey_ind, pred_ind)%auto_ind(auto_ind2)
+            do auto_ind2 = 1, grazing_relationship_settings(prey_ind, pred_ind)%auto_ind_cnt
+              auto_ind = grazing_relationship_settings(prey_ind, pred_ind)%auto_ind(auto_ind2)
 
               ! scale by biomass from autotroph pool
               if (work1 > c0) then
@@ -1862,9 +1864,9 @@ contains
 
               ! routed to zooplankton
               auto_graze_zoo(auto_ind,k) = auto_graze_zoo(auto_ind,k) &
-                                         + grazer_settings(prey_ind, pred_ind)%graze_zoo * work2
+                                         + grazing_relationship_settings(prey_ind, pred_ind)%graze_zoo * work2
               x_graze_zoo(pred_ind,k)    = x_graze_zoo(pred_ind,k)    &
-                                         + grazer_settings(prey_ind, pred_ind)%graze_zoo * work2
+                                         + grazing_relationship_settings(prey_ind, pred_ind)%graze_zoo * work2
 
               ! routed to POC
               if (autotroph_settings(auto_ind)%imp_calcifier) then
@@ -1874,15 +1876,15 @@ contains
                                                              f_graze_sp_poc_lim))
               else
                 auto_graze_poc(auto_ind,k) = auto_graze_poc(auto_ind,k) &
-                                           + grazer_settings(prey_ind, pred_ind)%graze_poc * work2
+                                           + grazing_relationship_settings(prey_ind, pred_ind)%graze_poc * work2
               endif
 
               ! routed to DOC
               auto_graze_doc(auto_ind,k) = auto_graze_doc(auto_ind,k) &
-                                         + grazer_settings(prey_ind, pred_ind)%graze_doc * work2
+                                         + grazing_relationship_settings(prey_ind, pred_ind)%graze_doc * work2
 
               !  get fractional factor for routing of zoo losses, based on food supply
-              work3 = work3 + grazer_settings(prey_ind, pred_ind)%f_zoo_detr * (work2 + epsC * epsTinv)
+              work3 = work3 + grazing_relationship_settings(prey_ind, pred_ind)%f_zoo_detr * (work2 + epsC * epsTinv)
               work4 = work4 + (work2 + epsC * epsTinv)
 
             end do
@@ -1890,8 +1892,8 @@ contains
             !-----------------------------------------------------------------------
             !  Zooplankton prey
             !-----------------------------------------------------------------------
-            do zoo_ind2 = 1, grazer_settings(prey_ind, pred_ind)%zoo_ind_cnt
-              zoo_ind = grazer_settings(prey_ind, pred_ind)%zoo_ind(zoo_ind2)
+            do zoo_ind2 = 1, grazing_relationship_settings(prey_ind, pred_ind)%zoo_ind_cnt
+              zoo_ind = grazing_relationship_settings(prey_ind, pred_ind)%zoo_ind(zoo_ind2)
 
               ! scale by biomass from zooplankton pool
               if (work1 > c0) then
@@ -1905,18 +1907,18 @@ contains
 
               ! routed to zooplankton
               zoo_graze_zoo(zoo_ind,k) = zoo_graze_zoo(zoo_ind,k) &
-                                       + grazer_settings(prey_ind, pred_ind)%graze_zoo * work2
+                                       + grazing_relationship_settings(prey_ind, pred_ind)%graze_zoo * work2
               x_graze_zoo(pred_ind,k)  = x_graze_zoo(pred_ind,k)  &
-                                       + grazer_settings(prey_ind, pred_ind)%graze_zoo * work2
+                                       + grazing_relationship_settings(prey_ind, pred_ind)%graze_zoo * work2
 
               ! routed to POC/DOC
               zoo_graze_poc(zoo_ind,k) = zoo_graze_poc(zoo_ind,k) &
-                                       + grazer_settings(prey_ind, pred_ind)%graze_poc * work2
+                                       + grazing_relationship_settings(prey_ind, pred_ind)%graze_poc * work2
               zoo_graze_doc(zoo_ind,k) = zoo_graze_doc(zoo_ind,k) &
-                                       + grazer_settings(prey_ind, pred_ind)%graze_doc * work2
+                                       + grazing_relationship_settings(prey_ind, pred_ind)%graze_doc * work2
 
               !  get fractional factor for routing of zoo losses, based on food supply
-              work3 = work3 + grazer_settings(prey_ind, pred_ind)%f_zoo_detr * (work2 + epsC * epsTinv)
+              work3 = work3 + grazing_relationship_settings(prey_ind, pred_ind)%f_zoo_detr * (work2 + epsC * epsTinv)
               work4 = work4 + (work2 + epsC * epsTinv)
 
             end do

--- a/src/marbl_interior_tendency_share_mod.F90
+++ b/src/marbl_interior_tendency_share_mod.F90
@@ -32,7 +32,7 @@ contains
   !***********************************************************************
 
   subroutine marbl_interior_tendency_share_export_variables(&
-       k, &
+       km, &
        marbl_tracer_indices, &
        tracer_local, &
        carbonate, &
@@ -45,25 +45,25 @@ contains
     use marbl_interface_private_types, only : dissolved_organic_matter_type
     use marbl_interface_private_types, only : marbl_interior_tendency_share_type
 
-    integer,                                  intent(in)    :: k
+    integer,                                  intent(in)    :: km
     type(marbl_tracer_index_type),            intent(in)    :: marbl_tracer_indices
-    real(r8),                                 intent(in)    :: tracer_local(marbl_tracer_indices%total_cnt)
+    real(r8),                                 intent(in)    :: tracer_local(marbl_tracer_indices%total_cnt,km)
     type(carbonate_type),                     intent(in)    :: carbonate
     type(dissolved_organic_matter_type),      intent(in)    :: dissolved_organic_matter
-    real(r8),                                 intent(in)    :: QA_dust_def
+    real(r8),                                 intent(in)    :: QA_dust_def(km)
     type(marbl_interior_tendency_share_type), intent(inout) :: interior_tendency_share
 
     ! Populate fields used by carbon isotopes if running with ciso module
     if (ciso_on) then
-      interior_tendency_share%QA_dust_def(k)    = QA_dust_def
-      interior_tendency_share%CO3_fields(k)   = carbonate%CO3(k)
-      interior_tendency_share%HCO3_fields(k)  = carbonate%HCO3(k)
-      interior_tendency_share%H2CO3_fields(k) = carbonate%H2CO3(k)
-      interior_tendency_share%CO3_sat_calcite(k) = carbonate%CO3_sat_calcite(k)
-      interior_tendency_share%DOCtot_loc_fields(k) = &
-           tracer_local(marbl_tracer_indices%DOC_ind) + tracer_local(marbl_tracer_indices%DOCr_ind)
-      interior_tendency_share%DOCtot_remin_fields(k) = &
-           dissolved_organic_matter%DOC_remin(k) + dissolved_organic_matter%DOCr_remin(k)
+      interior_tendency_share%QA_dust_def(:)    = QA_dust_def(:)
+      interior_tendency_share%CO3_fields(:)   = carbonate%CO3(:)
+      interior_tendency_share%HCO3_fields(:)  = carbonate%HCO3(:)
+      interior_tendency_share%H2CO3_fields(:) = carbonate%H2CO3(:)
+      interior_tendency_share%CO3_sat_calcite(:) = carbonate%CO3_sat_calcite(:)
+      interior_tendency_share%DOCtot_remin_fields(:) = &
+           dissolved_organic_matter%DOC_remin(:) + dissolved_organic_matter%DOCr_remin(:)
+      interior_tendency_share%DOCtot_loc_fields(:) = &
+           tracer_local(marbl_tracer_indices%DOC_ind,:) + tracer_local(marbl_tracer_indices%DOCr_ind,:)
     end if
 
   end subroutine marbl_interior_tendency_share_export_variables

--- a/src/marbl_interior_tendency_share_mod.F90
+++ b/src/marbl_interior_tendency_share_mod.F90
@@ -72,18 +72,18 @@ contains
        zooplankton_derived_terms, marbl_zooplankton_share)
 
     use marbl_interface_private_types, only : zooplankton_derived_terms_type
-    use marbl_pft_mod, only : zooplankton_local_type
+    use marbl_interface_private_types, only : zooplankton_local_type
     use marbl_pft_mod, only : marbl_zooplankton_share_type
 
     integer,                              intent(in)    :: k
-    type(zooplankton_local_type),         intent(in)    :: zooplankton_local(:)
+    type(zooplankton_local_type),         intent(in)    :: zooplankton_local
     type(zooplankton_derived_terms_type), intent(in)    :: zooplankton_derived_terms
     type(marbl_zooplankton_share_type),   intent(inout) :: marbl_zooplankton_share
 
     ! Populate fields used by carbon isotopes if running with ciso module
     if (ciso_on) then
       associate(share => marbl_zooplankton_share)
-         share%zoototC_loc_fields      = sum(zooplankton_local(:)%C)
+         share%zoototC_loc_fields      = sum(zooplankton_local%C(:,k))
          share%zootot_loss_fields      = sum(zooplankton_derived_terms%zoo_loss(:,k))
          share%zootot_loss_poc_fields  = sum(zooplankton_derived_terms%zoo_loss_poc(:,k))
          share%zootot_loss_doc_fields  = sum(zooplankton_derived_terms%zoo_loss_doc(:,k))

--- a/src/marbl_interior_tendency_share_mod.F90
+++ b/src/marbl_interior_tendency_share_mod.F90
@@ -70,30 +70,29 @@ contains
 
   !***********************************************************************
 
-  subroutine marbl_interior_tendency_share_export_zooplankton(k, zooplankton_local, &
+  subroutine marbl_interior_tendency_share_export_zooplankton(zooplankton_local, &
        zooplankton_derived_terms, zooplankton_share)
 
     use marbl_interface_private_types, only : zooplankton_derived_terms_type
     use marbl_interface_private_types, only : zooplankton_local_type
     use marbl_interface_private_types, only : zooplankton_share_type
 
-    integer,                              intent(in)    :: k
     type(zooplankton_local_type),         intent(in)    :: zooplankton_local
     type(zooplankton_derived_terms_type), intent(in)    :: zooplankton_derived_terms
     type(zooplankton_share_type),         intent(inout) :: zooplankton_share
 
     ! Populate fields used by carbon isotopes if running with ciso module
     if (ciso_on) then
-      zooplankton_share%zoototC_loc_fields(k)      = sum(zooplankton_local%C(:,k))
-      zooplankton_share%zootot_loss_fields(k)      = sum(zooplankton_derived_terms%zoo_loss(:,k))
-      zooplankton_share%zootot_loss_poc_fields(k)  = sum(zooplankton_derived_terms%zoo_loss_poc(:,k))
-      zooplankton_share%zootot_loss_doc_fields(k)  = sum(zooplankton_derived_terms%zoo_loss_doc(:,k))
-      zooplankton_share%zootot_loss_dic_fields(k)  = sum(zooplankton_derived_terms%zoo_loss_dic(:,k))
-      zooplankton_share%zootot_graze_fields(k)     = sum(zooplankton_derived_terms%zoo_graze(:,k))
-      zooplankton_share%zootot_graze_zoo_fields(k) = sum(zooplankton_derived_terms%zoo_graze_zoo(:,k))
-      zooplankton_share%zootot_graze_poc_fields(k) = sum(zooplankton_derived_terms%zoo_graze_poc(:,k))
-      zooplankton_share%zootot_graze_doc_fields(k) = sum(zooplankton_derived_terms%zoo_graze_doc(:,k))
-      zooplankton_share%zootot_graze_dic_fields(k) = sum(zooplankton_derived_terms%zoo_graze_dic(:,k))
+      zooplankton_share%zoototC_loc_fields(:)      = sum(zooplankton_local%C(:,:), dim=1)
+      zooplankton_share%zootot_loss_fields(:)      = sum(zooplankton_derived_terms%zoo_loss(:,:), dim=1)
+      zooplankton_share%zootot_loss_poc_fields(:)  = sum(zooplankton_derived_terms%zoo_loss_poc(:,:), dim=1)
+      zooplankton_share%zootot_loss_doc_fields(:)  = sum(zooplankton_derived_terms%zoo_loss_doc(:,:), dim=1)
+      zooplankton_share%zootot_loss_dic_fields(:)  = sum(zooplankton_derived_terms%zoo_loss_dic(:,:), dim=1)
+      zooplankton_share%zootot_graze_fields(:)     = sum(zooplankton_derived_terms%zoo_graze(:,:), dim=1)
+      zooplankton_share%zootot_graze_zoo_fields(:) = sum(zooplankton_derived_terms%zoo_graze_zoo(:,:), dim=1)
+      zooplankton_share%zootot_graze_poc_fields(:) = sum(zooplankton_derived_terms%zoo_graze_poc(:,:), dim=1)
+      zooplankton_share%zootot_graze_doc_fields(:) = sum(zooplankton_derived_terms%zoo_graze_doc(:,:), dim=1)
+      zooplankton_share%zootot_graze_dic_fields(:) = sum(zooplankton_derived_terms%zoo_graze_dic(:,:), dim=1)
     end if
 
   end subroutine marbl_interior_tendency_share_export_zooplankton

--- a/src/marbl_interior_tendency_share_mod.F90
+++ b/src/marbl_interior_tendency_share_mod.F90
@@ -32,6 +32,7 @@ contains
   !***********************************************************************
 
   subroutine marbl_interior_tendency_share_export_variables(&
+       k, &
        tracer_local, &
        marbl_tracer_indices, &
        carbonate, &
@@ -44,6 +45,7 @@ contains
     use marbl_interface_private_types, only : dissolved_organic_matter_type
     use marbl_interface_private_types, only : marbl_interior_tendency_share_type
 
+    integer,                                  intent(in)    :: k
     real(r8),                                 intent(in)    :: tracer_local(:)
     type(marbl_tracer_index_type),            intent(in)    :: marbl_tracer_indices
     type(carbonate_type),                     intent(in)    :: carbonate
@@ -61,7 +63,7 @@ contains
       marbl_interior_tendency_share%DOCtot_loc_fields = &
            tracer_local(marbl_tracer_indices%DOC_ind) + tracer_local(marbl_tracer_indices%DOCr_ind)
       marbl_interior_tendency_share%DOCtot_remin_fields = &
-           dissolved_organic_matter%DOC_remin + dissolved_organic_matter%DOCr_remin
+           dissolved_organic_matter%DOC_remin(k) + dissolved_organic_matter%DOCr_remin(k)
     end if
 
   end subroutine marbl_interior_tendency_share_export_variables

--- a/src/marbl_interior_tendency_share_mod.F90
+++ b/src/marbl_interior_tendency_share_mod.F90
@@ -69,30 +69,30 @@ contains
   !***********************************************************************
 
   subroutine marbl_interior_tendency_share_export_zooplankton(k, zooplankton_local, &
-       zooplankton_secondary_species, marbl_zooplankton_share)
+       zooplankton_derived_terms, marbl_zooplankton_share)
 
-    use marbl_interface_private_types, only : zooplankton_secondary_species_type
+    use marbl_interface_private_types, only : zooplankton_derived_terms_type
     use marbl_pft_mod, only : zooplankton_local_type
     use marbl_pft_mod, only : marbl_zooplankton_share_type
 
-    integer,                                   intent(in)    :: k
-    type(zooplankton_local_type)             , intent(in)    :: zooplankton_local(:)
-    type(zooplankton_secondary_species_type) , intent(in)    :: zooplankton_secondary_species
-    type(marbl_zooplankton_share_type)       , intent(inout) :: marbl_zooplankton_share
+    integer,                              intent(in)    :: k
+    type(zooplankton_local_type),         intent(in)    :: zooplankton_local(:)
+    type(zooplankton_derived_terms_type), intent(in)    :: zooplankton_derived_terms
+    type(marbl_zooplankton_share_type),   intent(inout) :: marbl_zooplankton_share
 
     ! Populate fields used by carbon isotopes if running with ciso module
     if (ciso_on) then
       associate(share => marbl_zooplankton_share)
          share%zoototC_loc_fields      = sum(zooplankton_local(:)%C)
-         share%zootot_loss_fields      = sum(zooplankton_secondary_species%zoo_loss(:,k))
-         share%zootot_loss_poc_fields  = sum(zooplankton_secondary_species%zoo_loss_poc(:,k))
-         share%zootot_loss_doc_fields  = sum(zooplankton_secondary_species%zoo_loss_doc(:,k))
-         share%zootot_loss_dic_fields  = sum(zooplankton_secondary_species%zoo_loss_dic(:,k))
-         share%zootot_graze_fields     = sum(zooplankton_secondary_species%zoo_graze(:,k))
-         share%zootot_graze_zoo_fields = sum(zooplankton_secondary_species%zoo_graze_zoo(:,k))
-         share%zootot_graze_poc_fields = sum(zooplankton_secondary_species%zoo_graze_poc(:,k))
-         share%zootot_graze_doc_fields = sum(zooplankton_secondary_species%zoo_graze_doc(:,k))
-         share%zootot_graze_dic_fields = sum(zooplankton_secondary_species%zoo_graze_dic(:,k))
+         share%zootot_loss_fields      = sum(zooplankton_derived_terms%zoo_loss(:,k))
+         share%zootot_loss_poc_fields  = sum(zooplankton_derived_terms%zoo_loss_poc(:,k))
+         share%zootot_loss_doc_fields  = sum(zooplankton_derived_terms%zoo_loss_doc(:,k))
+         share%zootot_loss_dic_fields  = sum(zooplankton_derived_terms%zoo_loss_dic(:,k))
+         share%zootot_graze_fields     = sum(zooplankton_derived_terms%zoo_graze(:,k))
+         share%zootot_graze_zoo_fields = sum(zooplankton_derived_terms%zoo_graze_zoo(:,k))
+         share%zootot_graze_poc_fields = sum(zooplankton_derived_terms%zoo_graze_poc(:,k))
+         share%zootot_graze_doc_fields = sum(zooplankton_derived_terms%zoo_graze_doc(:,k))
+         share%zootot_graze_dic_fields = sum(zooplankton_derived_terms%zoo_graze_dic(:,k))
       end associate
     end if
 

--- a/src/marbl_interior_tendency_share_mod.F90
+++ b/src/marbl_interior_tendency_share_mod.F90
@@ -71,31 +71,29 @@ contains
   !***********************************************************************
 
   subroutine marbl_interior_tendency_share_export_zooplankton(k, zooplankton_local, &
-       zooplankton_derived_terms, marbl_zooplankton_share)
+       zooplankton_derived_terms, zooplankton_share)
 
     use marbl_interface_private_types, only : zooplankton_derived_terms_type
     use marbl_interface_private_types, only : zooplankton_local_type
-    use marbl_pft_mod, only : marbl_zooplankton_share_type
+    use marbl_interface_private_types, only : zooplankton_share_type
 
     integer,                              intent(in)    :: k
     type(zooplankton_local_type),         intent(in)    :: zooplankton_local
     type(zooplankton_derived_terms_type), intent(in)    :: zooplankton_derived_terms
-    type(marbl_zooplankton_share_type),   intent(inout) :: marbl_zooplankton_share
+    type(zooplankton_share_type),         intent(inout) :: zooplankton_share
 
     ! Populate fields used by carbon isotopes if running with ciso module
     if (ciso_on) then
-      associate(share => marbl_zooplankton_share)
-         share%zoototC_loc_fields      = sum(zooplankton_local%C(:,k))
-         share%zootot_loss_fields      = sum(zooplankton_derived_terms%zoo_loss(:,k))
-         share%zootot_loss_poc_fields  = sum(zooplankton_derived_terms%zoo_loss_poc(:,k))
-         share%zootot_loss_doc_fields  = sum(zooplankton_derived_terms%zoo_loss_doc(:,k))
-         share%zootot_loss_dic_fields  = sum(zooplankton_derived_terms%zoo_loss_dic(:,k))
-         share%zootot_graze_fields     = sum(zooplankton_derived_terms%zoo_graze(:,k))
-         share%zootot_graze_zoo_fields = sum(zooplankton_derived_terms%zoo_graze_zoo(:,k))
-         share%zootot_graze_poc_fields = sum(zooplankton_derived_terms%zoo_graze_poc(:,k))
-         share%zootot_graze_doc_fields = sum(zooplankton_derived_terms%zoo_graze_doc(:,k))
-         share%zootot_graze_dic_fields = sum(zooplankton_derived_terms%zoo_graze_dic(:,k))
-      end associate
+      zooplankton_share%zoototC_loc_fields(k)      = sum(zooplankton_local%C(:,k))
+      zooplankton_share%zootot_loss_fields(k)      = sum(zooplankton_derived_terms%zoo_loss(:,k))
+      zooplankton_share%zootot_loss_poc_fields(k)  = sum(zooplankton_derived_terms%zoo_loss_poc(:,k))
+      zooplankton_share%zootot_loss_doc_fields(k)  = sum(zooplankton_derived_terms%zoo_loss_doc(:,k))
+      zooplankton_share%zootot_loss_dic_fields(k)  = sum(zooplankton_derived_terms%zoo_loss_dic(:,k))
+      zooplankton_share%zootot_graze_fields(k)     = sum(zooplankton_derived_terms%zoo_graze(:,k))
+      zooplankton_share%zootot_graze_zoo_fields(k) = sum(zooplankton_derived_terms%zoo_graze_zoo(:,k))
+      zooplankton_share%zootot_graze_poc_fields(k) = sum(zooplankton_derived_terms%zoo_graze_poc(:,k))
+      zooplankton_share%zootot_graze_doc_fields(k) = sum(zooplankton_derived_terms%zoo_graze_doc(:,k))
+      zooplankton_share%zootot_graze_dic_fields(k) = sum(zooplankton_derived_terms%zoo_graze_dic(:,k))
     end if
 
   end subroutine marbl_interior_tendency_share_export_zooplankton

--- a/src/marbl_interior_tendency_share_mod.F90
+++ b/src/marbl_interior_tendency_share_mod.F90
@@ -33,8 +33,8 @@ contains
 
   subroutine marbl_interior_tendency_share_export_variables(&
        k, &
-       tracer_local, &
        marbl_tracer_indices, &
+       tracer_local, &
        carbonate, &
        dissolved_organic_matter, &
        QA_dust_def, &
@@ -46,8 +46,8 @@ contains
     use marbl_interface_private_types, only : marbl_interior_tendency_share_type
 
     integer,                                  intent(in)    :: k
-    real(r8),                                 intent(in)    :: tracer_local(:)
     type(marbl_tracer_index_type),            intent(in)    :: marbl_tracer_indices
+    real(r8),                                 intent(in)    :: tracer_local(marbl_tracer_indices%total_cnt)
     type(carbonate_type),                     intent(in)    :: carbonate
     type(dissolved_organic_matter_type),      intent(in)    :: dissolved_organic_matter
     real(r8),                                 intent(in)    :: QA_dust_def
@@ -56,10 +56,10 @@ contains
     ! Populate fields used by carbon isotopes if running with ciso module
     if (ciso_on) then
       interior_tendency_share%QA_dust_def(k)    = QA_dust_def
-      interior_tendency_share%CO3_fields(k)   = carbonate%CO3
-      interior_tendency_share%HCO3_fields(k)  = carbonate%HCO3
-      interior_tendency_share%H2CO3_fields(k) = carbonate%H2CO3
-      interior_tendency_share%CO3_sat_calcite(k) = carbonate%CO3_sat_calcite
+      interior_tendency_share%CO3_fields(k)   = carbonate%CO3(k)
+      interior_tendency_share%HCO3_fields(k)  = carbonate%HCO3(k)
+      interior_tendency_share%H2CO3_fields(k) = carbonate%H2CO3(k)
+      interior_tendency_share%CO3_sat_calcite(k) = carbonate%CO3_sat_calcite(k)
       interior_tendency_share%DOCtot_loc_fields(k) = &
            tracer_local(marbl_tracer_indices%DOC_ind) + tracer_local(marbl_tracer_indices%DOCr_ind)
       interior_tendency_share%DOCtot_remin_fields(k) = &

--- a/src/marbl_interior_tendency_share_mod.F90
+++ b/src/marbl_interior_tendency_share_mod.F90
@@ -68,32 +68,31 @@ contains
 
   !***********************************************************************
 
-  subroutine marbl_interior_tendency_share_export_zooplankton(&
-       zooplankton_local, &
-       zooplankton_secondary_species, &
-       marbl_zooplankton_share)
+  subroutine marbl_interior_tendency_share_export_zooplankton(k, zooplankton_local, &
+       zooplankton_secondary_species, marbl_zooplankton_share)
 
+    use marbl_interface_private_types, only : zooplankton_secondary_species_type
     use marbl_pft_mod, only : zooplankton_local_type
-    use marbl_pft_mod, only : zooplankton_secondary_species_type
     use marbl_pft_mod, only : marbl_zooplankton_share_type
 
+    integer,                                   intent(in)    :: k
     type(zooplankton_local_type)             , intent(in)    :: zooplankton_local(:)
-    type(zooplankton_secondary_species_type) , intent(in)    :: zooplankton_secondary_species(:)
+    type(zooplankton_secondary_species_type) , intent(in)    :: zooplankton_secondary_species
     type(marbl_zooplankton_share_type)       , intent(inout) :: marbl_zooplankton_share
 
     ! Populate fields used by carbon isotopes if running with ciso module
     if (ciso_on) then
       associate(share => marbl_zooplankton_share)
          share%zoototC_loc_fields      = sum(zooplankton_local(:)%C)
-         share%zootot_loss_fields      = sum(zooplankton_secondary_species(:)%zoo_loss)
-         share%zootot_loss_poc_fields  = sum(zooplankton_secondary_species(:)%zoo_loss_poc)
-         share%zootot_loss_doc_fields  = sum(zooplankton_secondary_species(:)%zoo_loss_doc)
-         share%zootot_loss_dic_fields  = sum(zooplankton_secondary_species(:)%zoo_loss_dic)
-         share%zootot_graze_fields     = sum(zooplankton_secondary_species(:)%zoo_graze)
-         share%zootot_graze_zoo_fields = sum(zooplankton_secondary_species(:)%zoo_graze_zoo)
-         share%zootot_graze_poc_fields = sum(zooplankton_secondary_species(:)%zoo_graze_poc)
-         share%zootot_graze_doc_fields = sum(zooplankton_secondary_species(:)%zoo_graze_doc)
-         share%zootot_graze_dic_fields = sum(zooplankton_secondary_species(:)%zoo_graze_dic)
+         share%zootot_loss_fields      = sum(zooplankton_secondary_species%zoo_loss(:,k))
+         share%zootot_loss_poc_fields  = sum(zooplankton_secondary_species%zoo_loss_poc(:,k))
+         share%zootot_loss_doc_fields  = sum(zooplankton_secondary_species%zoo_loss_doc(:,k))
+         share%zootot_loss_dic_fields  = sum(zooplankton_secondary_species%zoo_loss_dic(:,k))
+         share%zootot_graze_fields     = sum(zooplankton_secondary_species%zoo_graze(:,k))
+         share%zootot_graze_zoo_fields = sum(zooplankton_secondary_species%zoo_graze_zoo(:,k))
+         share%zootot_graze_poc_fields = sum(zooplankton_secondary_species%zoo_graze_poc(:,k))
+         share%zootot_graze_doc_fields = sum(zooplankton_secondary_species%zoo_graze_doc(:,k))
+         share%zootot_graze_dic_fields = sum(zooplankton_secondary_species%zoo_graze_dic(:,k))
       end associate
     end if
 

--- a/src/marbl_interior_tendency_share_mod.F90
+++ b/src/marbl_interior_tendency_share_mod.F90
@@ -38,7 +38,7 @@ contains
        carbonate, &
        dissolved_organic_matter, &
        QA_dust_def, &
-       marbl_interior_tendency_share)
+       interior_tendency_share)
 
     use marbl_interface_private_types, only : marbl_tracer_index_type
     use marbl_interface_private_types, only : carbonate_type
@@ -51,18 +51,18 @@ contains
     type(carbonate_type),                     intent(in)    :: carbonate
     type(dissolved_organic_matter_type),      intent(in)    :: dissolved_organic_matter
     real(r8),                                 intent(in)    :: QA_dust_def
-    type(marbl_interior_tendency_share_type), intent(inout) :: marbl_interior_tendency_share
+    type(marbl_interior_tendency_share_type), intent(inout) :: interior_tendency_share
 
     ! Populate fields used by carbon isotopes if running with ciso module
     if (ciso_on) then
-      marbl_interior_tendency_share%QA_dust_def    = QA_dust_def
-      marbl_interior_tendency_share%CO3_fields   = carbonate%CO3
-      marbl_interior_tendency_share%HCO3_fields  = carbonate%HCO3
-      marbl_interior_tendency_share%H2CO3_fields = carbonate%H2CO3
-      marbl_interior_tendency_share%CO3_sat_calcite = carbonate%CO3_sat_calcite
-      marbl_interior_tendency_share%DOCtot_loc_fields = &
+      interior_tendency_share%QA_dust_def(k)    = QA_dust_def
+      interior_tendency_share%CO3_fields(k)   = carbonate%CO3
+      interior_tendency_share%HCO3_fields(k)  = carbonate%HCO3
+      interior_tendency_share%H2CO3_fields(k) = carbonate%H2CO3
+      interior_tendency_share%CO3_sat_calcite(k) = carbonate%CO3_sat_calcite
+      interior_tendency_share%DOCtot_loc_fields(k) = &
            tracer_local(marbl_tracer_indices%DOC_ind) + tracer_local(marbl_tracer_indices%DOCr_ind)
-      marbl_interior_tendency_share%DOCtot_remin_fields = &
+      interior_tendency_share%DOCtot_remin_fields(k) = &
            dissolved_organic_matter%DOC_remin(k) + dissolved_organic_matter%DOCr_remin(k)
     end if
 

--- a/src/marbl_pft_mod.F90
+++ b/src/marbl_pft_mod.F90
@@ -117,55 +117,6 @@ module marbl_pft_mod
 
   !*****************************************************************************
 
-  type, public :: autotroph_secondary_species_type
-     real(r8) :: thetaC          ! current Chl/C ratio (mg Chl/mmol C)
-     real(r8) :: QCaCO3          ! current CaCO3/C ratio (mmol CaCO3/mmol C)
-     real(r8) :: Qp              ! current P/C ratio (mmol P/mmol C)
-     real(r8) :: gQp             ! P/C for growth
-     real(r8) :: Qfe             ! current Fe/C ratio (mmol Fe/mmol C)
-     real(r8) :: gQfe            ! fe/C for growth
-     real(r8) :: Qsi             ! current Si/C ratio (mmol Si/mmol C)
-     real(r8) :: gQsi            ! diatom Si/C ratio for growth (new biomass)
-     real(r8) :: VNO3            ! NH4 uptake rate (non-dim)
-     real(r8) :: VNH4            ! NO3 uptake rate (non-dim)
-     real(r8) :: VNtot           ! total N uptake rate (non-dim)
-     real(r8) :: NO3_V           ! nitrate uptake (mmol NO3/m^3/sec)
-     real(r8) :: NH4_V           ! ammonium uptake (mmol NH4/m^3/sec)
-     real(r8) :: PO4_V           ! PO4 uptake (mmol PO4/m^3/sec)
-     real(r8) :: DOP_V           ! DOP uptake (mmol DOP/m^3/sec)
-     real(r8) :: VPO4            ! C-specific PO4 uptake (non-dim)
-     real(r8) :: VDOP            ! C-specific DOP uptake rate (non-dim)
-     real(r8) :: VPtot           ! total P uptake rate (non-dim)
-     real(r8) :: f_nut           ! nut limitation factor, modifies C fixation (non-dim)
-     real(r8) :: VFe             ! C-specific Fe uptake (non-dim)
-     real(r8) :: VSiO3           ! C-specific SiO3 uptake (non-dim)
-     real(r8) :: light_lim       ! light limitation factor
-     real(r8) :: PCphoto         ! C-specific rate of photosynth. (1/sec)
-     real(r8) :: photoC          ! C-fixation (mmol C/m^3/sec)
-     real(r8) :: photoFe         ! iron uptake
-     real(r8) :: photoSi         ! silicon uptake (mmol Si/m^3/sec)
-     real(r8) :: photoacc        ! Chl synth. term in photoadapt. (GD98) (mg Chl/m^3/sec)
-     real(r8) :: auto_loss       ! autotroph non-grazing mort (mmol C/m^3/sec)
-     real(r8) :: auto_loss_poc   ! auto_loss routed to poc (mmol C/m^3/sec)
-     real(r8) :: auto_loss_doc   ! auto_loss routed to doc (mmol C/m^3/sec)
-     real(r8) :: auto_loss_dic   ! auto_loss routed to dic (mmol C/m^3/sec)
-     real(r8) :: auto_agg        ! autotroph aggregation (mmol C/m^3/sec)
-     real(r8) :: auto_graze      ! autotroph grazing rate (mmol C/m^3/sec)
-     real(r8) :: auto_graze_zoo  ! auto_graze routed to zoo (mmol C/m^3/sec)
-     real(r8) :: auto_graze_poc  ! auto_graze routed to poc (mmol C/m^3/sec)
-     real(r8) :: auto_graze_doc  ! auto_graze routed to doc (mmol C/m^3/sec)
-     real(r8) :: auto_graze_dic  ! auto_graze routed to dic (mmol C/m^3/sec)
-     real(r8) :: Pprime          ! used to limit autotroph mort at low biomass (mmol C/m^3)
-     real(r8) :: CaCO3_form      ! calcification of CaCO3 by small phyto (mmol CaCO3/m^3/sec)
-     real(r8) :: Nfix            ! total Nitrogen fixation (mmol N/m^3/sec)
-     real(r8) :: Nexcrete        ! fixed N excretion
-     real(r8) :: remaining_P_dop ! remaining_P from grazing routed to DOP pool
-     real(r8) :: remaining_P_pop ! remaining_P from grazing routed to POP pool
-     real(r8) :: remaining_P_dip ! remaining_P from grazing routed to remin
-  end type autotroph_secondary_species_type
-
-  !*****************************************************************************
-
   type, public :: zooplankton_secondary_species_type
      real(r8) :: f_zoo_detr       ! frac of zoo losses into large detrital pool (non-dim)
      real(r8) :: x_graze_zoo      ! {auto, zoo}_graze routed to zoo (mmol C/m^3/sec)

--- a/src/marbl_pft_mod.F90
+++ b/src/marbl_pft_mod.F90
@@ -60,11 +60,6 @@ module marbl_pft_mod
      procedure, public :: set_to_default => zooplankton_set_to_default
   end type zooplankton_settings_type
 
-  type, public :: zooplankton_local_type
-    ! FIXME #316: replace with indices into tracer_local
-    real (r8) :: C  ! local copy of model zooplankton C
-  end type zooplankton_local_type
-
   !****************************************************************************
   ! derived types for grazer settings
 

--- a/src/marbl_pft_mod.F90
+++ b/src/marbl_pft_mod.F90
@@ -15,7 +15,6 @@ module marbl_pft_mod
   real(r8), parameter :: UnsetValue = 1e34_r8
 
   !****************************************************************************
-  ! derived types for autotroph settings
 
   type, public :: autotroph_settings_type
     character(len=char_len) :: sname
@@ -46,7 +45,6 @@ module marbl_pft_mod
   end type autotroph_settings_type
 
   !****************************************************************************
-  ! derived types for zooplankton settings
 
   type, public :: zooplankton_settings_type
      character(len=char_len) :: sname
@@ -61,7 +59,6 @@ module marbl_pft_mod
   end type zooplankton_settings_type
 
   !****************************************************************************
-  ! derived types for grazer settings
 
   type, public :: grazing_relationship_settings_type
     character(len=char_len) :: sname

--- a/src/marbl_pft_mod.F90
+++ b/src/marbl_pft_mod.F90
@@ -45,19 +45,6 @@ module marbl_pft_mod
     procedure, public :: set_to_default => autotroph_set_to_default
   end type autotroph_type
 
-  type, public :: autotroph_local_type
-     real (r8) :: Chl   ! local copy of model autotroph Chl
-     real (r8) :: C     ! local copy of model autotroph C
-     real (r8) :: P     ! local copy of model autotroph P
-     real (r8) :: Fe    ! local copy of model autotroph Fe
-     real (r8) :: Si    ! local copy of model autotroph Si
-     real (r8) :: CaCO3 ! local copy of model autotroph CaCO3
-     real (r8) :: C13     ! local copy of model autotroph C13
-     real (r8) :: C14     ! local copy of model autotroph C14
-     real (r8) :: Ca13CO3 ! local copy of model autotroph Ca13CO3
-     real (r8) :: Ca14CO3 ! local copy of model autotroph Ca14CO3
-  end type autotroph_local_type
-
   !****************************************************************************
   ! derived types for zooplankton
 

--- a/src/marbl_pft_mod.F90
+++ b/src/marbl_pft_mod.F90
@@ -115,23 +115,6 @@ module marbl_pft_mod
      real(r8) :: zootot_graze_dic_fields ! grazing of zooplankton routed to dic (mmol C/m^3/sec)
   end type marbl_zooplankton_share_type
 
-  !*****************************************************************************
-
-  type, public :: zooplankton_secondary_species_type
-     real(r8) :: f_zoo_detr       ! frac of zoo losses into large detrital pool (non-dim)
-     real(r8) :: x_graze_zoo      ! {auto, zoo}_graze routed to zoo (mmol C/m^3/sec)
-     real(r8) :: zoo_graze        ! zooplankton losses due to grazing (mmol C/m^3/sec)
-     real(r8) :: zoo_graze_zoo    ! grazing of zooplankton routed to zoo (mmol C/m^3/sec)
-     real(r8) :: zoo_graze_poc    ! grazing of zooplankton routed to poc (mmol C/m^3/sec)
-     real(r8) :: zoo_graze_doc    ! grazing of zooplankton routed to doc (mmol C/m^3/sec)
-     real(r8) :: zoo_graze_dic    ! grazing of zooplankton routed to dic (mmol C/m^3/sec)
-     real(r8) :: zoo_loss         ! mortality & higher trophic grazing on zooplankton (mmol C/m^3/sec)
-     real(r8) :: zoo_loss_poc     ! zoo_loss routed to poc (mmol C/m^3/sec)
-     real(r8) :: zoo_loss_doc     ! zoo_loss routed to doc (mmol C/m^3/sec)
-     real(r8) :: zoo_loss_dic     ! zoo_loss routed to dic (mmol C/m^3/sec)
-     real(r8) :: Zprime           ! used to limit zoo mort at low biomass (mmol C/m^3)
-  end type zooplankton_secondary_species_type
-
   !****************************************************************************
 
   ! Public parameters

--- a/src/marbl_pft_mod.F90
+++ b/src/marbl_pft_mod.F90
@@ -15,9 +15,9 @@ module marbl_pft_mod
   real(r8), parameter :: UnsetValue = 1e34_r8
 
   !****************************************************************************
-  ! derived types for autotrophs
+  ! derived types for autotroph settings
 
-  type, public :: autotroph_type
+  type, public :: autotroph_settings_type
     character(len=char_len) :: sname
     character(len=char_len) :: lname
     logical(log_kind)       :: Nfixer                             ! flag set to true if this autotroph fixes N2
@@ -43,7 +43,7 @@ module marbl_pft_mod
     real(r8)                :: loss_poc                           ! routing of loss term
   contains
     procedure, public :: set_to_default => autotroph_set_to_default
-  end type autotroph_type
+  end type autotroph_settings_type
 
   !****************************************************************************
   ! derived types for zooplankton
@@ -61,7 +61,8 @@ module marbl_pft_mod
   end type zooplankton_type
 
   type, public :: zooplankton_local_type
-     real (r8) :: C  ! local copy of model zooplankton C
+    ! FIXME #316: replace with indices into tracer_local
+    real (r8) :: C  ! local copy of model zooplankton C
   end type zooplankton_local_type
 
   !****************************************************************************
@@ -70,8 +71,8 @@ module marbl_pft_mod
   type, public :: grazing_type
     character(len=char_len) :: sname
     character(len=char_len) :: lname
-    integer(int_kind)       :: auto_ind_cnt     ! number of autotrophs in prey-clase auto_ind
-    integer(int_kind)       :: zoo_ind_cnt      ! number of zooplankton in prey-clase zoo_ind
+    integer(int_kind)       :: auto_ind_cnt     ! number of autotrophs in prey-class auto_ind
+    integer(int_kind)       :: zoo_ind_cnt      ! number of zooplankton in prey-class zoo_ind
     integer(int_kind)       :: grazing_function ! functional form of grazing parameterization
     real(r8)                :: z_umax_0_per_day ! max zoo growth rate at tref (1/day)
     real(r8)                :: z_umax_0         ! max zoo growth rate at tref (1/sec) (derived from z_umax_0_per_day)
@@ -117,9 +118,9 @@ contains
 
   subroutine autotroph_set_to_default(self, autotroph_id, marbl_status_log)
 
-    class(autotroph_type), intent(out)   :: self
-    character(len=*),      intent(in)    :: autotroph_id
-    type(marbl_log_type),  intent(inout) :: marbl_status_log
+    class(autotroph_settings_type), intent(out)   :: self
+    character(len=*),               intent(in)    :: autotroph_id
+    type(marbl_log_type),           intent(inout) :: marbl_status_log
 
     character(len=*), parameter :: subname = 'marbl_pft_mod:autotroph_set_to_default'
     character(len=char_len)     :: log_message

--- a/src/marbl_pft_mod.F90
+++ b/src/marbl_pft_mod.F90
@@ -63,7 +63,7 @@ module marbl_pft_mod
   !****************************************************************************
   ! derived types for grazer settings
 
-  type, public :: grazer_settings_type
+  type, public :: grazing_relationship_settings_type
     character(len=char_len) :: sname
     character(len=char_len) :: lname
     integer(int_kind)       :: auto_ind_cnt     ! number of autotrophs in prey-class auto_ind
@@ -81,7 +81,7 @@ module marbl_pft_mod
   contains
     procedure, public :: set_to_default => grazer_set_to_default
     procedure, public :: construct => grazer_constructor
-  end type grazer_settings_type
+  end type grazing_relationship_settings_type
 
   !****************************************************************************
 
@@ -258,9 +258,9 @@ contains
 
   subroutine grazer_set_to_default(self, grazer_id, marbl_status_log)
 
-    class(grazer_settings_type), intent(inout) :: self
-    character(len=*),            intent(in)    :: grazer_id
-    type(marbl_log_type),        intent(inout) :: marbl_status_log
+    class(grazing_relationship_settings_type), intent(inout) :: self
+    character(len=*),                          intent(in)    :: grazer_id
+    type(marbl_log_type),                      intent(inout) :: marbl_status_log
 
     character(len=*), parameter :: subname = 'marbl_pft_mod:grazer_set_to_default'
     character(len=char_len)     :: log_message
@@ -330,10 +330,10 @@ contains
 
   subroutine grazer_constructor(self, autotroph_cnt, zooplankton_cnt, marbl_status_log)
 
-    class(grazer_settings_type), intent(out)   :: self
-    integer(int_kind),           intent(in)    :: autotroph_cnt
-    integer(int_kind),           intent(in)    :: zooplankton_cnt
-    type(marbl_log_type),        intent(inout) :: marbl_status_log
+    class(grazing_relationship_settings_type), intent(out)   :: self
+    integer(int_kind),                         intent(in)    :: autotroph_cnt
+    integer(int_kind),                         intent(in)    :: zooplankton_cnt
+    type(marbl_log_type),                      intent(inout) :: marbl_status_log
 
     character(len=*), parameter :: subname = 'marbl_pft_mod:grazer_constructor'
     character(len=char_len)     :: log_message

--- a/src/marbl_pft_mod.F90
+++ b/src/marbl_pft_mod.F90
@@ -46,9 +46,9 @@ module marbl_pft_mod
   end type autotroph_settings_type
 
   !****************************************************************************
-  ! derived types for zooplankton
+  ! derived types for zooplankton settings
 
-  type, public :: zooplankton_type
+  type, public :: zooplankton_settings_type
      character(len=char_len) :: sname
      character(len=char_len) :: lname
      real(r8)                :: z_mort_0_per_day   ! zoo linear mort rate (1/day)
@@ -58,7 +58,7 @@ module marbl_pft_mod
      real(r8)                :: loss_thres         ! zoo conc. where losses go to zero
    contains
      procedure, public :: set_to_default => zooplankton_set_to_default
-  end type zooplankton_type
+  end type zooplankton_settings_type
 
   type, public :: zooplankton_local_type
     ! FIXME #316: replace with indices into tracer_local
@@ -66,9 +66,9 @@ module marbl_pft_mod
   end type zooplankton_local_type
 
   !****************************************************************************
-  ! derived types for grazing
+  ! derived types for grazer settings
 
-  type, public :: grazing_type
+  type, public :: grazer_settings_type
     character(len=char_len) :: sname
     character(len=char_len) :: lname
     integer(int_kind)       :: auto_ind_cnt     ! number of autotrophs in prey-class auto_ind
@@ -84,9 +84,9 @@ module marbl_pft_mod
     integer(int_kind), allocatable :: auto_ind(:)
     integer(int_kind), allocatable :: zoo_ind(:)
   contains
-    procedure, public :: set_to_default => grazing_set_to_default
-    procedure, public :: construct => grazing_constructor
-  end type grazing_type
+    procedure, public :: set_to_default => grazer_set_to_default
+    procedure, public :: construct => grazer_constructor
+  end type grazer_settings_type
 
   !***********************************************************************
 
@@ -246,9 +246,9 @@ contains
 
   subroutine zooplankton_set_to_default(self, zooplankton_id, marbl_status_log)
 
-    class(zooplankton_type), intent(out)   :: self
-    character(len=*),        intent(in)    :: zooplankton_id
-    type(marbl_log_type),    intent(inout) :: marbl_status_log
+    class(zooplankton_settings_type), intent(out)   :: self
+    character(len=*),                 intent(in)    :: zooplankton_id
+    type(marbl_log_type),             intent(inout) :: marbl_status_log
 
     character(len=*), parameter :: subname = 'marbl_pft_mod:zooplankton_set_to_default'
     character(len=char_len)     :: log_message
@@ -276,16 +276,16 @@ contains
 
   !*****************************************************************************
 
-  subroutine grazing_set_to_default(self, grazing_id, marbl_status_log)
+  subroutine grazer_set_to_default(self, grazer_id, marbl_status_log)
 
-    class(grazing_type),  intent(inout) :: self
-    character(len=*),     intent(in)    :: grazing_id
-    type(marbl_log_type), intent(inout) :: marbl_status_log
+    class(grazer_settings_type), intent(inout) :: self
+    character(len=*),            intent(in)    :: grazer_id
+    type(marbl_log_type),        intent(inout) :: marbl_status_log
 
-    character(len=*), parameter :: subname = 'marbl_pft_mod:grazing_set_to_default'
+    character(len=*), parameter :: subname = 'marbl_pft_mod:grazer_set_to_default'
     character(len=char_len)     :: log_message
 
-    select case (grazing_id)
+    select case (grazer_id)
       case ('sp_zoo')
         self%sname = 'grz_sp_zoo'                         ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE in marbl_settings_mod
         self%lname = 'Grazing of sp by zoo'               ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE in marbl_settings_mod
@@ -340,22 +340,22 @@ contains
         self%f_zoo_detr       = UnsetValue
         self%grazing_function = grz_fnc_michaelis_menten
       case DEFAULT
-        write(log_message, "(3A)") "'", grazing_id, "' is not a valid grazing ID"
+        write(log_message, "(3A)") "'", grazer_id, "' is not a valid grazing ID"
         call marbl_status_log%log_error(log_message, subname)
         return
     end select
 
-  end subroutine grazing_set_to_default
+  end subroutine grazer_set_to_default
   !*****************************************************************************
 
-  subroutine grazing_constructor(self, autotroph_cnt, zooplankton_cnt, marbl_status_log)
+  subroutine grazer_constructor(self, autotroph_cnt, zooplankton_cnt, marbl_status_log)
 
-    class(grazing_type),  intent(out)   :: self
-    integer(int_kind),    intent(in)    :: autotroph_cnt
-    integer(int_kind),    intent(in)    :: zooplankton_cnt
-    type(marbl_log_type), intent(inout) :: marbl_status_log
+    class(grazer_settings_type), intent(out)   :: self
+    integer(int_kind),           intent(in)    :: autotroph_cnt
+    integer(int_kind),           intent(in)    :: zooplankton_cnt
+    type(marbl_log_type),        intent(inout) :: marbl_status_log
 
-    character(len=*), parameter :: subname = 'marbl_pft_mod:grazing_constructor'
+    character(len=*), parameter :: subname = 'marbl_pft_mod:grazer_constructor'
     character(len=char_len)     :: log_message
 
     if (allocated(self%auto_ind)) then
@@ -373,7 +373,7 @@ contains
     allocate(self%auto_ind(autotroph_cnt))
     allocate(self%zoo_ind(zooplankton_cnt))
 
-  end subroutine grazing_constructor
+  end subroutine grazer_constructor
 
   !*****************************************************************************
 

--- a/src/marbl_pft_mod.F90
+++ b/src/marbl_pft_mod.F90
@@ -83,21 +83,6 @@ module marbl_pft_mod
     procedure, public :: construct => grazer_constructor
   end type grazer_settings_type
 
-  !***********************************************************************
-
-  type, public :: marbl_zooplankton_share_type
-     real(r8) :: zoototC_loc_fields      ! local copy of model zooC
-     real(r8) :: zootot_loss_fields      ! mortality & higher trophic grazing on zooplankton (mmol C/m^3/sec)
-     real(r8) :: zootot_loss_poc_fields  ! zoo_loss routed to large detrital (mmol C/m^3/sec)
-     real(r8) :: zootot_loss_doc_fields  ! zoo_loss routed to doc (mmol C/m^3/sec)
-     real(r8) :: zootot_loss_dic_fields  ! zoo_loss routed to dic (mmol C/m^3/sec)
-     real(r8) :: zootot_graze_fields     ! zooplankton losses due to grazing (mmol C/m^3/sec)
-     real(r8) :: zootot_graze_zoo_fields ! grazing of zooplankton routed to zoo (mmol C/m^3/sec)
-     real(r8) :: zootot_graze_poc_fields ! grazing of zooplankton routed to poc (mmol C/m^3/sec)
-     real(r8) :: zootot_graze_doc_fields ! grazing of zooplankton routed to doc (mmol C/m^3/sec)
-     real(r8) :: zootot_graze_dic_fields ! grazing of zooplankton routed to dic (mmol C/m^3/sec)
-  end type marbl_zooplankton_share_type
-
   !****************************************************************************
 
   ! Public parameters

--- a/src/marbl_settings_mod.F90
+++ b/src/marbl_settings_mod.F90
@@ -27,8 +27,8 @@ module marbl_settings_mod
   use marbl_constants_mod, only : molw_Fe
 
   use marbl_pft_mod, only : autotroph_settings_type
-  use marbl_pft_mod, only : zooplankton_type
-  use marbl_pft_mod, only : grazing_type
+  use marbl_pft_mod, only : zooplankton_settings_type
+  use marbl_pft_mod, only : grazer_settings_type
 
   use marbl_logging, only: marbl_log_type
 
@@ -312,8 +312,8 @@ module marbl_settings_mod
   !-------------------------------------------------------------
 
   type(autotroph_settings_type),   allocatable, target :: autotroph_settings(:)
-  type(zooplankton_type), allocatable, target :: zooplankton(:)
-  type(grazing_type),     allocatable, target :: grazing(:,:)
+  type(zooplankton_settings_type), allocatable, target :: zooplankton_settings(:)
+  type(grazer_settings_type),      allocatable, target :: grazer_settings(:,:)
 
   !  marbl_settings_define_tracer_dependent
   !    parameters that can not be set until MARBL knows what tracers
@@ -461,8 +461,8 @@ contains
     character(len=char_len)     :: log_message
     integer                     :: m, n
 
-    if (.not. all((/allocated(autotroph_settings), allocated(zooplankton), allocated(grazing)/))) then
-      write(log_message, '(A)') 'autotroph_settings, zooplankton, and grazing have not been allocated!'
+    if (.not. all((/allocated(autotroph_settings), allocated(zooplankton_settings), allocated(grazer_settings)/))) then
+      write(log_message, '(A)') 'autotroph_settings, zooplankton_settings, and grazer_settings have not been allocated!'
       call marbl_status_log%log_error(log_message, subname)
       return
     end if
@@ -472,20 +472,20 @@ contains
         call autotroph_settings(1)%set_to_default('sp', marbl_status_log)
         call autotroph_settings(2)%set_to_default('diat', marbl_status_log)
         call autotroph_settings(3)%set_to_default('diaz', marbl_status_log)
-        call zooplankton(1)%set_to_default('zoo', marbl_status_log)
-        call grazing(1,1)%set_to_default('sp_zoo', marbl_status_log)
-        call grazing(2,1)%set_to_default('diat_zoo', marbl_status_log)
-        call grazing(3,1)%set_to_default('diaz_zoo', marbl_status_log)
+        call zooplankton_settings(1)%set_to_default('zoo', marbl_status_log)
+        call grazer_settings(1,1)%set_to_default('sp_zoo', marbl_status_log)
+        call grazer_settings(2,1)%set_to_default('diat_zoo', marbl_status_log)
+        call grazer_settings(3,1)%set_to_default('diaz_zoo', marbl_status_log)
       case ('user-specified')
         do m=1,autotroph_cnt
           call autotroph_settings(m)%set_to_default('unset', marbl_status_log)
         end do
         do n=1,zooplankton_cnt
-          call zooplankton(n)%set_to_default('unset', marbl_status_log)
+          call zooplankton_settings(n)%set_to_default('unset', marbl_status_log)
         end do
         do n=1,zooplankton_cnt
           do m=1,max_grazer_prey_cnt
-            call grazing(m,n)%set_to_default('unset', marbl_status_log)
+            call grazer_settings(m,n)%set_to_default('unset', marbl_status_log)
           end do
         end do
       case DEFAULT
@@ -1151,15 +1151,15 @@ contains
     ! FIXME #69: this is not ideal for threaded runs
     if (.not. allocated(autotroph_settings)) &
       allocate(autotroph_settings(autotroph_cnt))
-    if (.not. allocated(zooplankton)) &
-      allocate(zooplankton(zooplankton_cnt))
-    if (.not. allocated(grazing)) then
-      allocate(grazing(max_grazer_prey_cnt, zooplankton_cnt))
+    if (.not. allocated(zooplankton_settings)) &
+      allocate(zooplankton_settings(zooplankton_cnt))
+    if (.not. allocated(grazer_settings)) then
+      allocate(grazer_settings(max_grazer_prey_cnt, zooplankton_cnt))
       do n=1,zooplankton_cnt
         do m=1,max_grazer_prey_cnt
-          call grazing(m,n)%construct(autotroph_cnt, zooplankton_cnt, marbl_status_log)
+          call grazer_settings(m,n)%construct(autotroph_cnt, zooplankton_cnt, marbl_status_log)
           if (marbl_status_log%labort_marbl) then
-            write(log_message,"(A,I0,A,I0,A)") 'grazing(', m, ',', n, ')%construct'
+            write(log_message,"(A,I0,A,I0,A)") 'grazer_settings(', m, ',', n, ')%construct'
             call marbl_status_log%log_error_trace(log_message, subname)
             return
           end if
@@ -1456,14 +1456,14 @@ contains
     end do
 
     do n=1, zooplankton_cnt
-      write(prefix, "(A,I0,A)") 'zooplankton(', n, ')%'
-      write(category, "(A,1X,I0)") 'zooplankton', n
+      write(prefix, "(A,I0,A)") 'zooplankton_settings(', n, ')%'
+      write(category, "(A,1X,I0)") 'zooplankton_settings', n
 
       write(sname, "(2A)") trim(prefix), 'sname'
       lname    = 'Short name of zooplankton'
       units    = 'unitless'
       datatype = 'string'
-      sptr     => zooplankton(n)%sname
+      sptr     => zooplankton_settings(n)%sname
       call this%add_var(sname, lname, units, datatype, category,     &
                         marbl_status_log, sptr=sptr,                 &
                         nondefault_required=(PFT_defaults .eq. 'user-specified'))
@@ -1473,7 +1473,7 @@ contains
       lname    = 'Long name of zooplankton'
       units    = 'unitless'
       datatype = 'string'
-      sptr     => zooplankton(n)%lname
+      sptr     => zooplankton_settings(n)%lname
       call this%add_var(sname, lname, units, datatype, category,     &
                         marbl_status_log, sptr=sptr,                 &
                         nondefault_required=(PFT_defaults .eq. 'user-specified'))
@@ -1483,7 +1483,7 @@ contains
       lname    = 'Linear mortality rate'
       units    = '1/day'
       datatype = 'real'
-      rptr     => zooplankton(n)%z_mort_0_per_day
+      rptr     => zooplankton_settings(n)%z_mort_0_per_day
       call this%add_var(sname, lname, units, datatype, category,     &
                         marbl_status_log, rptr=rptr,                 &
                         nondefault_required=(PFT_defaults .eq. 'user-specified'))
@@ -1493,7 +1493,7 @@ contains
       lname    = 'Concentration where losses go to zero'
       units    = 'nmol/cm^3'
       datatype = 'real'
-      rptr     => zooplankton(n)%loss_thres
+      rptr     => zooplankton_settings(n)%loss_thres
       call this%add_var(sname, lname, units, datatype, category,     &
                         marbl_status_log, rptr=rptr,                 &
                         nondefault_required=(PFT_defaults .eq. 'user-specified'))
@@ -1503,7 +1503,7 @@ contains
       lname    = 'Quadratic mortality rate'
       units    = '1/day/(mmol/m^3)'
       datatype = 'real'
-      rptr     => zooplankton(n)%z_mort2_0_per_day
+      rptr     => zooplankton_settings(n)%z_mort2_0_per_day
       call this%add_var(sname, lname, units, datatype, category,       &
                         marbl_status_log, rptr=rptr,                 &
                         nondefault_required=(PFT_defaults .eq. 'user-specified'))
@@ -1513,14 +1513,14 @@ contains
 
     do n=1,zooplankton_cnt
       do m=1,max_grazer_prey_cnt
-        write(prefix, "(A,I0,A,I0,A)") 'grazing(', m, ',', n, ')%'
-        write(category, "(A,1X,I0,1X,I0)") 'grazing', m, n
+        write(prefix, "(A,I0,A,I0,A)") 'grazer_settings(', m, ',', n, ')%'
+        write(category, "(A,1X,I0,1X,I0)") 'grazer_settings', m, n
 
         write(sname, "(2A)") trim(prefix), 'sname'
         lname    = 'Short name of grazer'
         units    = 'unitless'
         datatype = 'string'
-        sptr     => grazing(m,n)%sname
+        sptr     => grazer_settings(m,n)%sname
         call this%add_var(sname, lname, units, datatype, category,     &
                           marbl_status_log, sptr=sptr,                 &
                           nondefault_required=(PFT_defaults .eq. 'user-specified'))
@@ -1530,7 +1530,7 @@ contains
         lname    = 'Long name of grazer'
         units    = 'unitless'
         datatype = 'string'
-        sptr     => grazing(m,n)%lname
+        sptr     => grazer_settings(m,n)%lname
         call this%add_var(sname, lname, units, datatype, category,     &
                           marbl_status_log, sptr=sptr,                 &
                           nondefault_required=(PFT_defaults .eq. 'user-specified'))
@@ -1540,7 +1540,7 @@ contains
         lname    = 'number of autotrophs in prey-class auto_ind'
         units    = 'unitless'
         datatype = 'integer'
-        iptr     => grazing(m,n)%auto_ind_cnt
+        iptr     => grazer_settings(m,n)%auto_ind_cnt
         call this%add_var(sname, lname, units, datatype, category,     &
                           marbl_status_log, iptr=iptr,                 &
                           nondefault_required=(PFT_defaults .eq. 'user-specified'))
@@ -1550,17 +1550,17 @@ contains
         lname    = 'number of zooplankton in prey-class auto_ind'
         units    = 'unitless'
         datatype = 'integer'
-        iptr     => grazing(m,n)%zoo_ind_cnt
+        iptr     => grazer_settings(m,n)%zoo_ind_cnt
         call this%add_var(sname, lname, units, datatype, category,     &
                           marbl_status_log, iptr=iptr,                 &
                           nondefault_required=(PFT_defaults .eq. 'user-specified'))
         call check_and_log_add_var_error(marbl_status_log, sname, subname, labort_marbl_loc)
 
         write(sname, "(2A)") trim(prefix), 'grazing_function'
-        lname    = 'functional form of grazing parmaeterization'
+        lname    = 'functional form of grazer_settings parmaeterization'
         units    = 'unitless'
         datatype = 'integer'
-        iptr     => grazing(m,n)%grazing_function
+        iptr     => grazer_settings(m,n)%grazing_function
         call this%add_var(sname, lname, units, datatype, category,     &
                           marbl_status_log, iptr=iptr,                 &
                           nondefault_required=(PFT_defaults .eq. 'user-specified'))
@@ -1570,17 +1570,17 @@ contains
         lname    = 'max zoo growth rate at Tref'
         units    = '1/day'
         datatype = 'real'
-        rptr     => grazing(m,n)%z_umax_0_per_day
+        rptr     => grazer_settings(m,n)%z_umax_0_per_day
         call this%add_var(sname, lname, units, datatype, category,     &
                           marbl_status_log, rptr=rptr,                 &
                           nondefault_required=(PFT_defaults .eq. 'user-specified'))
         call check_and_log_add_var_error(marbl_status_log, sname, subname, labort_marbl_loc)
 
         write(sname, "(2A)") trim(prefix), 'z_grz'
-        lname    = 'Grazing coefficient'
+        lname    = 'grazer_settings coefficient'
         units    = '(mmol/m^3)^2'
         datatype = 'real'
-        rptr     => grazing(m,n)%z_grz
+        rptr     => grazer_settings(m,n)%z_grz
         call this%add_var(sname, lname, units, datatype, category,     &
                           marbl_status_log, rptr=rptr,                 &
                           nondefault_required=(PFT_defaults .eq. 'user-specified'))
@@ -1590,7 +1590,7 @@ contains
         lname    = 'routing of grazed term (remainder goes to DIC)'
         units    = 'unitless'
         datatype = 'real'
-        rptr     => grazing(m,n)%graze_zoo
+        rptr     => grazer_settings(m,n)%graze_zoo
         call this%add_var(sname, lname, units, datatype, category,     &
                           marbl_status_log, rptr=rptr,                 &
                           nondefault_required=(PFT_defaults .eq. 'user-specified'))
@@ -1600,7 +1600,7 @@ contains
         lname    = 'routing of grazed term (remainder goes to DIC)'
         units    = 'unitless'
         datatype = 'real'
-        rptr     => grazing(m,n)%graze_poc
+        rptr     => grazer_settings(m,n)%graze_poc
         call this%add_var(sname, lname, units, datatype, category,     &
                           marbl_status_log, rptr=rptr,                 &
                           nondefault_required=(PFT_defaults .eq. 'user-specified'))
@@ -1610,7 +1610,7 @@ contains
         lname    = 'routing of grazed term (remainder goes to DIC)'
         units    = 'unitless'
         datatype = 'real'
-        rptr     => grazing(m,n)%graze_doc
+        rptr     => grazer_settings(m,n)%graze_doc
         call this%add_var(sname, lname, units, datatype, category,     &
                           marbl_status_log, rptr=rptr,                 &
                           nondefault_required=(PFT_defaults .eq. 'user-specified'))
@@ -1620,32 +1620,32 @@ contains
         lname    = 'Fraction of zoo losses to detrital'
         units    = 'unitless'
         datatype = 'real'
-        rptr     => grazing(m,n)%f_zoo_detr
+        rptr     => grazer_settings(m,n)%f_zoo_detr
         call this%add_var(sname, lname, units, datatype, category,     &
                           marbl_status_log, rptr=rptr,                 &
                           nondefault_required=(PFT_defaults .eq. 'user-specified'))
         call check_and_log_add_var_error(marbl_status_log, sname, subname, labort_marbl_loc)
 
-        cnt = grazing(m,n)%auto_ind_cnt
+        cnt = grazer_settings(m,n)%auto_ind_cnt
         if (cnt .gt. 0) then
           write(sname, "(2A)") trim(prefix), 'auto_ind'
           lname     = 'Indices of autotrophs in class'
           units     = 'unitless'
           call this%add_var_1d_int(sname, lname, units, category,      &
-                            grazing(m,n)%auto_ind(1:cnt),              &
+                            grazer_settings(m,n)%auto_ind(1:cnt),      &
                             marbl_status_log,                          &
                             nondefault_required=(PFT_defaults .eq. 'user-specified'))
           call check_and_log_add_var_error(marbl_status_log, sname, subname, labort_marbl_loc)
         end if
 
-        cnt = grazing(m,n)%zoo_ind_cnt
+        cnt = grazer_settings(m,n)%zoo_ind_cnt
         if (cnt .gt. 0) then
           write(sname, "(2A)") trim(prefix), 'zoo_ind'
           lname     = 'Indices of autotrophs in class'
           units     = 'unitless'
-          call this%add_var_1d_int(sname, lname, units, category,      &
-                                   grazing(m,n)%zoo_ind(1:cnt),        &
-                                   marbl_status_log,                   &
+          call this%add_var_1d_int(sname, lname, units, category,       &
+                                   grazer_settings(m,n)%zoo_ind(1:cnt), &
+                                   marbl_status_log,                    &
                                    nondefault_required=(PFT_defaults .eq. 'user-specified'))
           call check_and_log_add_var_error(marbl_status_log, sname, subname, labort_marbl_loc)
         end if
@@ -1782,28 +1782,28 @@ contains
     call marbl_status_log%log_noerror('', subname)
 
     do n = 1, zooplankton_cnt
-       zooplankton(n)%z_mort_0 = dps * zooplankton(n)%z_mort_0_per_day
-       write(sname_in,  "(A,I0,A)") 'zooplankton(', n, ')%z_mort_0_per_day'
-       write(sname_out, "(A,I0,A)") 'zooplankton(', n, ')%z_mort_0'
+       zooplankton_settings(n)%z_mort_0 = dps * zooplankton_settings(n)%z_mort_0_per_day
+       write(sname_in,  "(A,I0,A)") 'zooplankton_settings(', n, ')%z_mort_0_per_day'
+       write(sname_out, "(A,I0,A)") 'zooplankton_settings(', n, ')%z_mort_0'
        call print_single_derived_parm(sname_in, sname_out, &
-            zooplankton(n)%z_mort_0, subname, marbl_status_log)
+            zooplankton_settings(n)%z_mort_0, subname, marbl_status_log)
 
-       zooplankton(n)%z_mort2_0 = dps * zooplankton(n)%z_mort2_0_per_day
-       write(sname_in,  "(A,I0,A)") 'zooplankton(', n, ')%z_mort2_0_per_day'
-       write(sname_out, "(A,I0,A)") 'zooplankton(', n, ')%z_mort2_0'
+       zooplankton_settings(n)%z_mort2_0 = dps * zooplankton_settings(n)%z_mort2_0_per_day
+       write(sname_in,  "(A,I0,A)") 'zooplankton_settings(', n, ')%z_mort2_0_per_day'
+       write(sname_out, "(A,I0,A)") 'zooplankton_settings(', n, ')%z_mort2_0'
        call print_single_derived_parm(sname_in, sname_out, &
-            zooplankton(n)%z_mort2_0, subname, marbl_status_log)
+            zooplankton_settings(n)%z_mort2_0, subname, marbl_status_log)
     end do
 
     call marbl_status_log%log_noerror('', subname)
 
     do n = 1, zooplankton_cnt
        do m = 1, max_grazer_prey_cnt
-          grazing(m,n)%z_umax_0 = dps * grazing(m,n)%z_umax_0_per_day
-          write(sname_in,  "(A,I0,A,I0,A)") 'grazing(', m, ',', n, ')%z_umax_0_per_day'
-          write(sname_out, "(A,I0,A,I0,A)") 'grazing(', m, ',', n, ')%z_umax_0'
+          grazer_settings(m,n)%z_umax_0 = dps * grazer_settings(m,n)%z_umax_0_per_day
+          write(sname_in,  "(A,I0,A,I0,A)") 'grazer_settings(', m, ',', n, ')%z_umax_0_per_day'
+          write(sname_out, "(A,I0,A,I0,A)") 'grazer_settings(', m, ',', n, ')%z_umax_0'
           call print_single_derived_parm(sname_in, sname_out, &
-               grazing(m,n)%z_umax_0, subname, marbl_status_log)
+               grazer_settings(m,n)%z_umax_0, subname, marbl_status_log)
        end do
     end do
 


### PR DESCRIPTION
Many data structures had names that were not descriptive, so it was confusing what the purpose of the structures were. Also, there were several datatypes that were declared as arrays when it made more sense to have the array dimensions inside the datatype.

These changes go hand-in-hand with moving the `k` loop out of `interior_tendency_compute()` -- moving the array dimensions inside the type will make it easier to vectorize computations across a single column rather than needing to loop over each level.

This pull request is restricted to being bit-for-bit, so there will likely be additional vector-based optimizations to make at a later date.

Addresses #53 (perhaps not entirely) and #317. The Fortran interface will not change, but the names of variables in the settings file will - that will affect the GCMs and also require documentation updates.