### PR TITLE
Remove workaround to PGI compiler bug

### DIFF
--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -541,7 +541,7 @@ contains
 
   !***********************************************************************
 
-  subroutine put_input_file_line(this, line, pgi_bugfix_var)
+  subroutine put_input_file_line(this, line)
 
     ! This subroutine takes a single line from MARBL's default input file format,
     ! determines the variable name and whether the value is a scalar or an array,
@@ -555,21 +555,12 @@ contains
 
     class(marbl_interface_class), intent(inout) :: this
     character(len=*),             intent(in)    :: line
-    ! For some reason PGI doesn't like this particular interface to put_setting()
-    ! --- Error from building stand-alone driver ---
-    ! PGF90-S-0155-cannot access PRIVATE type bound procedure
-    ! put_input_file_line$tbp (/NO_BACKUP/codes/marbl/tests/driver_src/marbl.F90: 239)
-    !
-    ! But adding another variable to the interface makes it okay
-    logical, optional,            intent(in)    :: pgi_bugfix_var(0)
 
     character(len=char_len), dimension(:), allocatable :: value, line_loc_arr
     character(len=char_len) :: varname, var_loc, line_loc
     integer(int_kind)       :: n, char_ind
 
     line_loc = ''
-    ! The included PGI bugfix variable triggers a warning from gfortran unless it's used
-    if (present(pgi_bugfix_var)) line_loc=''
     ! Strip out comments (denoted by '!'); line_loc_arr(1) is the line to be processed
     call marbl_utils_str_to_substrs(line, '!', line_loc_arr)
     line_loc = line_loc_arr(1)

--- a/tests/python_for_tests/machines.py
+++ b/tests/python_for_tests/machines.py
@@ -94,7 +94,7 @@ def machine_specific(mach, supported_compilers, module_names):
     module_names['nag'] = 'compiler/nag/6.2'
     module_names['intel'] = 'compiler/intel/18.0.3'
     module_names['gnu'] = 'compiler/gnu/8.1.0'
-    module_names['pgi'] = 'compiler/pgi/18.1'
+    module_names['pgi'] = 'compiler/pgi/18.10'
     return
 
   if mach == 'edison':


### PR DESCRIPTION
As of 18.10, put_input_file_line() does not need the pgi_bugfix_var optional
argument to be recognized as a unique interface for put_setting(). Once this is
accepted onto development, PGI 18.4 (and earlier) will not be able to compile
MARBL. It will fail to build the stand-alone driver with the error

```
PGF90-S-0155-cannot access PRIVATE type bound procedure put_input_file_line
```

(Presumably GCMs that use put_setting() will also run into this error)