### PR TITLE
Introduce work array to check for underflows

### DIFF
--- a/src/marbl_interior_tendency_mod.F90
+++ b/src/marbl_interior_tendency_mod.F90
@@ -1331,6 +1331,7 @@ contains
     real(r8) :: PCphoto_subcol   ! PCphoto for a sub-column
     real(r8) :: pChl_subcol      ! Chl synth. regulation term (mg Chl/mmol N)
     real(r8) :: photoacc_subcol  ! photoacc for a sub-column
+    real(r8) :: work             ! intermediate term common to multiple expressions
     !-----------------------------------------------------------------------
 
     associate(                                                &
@@ -1358,16 +1359,14 @@ contains
             photoacc(auto_ind,k)  = c0
 
             do subcol_ind = 1, PAR_nsubcols
-              if (PAR_avg(k,subcol_ind) > c0) then
-                light_lim_subcol = (c1 - exp((-c1 * autotroph_settings(auto_ind)%alphaPI &
-                                              * thetaC(auto_ind,k) * PAR_avg(k,subcol_ind)) &
-                                       / (PCmax + epsTinv)))
+              work = autotroph_settings(auto_ind)%alphaPI * thetaC(auto_ind,k) * PAR_avg(k,subcol_ind)
+              if (work > c0) then
+                light_lim_subcol = (c1 - exp(-work / (PCmax + epsTinv)))
 
                 PCphoto_subcol = PCmax * light_lim_subcol
 
                 ! GD 98 Chl. synth. term
-                pChl_subcol = autotroph_settings(auto_ind)%thetaN_max * PCphoto_subcol &
-                            / (autotroph_settings(auto_ind)%alphaPI * thetaC(auto_ind,k) * PAR_avg(k,subcol_ind))
+                pChl_subcol = autotroph_settings(auto_ind)%thetaN_max * PCphoto_subcol / work
                 photoacc_subcol = (pChl_subcol * PCphoto_subcol * Q / thetaC(auto_ind,k)) &
                                 * autotroph_local%Chl(auto_ind,k)
 


### PR DESCRIPTION
There is a three-term product (alphaPI * thetaC * PAR_avg) that underflowed to
zero in the denominator of a computation in compute_autotroph_photosynthesis().
Storing this product and checking if the entire product > 0 rather than
checking if just PAR_avg > 0 avoids the underflow.

Our previous attempt to fix #50 didn't account for cases where `thetaC` is extremely small; this check addresses another path that led to underflows and division by zero errors. Thanks to @klindsay28 for providing this fix.

Testing: all CESM tests in the `aux_pop_MARBL` testlist are bit-for-bit compared to tests using the previous head of `development`