### PR TITLE
Clean up standalone tests

### DIFF
--- a/MARBL_tools/run_test_suite.sh
+++ b/MARBL_tools/run_test_suite.sh
@@ -16,10 +16,14 @@ function check_return() {
 # Output test results
 function print_status() {
   TEST_CNT=$((TEST_CNT+1))
+  HEAD="   "
+  TAIL=""
   if [ "${STATUS}" == "FAIL" ]; then
     FAIL_CNT=$((FAIL_CNT+1))
+    HEAD="***"
+    TAIL=" ***"
   fi
-  echo "${TEST_CNT}. $1: ${STATUS}"
+  echo "${HEAD} ${TEST_CNT}. $1: ${STATUS}${TAIL}"
 }
 
 #################################################

--- a/docs/py_requirements.txt
+++ b/docs/py_requirements.txt
@@ -1,4 +1,5 @@
 pylint==1.9.2
+isort<5
 Sphinx==1.7.5
 sphinxcontrib-bibtex==0.4.0
 pybtex==0.22

--- a/src/marbl_settings_mod.F90
+++ b/src/marbl_settings_mod.F90
@@ -460,7 +460,7 @@ contains
         zooplankton_cnt               = -1       ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
         max_grazer_prey_cnt           = -1       ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
       case DEFAULT
-        write(log_message, "(3A)") "'", trim(PFT_defaults), "'' is not a valid value for PFT_defaults"
+        write(log_message, "(3A)") "'", trim(PFT_defaults), "' is not a valid value for PFT_defaults"
         call marbl_status_log%log_error(log_message, subname)
     end select
 


### PR DESCRIPTION
Travis CI was failing due to python package incompatibilities, and I also cleaned up the output of the test suite to better highlight test failures.

@kristenkrumhardt and I also ran into an issue where the stand-alone test seg-faulted instead of exiting cleanly in some tests if the `PFT_defaults` provided was not valid -- I will also fix that issue once Travis is passing again.