### PR TITLE
Initialize more arrays below kmt

### DIFF
--- a/src/marbl_ciso_interior_tendency_mod.F90
+++ b/src/marbl_ciso_interior_tendency_mod.F90
@@ -1074,6 +1074,7 @@ contains
     use marbl_settings_mod , only : caco3_bury_thres_iopt_fixed_depth
     use marbl_settings_mod , only : caco3_bury_thres_depth
     use marbl_settings_mod , only : caco3_bury_thres_omega_calc
+    use marbl_interior_tendency_share_mod, only : marbl_interior_tendency_share_set_used_particle_terms_to_zero
 
     integer (int_kind),                       intent(in)    :: k                 ! vertical model level
     type(marbl_domain_type),                  intent(in)    :: domain
@@ -1207,6 +1208,9 @@ contains
             ((POC_ciso%sflux_in(k) - POC_ciso%sflux_out(k)) + &
              (POC_ciso%hflux_in(k) - POC_ciso%hflux_out(k))) * dzr_loc
 
+    else ! k > column_kmt
+      call marbl_interior_tendency_share_set_used_particle_terms_to_zero(k, POC_ciso)
+      call marbl_interior_tendency_share_set_used_particle_terms_to_zero(k, P_CaCO3_ciso)
     endif
 
     !-----------------------------------------------------------------------
@@ -1276,7 +1280,6 @@ contains
        if (POC_ciso%to_floor > c0) then
           POC_ciso%remin(k) = POC_ciso%remin(k) + ((POC_ciso%to_floor - POC_ciso%sed_loss(k)) * dzr_loc)
        endif
-
     endif
 
     end associate

--- a/src/marbl_ciso_interior_tendency_mod.F90
+++ b/src/marbl_ciso_interior_tendency_mod.F90
@@ -1211,6 +1211,7 @@ contains
     else ! k > column_kmt
       call marbl_interior_tendency_share_set_used_particle_terms_to_zero(k, POC_ciso)
       call marbl_interior_tendency_share_set_used_particle_terms_to_zero(k, P_CaCO3_ciso)
+      dzr_loc = c0
     endif
 
     !-----------------------------------------------------------------------

--- a/src/marbl_interior_tendency_mod.F90
+++ b/src/marbl_interior_tendency_mod.F90
@@ -2636,6 +2636,7 @@ contains
      use marbl_glo_avg_mod, only : glo_avg_field_ind_interior_tendency_d_POP_bury_d_bury_coeff
      use marbl_glo_avg_mod, only : glo_avg_field_ind_interior_tendency_d_bSi_bury_d_bury_coeff
      use marbl_interior_tendency_share_mod, only : marbl_interior_tendency_share_export_particulate
+     use marbl_interior_tendency_share_mod, only : marbl_interior_tendency_share_set_used_particle_terms_to_zero
 
      integer (int_kind)                , intent(in)    :: k                   ! vertical model level
      type(marbl_domain_type)           , intent(in)    :: domain
@@ -2974,32 +2975,15 @@ contains
 
      else
 
-        ! Set lots of variables to 0 to avoid potential uninitialized-memory warnings / errors
-        dzr_loc = c0
-
-        P_CaCO3%remin(k) = c0
-        P_CaCO3_ALT_CO2%remin(k) = c0
-        P_SiO2%remin(k) = c0
-        dust%remin(k) = c0
-        POC%remin(k) = c0
-        P_iron%remin(k) = c0
-        POP%remin(k) = c0
+        call marbl_interior_tendency_share_set_used_particle_terms_to_zero(k, P_CaCO3)
+        call marbl_interior_tendency_share_set_used_particle_terms_to_zero(k, P_CaCO3_ALT_CO2)
+        call marbl_interior_tendency_share_set_used_particle_terms_to_zero(k, P_SiO2)
+        call marbl_interior_tendency_share_set_used_particle_terms_to_zero(k, dust)
+        call marbl_interior_tendency_share_set_used_particle_terms_to_zero(k, POC)
+        call marbl_interior_tendency_share_set_used_particle_terms_to_zero(k, P_iron)
+        call marbl_interior_tendency_share_set_used_particle_terms_to_zero(k, POP)
         PON_remin = c0
-
-        P_CaCO3%sflux_out(k) = c0
-        P_CaCO3%hflux_out(k) = c0
-        P_CaCO3_ALT_CO2%sflux_out(k) = c0
-        P_CaCO3_ALT_CO2%hflux_out(k) = c0
-        P_SiO2%sflux_out(k) = c0
-        P_SiO2%hflux_out(k) = c0
-        dust%sflux_out(k) = c0
-        dust%hflux_out(k) = c0
-        POC%sflux_out(k) = c0
-        POC%hflux_out(k) = c0
-        P_iron%sflux_out(k) = c0
-        P_iron%hflux_out(k) = c0
-        POP%sflux_out(k) = c0
-        POP%hflux_out(k) = c0
+        dzr_loc = c0
 
      endif
 

--- a/src/marbl_interior_tendency_mod.F90
+++ b/src/marbl_interior_tendency_mod.F90
@@ -2974,10 +2974,32 @@ contains
 
      else
 
-        dzr_loc = c0 ! avoid 'dzr_loc' may be used uninitialized warning from gfortran
+        ! Set lots of variables to 0 to avoid potential uninitialized-memory warnings / errors
+        dzr_loc = c0
+
+        P_CaCO3%remin(k) = c0
+        P_CaCO3_ALT_CO2%remin(k) = c0
+        P_SiO2%remin(k) = c0
+        dust%remin(k) = c0
         POC%remin(k) = c0
+        P_iron%remin(k) = c0
+        POP%remin(k) = c0
+        PON_remin = c0
+
+        P_CaCO3%sflux_out(k) = c0
+        P_CaCO3%hflux_out(k) = c0
+        P_CaCO3_ALT_CO2%sflux_out(k) = c0
+        P_CaCO3_ALT_CO2%hflux_out(k) = c0
+        P_SiO2%sflux_out(k) = c0
+        P_SiO2%hflux_out(k) = c0
+        dust%sflux_out(k) = c0
+        dust%hflux_out(k) = c0
         POC%sflux_out(k) = c0
         POC%hflux_out(k) = c0
+        P_iron%sflux_out(k) = c0
+        P_iron%hflux_out(k) = c0
+        POP%sflux_out(k) = c0
+        POP%hflux_out(k) = c0
 
      endif
 

--- a/src/marbl_interior_tendency_mod.F90
+++ b/src/marbl_interior_tendency_mod.F90
@@ -2973,7 +2973,7 @@ contains
 
         POP%hflux_out(k) = POP%hflux_in(k)
 
-     else
+     else ! k > column_kmt
 
         call marbl_interior_tendency_share_set_used_particle_terms_to_zero(k, P_CaCO3)
         call marbl_interior_tendency_share_set_used_particle_terms_to_zero(k, P_CaCO3_ALT_CO2)

--- a/src/marbl_interior_tendency_share_mod.F90
+++ b/src/marbl_interior_tendency_share_mod.F90
@@ -2,12 +2,14 @@ module marbl_interior_tendency_share_mod
 
   use marbl_kinds_mod, only : int_kind
   use marbl_kinds_mod, only : r8
+  use marbl_constants_mod, only : c0
   use marbl_settings_mod, only : ciso_on
 
   implicit none
   private
 
   public :: marbl_interior_tendency_share_update_particle_flux_from_above
+  public :: marbl_interior_tendency_share_set_used_particle_terms_to_zero
   public :: marbl_interior_tendency_share_export_variables
   public :: marbl_interior_tendency_share_export_zooplankton
   public :: marbl_interior_tendency_share_export_particulate
@@ -28,6 +30,20 @@ contains
     sinking_particle%hflux_in(k)  = sinking_particle%hflux_out(k-1)
 
   end subroutine marbl_interior_tendency_share_update_particle_flux_from_above
+
+  !***********************************************************************
+
+  subroutine marbl_interior_tendency_share_set_used_particle_terms_to_zero(k, sinking_particle)
+
+    use marbl_interface_private_types, only : column_sinking_particle_type
+
+    integer (int_kind), intent(in) :: k
+    type(column_sinking_particle_type), intent(inout) :: sinking_particle
+
+    sinking_particle%sflux_out(k) = c0
+    sinking_particle%hflux_out(k) = c0
+
+  end subroutine marbl_interior_tendency_share_set_used_particle_terms_to_zero
 
   !***********************************************************************
 
@@ -126,6 +142,7 @@ contains
        marbl_particulate_share%caco3_diss_fields(k)     = caco3_diss
     endif
   end subroutine marbl_interior_tendency_share_export_particulate
+
   !***********************************************************************
 
 end module marbl_interior_tendency_share_mod

--- a/src/marbl_interior_tendency_share_mod.F90
+++ b/src/marbl_interior_tendency_share_mod.F90
@@ -42,6 +42,7 @@ contains
 
     sinking_particle%sflux_out(k) = c0
     sinking_particle%hflux_out(k) = c0
+    sinking_particle%remin(k) = c0
 
   end subroutine marbl_interior_tendency_share_set_used_particle_terms_to_zero
 

--- a/tests/driver_src/Makefile
+++ b/tests/driver_src/Makefile
@@ -151,7 +151,7 @@ all: gnu
 
 .PHONY: gnu
 gnu:
-	$(MAKE) -f $(MAKE_DIR)/Makefile $(EXE) COMP_NAME=gnu$(MPISUF) FC=gfortran FCFLAGS="-Wall -Wextra -Wno-compare-reals -Werror -O2 -ffree-form -cpp" INC="-J $(OBJ_ROOT)/gnu$(MPISUF)" INC2="-J $(OBJ_ROOT)/gnu$(MPISUF)/driver"
+	$(MAKE) -f $(MAKE_DIR)/Makefile $(EXE) COMP_NAME=gnu$(MPISUF) FC=gfortran FCFLAGS="-Wall -Wextra -Wno-compare-reals -Werror -O2 -ffree-form -cpp -finit-real=snan -ffpe-trap=invalid" INC="-J $(OBJ_ROOT)/gnu$(MPISUF)" INC2="-J $(OBJ_ROOT)/gnu$(MPISUF)/driver"
 
 .PHONY: intel
 intel:

--- a/tests/driver_src/Makefile
+++ b/tests/driver_src/Makefile
@@ -155,7 +155,7 @@ gnu:
 
 .PHONY: intel
 intel:
-	$(MAKE) -f $(MAKE_DIR)/Makefile $(EXE) COMP_NAME=intel$(MPISUF) FC=ifort FCFLAGS="-O2 -free -cpp -nogen-interface -fp-model source" INC="-module $(OBJ_ROOT)/intel$(MPISUF)" INC2="-module $(OBJ_ROOT)/intel$(MPISUF)/driver" 
+	$(MAKE) -f $(MAKE_DIR)/Makefile $(EXE) COMP_NAME=intel$(MPISUF) FC=ifort FCFLAGS="-g -O2 -init=snan,arrays -free -cpp -nogen-interface -fp-model source" INC="-module $(OBJ_ROOT)/intel$(MPISUF)" INC2="-module $(OBJ_ROOT)/intel$(MPISUF)/driver"
 
 .PHONY: pgi
 pgi:


### PR DESCRIPTION
Running call_compute_subroutines with the intel compiler using the following
FFLAGS: `-g -O0 -init=snan,arrays` crashed until I initialized several fields
below the sea floor.

Leaving this is draft status until @mvertens verifies that it fixes the error she was seeing.

Fixes #371