### PR TITLE
Distribute particulate bottom flux within column

### DIFF
--- a/defaults/json/settings_cesm2.0.json
+++ b/defaults/json/settings_cesm2.0.json
@@ -888,6 +888,13 @@
          "subcategory": "4. general parameters (bury coeffs)",
          "units": "unitless"
       },
+      "bftt_dz_sum_thres": {
+         "datatype": "real",
+         "default_value": 1e-14,
+         "longname": "MARBL will abort if abs(1 - sum(bot_flux_to_tend)) exceeds this threshold",
+         "subcategory": "4. general parameters",
+         "units": "unitless"
+      },
       "bury_coeff_rmean_timescale_years": {
          "datatype": "real",
          "default_value": 10,

--- a/defaults/json/settings_cesm2.1+cocco.json
+++ b/defaults/json/settings_cesm2.1+cocco.json
@@ -930,6 +930,13 @@
          "subcategory": "4. general parameters (bury coeffs)",
          "units": "unitless"
       },
+      "bftt_dz_sum_thres": {
+         "datatype": "real",
+         "default_value": 1e-14,
+         "longname": "MARBL will abort if abs(1 - sum(bot_flux_to_tend)) exceeds this threshold",
+         "subcategory": "4. general parameters",
+         "units": "unitless"
+      },
       "bury_coeff_rmean_timescale_years": {
          "datatype": "real",
          "default_value": 10,

--- a/defaults/json/settings_cesm2.1.json
+++ b/defaults/json/settings_cesm2.1.json
@@ -888,6 +888,13 @@
          "subcategory": "4. general parameters (bury coeffs)",
          "units": "unitless"
       },
+      "bftt_dz_sum_thres": {
+         "datatype": "real",
+         "default_value": 1e-14,
+         "longname": "MARBL will abort if abs(1 - sum(bot_flux_to_tend)) exceeds this threshold",
+         "subcategory": "4. general parameters",
+         "units": "unitless"
+      },
       "bury_coeff_rmean_timescale_years": {
          "datatype": "real",
          "default_value": 10,

--- a/defaults/json/settings_latest+cocco.json
+++ b/defaults/json/settings_latest+cocco.json
@@ -930,6 +930,13 @@
          "subcategory": "4. general parameters (bury coeffs)",
          "units": "unitless"
       },
+      "bftt_dz_sum_thres": {
+         "datatype": "real",
+         "default_value": 1e-14,
+         "longname": "MARBL will abort if abs(1 - sum(bot_flux_to_tend)) exceeds this threshold",
+         "subcategory": "4. general parameters",
+         "units": "unitless"
+      },
       "bury_coeff_rmean_timescale_years": {
          "datatype": "real",
          "default_value": 10,

--- a/defaults/json/settings_latest.json
+++ b/defaults/json/settings_latest.json
@@ -888,6 +888,13 @@
          "subcategory": "4. general parameters (bury coeffs)",
          "units": "unitless"
       },
+      "bftt_dz_sum_thres": {
+         "datatype": "real",
+         "default_value": 1e-14,
+         "longname": "MARBL will abort if abs(1 - sum(bot_flux_to_tend)) exceeds this threshold",
+         "subcategory": "4. general parameters",
+         "units": "unitless"
+      },
       "bury_coeff_rmean_timescale_years": {
          "datatype": "real",
          "default_value": 10,

--- a/defaults/settings_cesm2.0.yaml
+++ b/defaults/settings_cesm2.0.yaml
@@ -281,6 +281,12 @@ general_parms :
       units : unitless
       datatype : logical
       default_value : .false.
+   bftt_dz_sum_thres:
+      longname : MARBL will abort if abs(1 - sum(bot_flux_to_tend)) exceeds this threshold
+      subcategory : 4. general parameters
+      units : unitless
+      datatype : real
+      default_value : 1.0e-14
    Jint_Ctot_thres_molpm2pyr :
       longname : MARBL will abort if abs(Jint_Ctot) exceeds this threshold
       subcategory : 4. general parameters

--- a/defaults/settings_cesm2.1+cocco.yaml
+++ b/defaults/settings_cesm2.1+cocco.yaml
@@ -285,6 +285,12 @@ general_parms :
       units : unitless
       datatype : logical
       default_value : .false.
+   bftt_dz_sum_thres:
+      longname : MARBL will abort if abs(1 - sum(bot_flux_to_tend)) exceeds this threshold
+      subcategory : 4. general parameters
+      units : unitless
+      datatype : real
+      default_value : 1.0e-14
    Jint_Ctot_thres_molpm2pyr :
       longname : MARBL will abort if abs(Jint_Ctot) exceeds this threshold
       subcategory : 4. general parameters

--- a/defaults/settings_cesm2.1.yaml
+++ b/defaults/settings_cesm2.1.yaml
@@ -283,6 +283,12 @@ general_parms :
       units : unitless
       datatype : logical
       default_value : .false.
+   bftt_dz_sum_thres:
+      longname : MARBL will abort if abs(1 - sum(bot_flux_to_tend)) exceeds this threshold
+      subcategory : 4. general parameters
+      units : unitless
+      datatype : real
+      default_value : 1.0e-14
    Jint_Ctot_thres_molpm2pyr :
       longname : MARBL will abort if abs(Jint_Ctot) exceeds this threshold
       subcategory : 4. general parameters

--- a/defaults/settings_latest+cocco.yaml
+++ b/defaults/settings_latest+cocco.yaml
@@ -285,6 +285,12 @@ general_parms :
       units : unitless
       datatype : logical
       default_value : .false.
+   bftt_dz_sum_thres:
+      longname : MARBL will abort if abs(1 - sum(bot_flux_to_tend)) exceeds this threshold
+      subcategory : 4. general parameters
+      units : unitless
+      datatype : real
+      default_value : 1.0e-14
    Jint_Ctot_thres_molpm2pyr :
       longname : MARBL will abort if abs(Jint_Ctot) exceeds this threshold
       subcategory : 4. general parameters

--- a/defaults/settings_latest.yaml
+++ b/defaults/settings_latest.yaml
@@ -283,6 +283,12 @@ general_parms :
       units : unitless
       datatype : logical
       default_value : .false.
+   bftt_dz_sum_thres:
+      longname : MARBL will abort if abs(1 - sum(bot_flux_to_tend)) exceeds this threshold
+      subcategory : 4. general parameters
+      units : unitless
+      datatype : real
+      default_value : 1.0e-14
    Jint_Ctot_thres_molpm2pyr :
       longname : MARBL will abort if abs(Jint_Ctot) exceeds this threshold
       subcategory : 4. general parameters

--- a/src/marbl_co2calc_mod.F90
+++ b/src/marbl_co2calc_mod.F90
@@ -43,7 +43,7 @@ module marbl_co2calc_mod
   !   10**-9 drops precision to 2 significant figures).
 
   real(kind=r8)          , parameter :: xacc = 1e-10_r8
-  integer(kind=int_kind) , parameter :: max_bracket_grow_it = 3
+  integer(kind=int_kind) , parameter :: max_bracket_grow_it = 5
   integer(kind=int_kind) , parameter :: maxit = 100
 
   real(kind=r8)          , parameter :: salt_min = 0.1_r8

--- a/src/marbl_co2calc_mod.F90
+++ b/src/marbl_co2calc_mod.F90
@@ -43,7 +43,7 @@ module marbl_co2calc_mod
   !   10**-9 drops precision to 2 significant figures).
 
   real(kind=r8)          , parameter :: xacc = 1e-10_r8
-  integer(kind=int_kind) , parameter :: max_bracket_grow_it = 5
+  integer(kind=int_kind) , parameter :: max_bracket_grow_it = 3
   integer(kind=int_kind) , parameter :: maxit = 100
 
   real(kind=r8)          , parameter :: salt_min = 0.1_r8

--- a/src/marbl_init_mod.F90
+++ b/src/marbl_init_mod.F90
@@ -129,6 +129,7 @@ contains
                                 tracers_at_surface, &
                                 surface_fluxes, &
                                 tracers, &
+                                bot_flux_to_tend, &
                                 interior_tendencies, &
                                 tracer_metadata, &
                                 marbl_status_log)
@@ -146,6 +147,7 @@ contains
     real(r8),                         allocatable, intent(out)   :: tracers_at_surface(:,:)
     real(r8),                         allocatable, intent(out)   :: surface_fluxes(:,:)
     real(r8),                         allocatable, intent(out)   :: tracers(:,:)
+    real(r8),                         allocatable, intent(out)   :: bot_flux_to_tend(:)
     real(r8),                         allocatable, intent(out)   :: interior_tendencies(:,:)
     type(marbl_tracer_metadata_type), allocatable, intent(out)   :: tracer_metadata(:)
     type(marbl_log_type),                          intent(inout) :: marbl_status_log
@@ -168,6 +170,7 @@ contains
     allocate(tracers_at_surface(num_elements_surface_flux, tracer_indices%total_cnt))
     allocate(surface_fluxes(num_elements_surface_flux, tracer_indices%total_cnt))
     allocate(tracers(tracer_indices%total_cnt, num_levels))
+    allocate(bot_flux_to_tend(num_levels))
     allocate(interior_tendencies(tracer_indices%total_cnt, num_levels))
     allocate(tracer_metadata(tracer_indices%total_cnt))
     if (.not.allocated(tracer_restore_vars)) &

--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -84,6 +84,7 @@ module marbl_interface
 
      ! public data related to computing interior tendencies
      real (r8), allocatable                             , public  :: tracers(:,:)                  ! input
+     real (r8), allocatable                             , public  :: bot_flux_to_tend(:)           ! input
      type(marbl_forcing_fields_type), allocatable       , public  :: interior_tendency_forcings(:) ! input
      real (r8), allocatable                             , public  :: interior_tendencies(:,:)      ! output
      type(marbl_interior_tendency_forcing_indexing_type), public  :: interior_tendency_forcing_ind ! FIXME #311: should be private
@@ -306,8 +307,8 @@ contains
 
     call marbl_init_tracers(num_levels, num_elements_surface_flux, &
                             this%tracer_indices, this%tracers_at_surface, this%surface_fluxes, &
-                            this%tracers, this%interior_tendencies, this%tracer_metadata, &
-                            this%StatusLog)
+                            this%tracers, this%bot_flux_to_tend, this%interior_tendencies, &
+                            this%tracer_metadata, this%StatusLog)
     if (this%StatusLog%labort_marbl) then
       call this%StatusLog%log_error_trace("marbl_init_tracers", subname)
       return
@@ -881,6 +882,7 @@ contains
 
     call marbl_interior_tendency_compute(                                           &
          domain                            = this%domain,                           &
+         bot_flux_to_tend                  = this%bot_flux_to_tend,                 &
          interior_tendency_forcings        = this%interior_tendency_forcings,       &
          tracers                           = this%tracers,                          &
          surface_flux_forcing_indices      = this%surface_flux_forcing_ind,         &
@@ -1042,6 +1044,7 @@ contains
       deallocate(this%tracers_at_surface)
       deallocate(this%surface_fluxes)
       deallocate(this%tracers)
+      deallocate(this%bot_flux_to_tend)
       deallocate(this%interior_tendencies)
       deallocate(this%tracer_metadata)
       if (allocated(tracer_restore_vars)) deallocate(tracer_restore_vars)

--- a/src/marbl_interior_tendency_mod.F90
+++ b/src/marbl_interior_tendency_mod.F90
@@ -76,6 +76,7 @@ module marbl_interior_tendency_mod
   use marbl_settings_mod, only : del_ph
   use marbl_settings_mod, only : phhi_3d_init
   use marbl_settings_mod, only : phlo_3d_init
+  use marbl_settings_mod, only : bftt_dz_sum_thres
 
   use marbl_pft_mod, only : Qp_zoo
 
@@ -209,7 +210,7 @@ contains
     ! computations.
 
     interior_tendencies(:, :) = c0
-    if (abs(c1 - sum(domain%delta_z(:) * bot_flux_to_tend(:))) > 1e-14) then
+    if (abs(c1 - sum(domain%delta_z(:) * bot_flux_to_tend(:))) > bftt_dz_sum_thres) then
       write(log_message, "(A, E11.3, A)") "1 - sum(bot_flux_to_tend * dz) = ", &
                                           c1 - sum(domain%delta_z(:) * bot_flux_to_tend(:)), &
                                           ", which is too far from 0 for conservation"

--- a/src/marbl_interior_tendency_mod.F90
+++ b/src/marbl_interior_tendency_mod.F90
@@ -209,11 +209,16 @@ contains
     ! computations.
 
     interior_tendencies(:, :) = c0
-    if (abs(c1 - sum(domain%delta_z(:) * bot_flux_to_tend(:))) > 1e-10) then
+    if (abs(c1 - sum(domain%delta_z(:) * bot_flux_to_tend(:))) > 1e-14) then
       write(log_message, "(A, E11.3, A)") "1 - sum(bot_flux_to_tend * dz) = ", &
                                           c1 - sum(domain%delta_z(:) * bot_flux_to_tend(:)), &
                                           ", which is too far from 0 for conservation"
       call marbl_status_log%log_error(log_message, subname)
+      do k=1,domain%km
+        write(log_message, *) k, domain%delta_z(k), bot_flux_to_tend(k), domain%zw(k), &
+                              c1 - sum(domain%delta_z(1:k) * bot_flux_to_tend(1:k))
+        call marbl_status_log%log_error(log_message, subname)
+      end do
       return
     end if
 

--- a/src/marbl_interior_tendency_mod.F90
+++ b/src/marbl_interior_tendency_mod.F90
@@ -209,7 +209,7 @@ contains
     ! computations.
 
     interior_tendencies(:, :) = c0
-    if (abs(c1 - sum(domain%delta_z(:) * bot_flux_to_tend(:))) > 1e-12) then
+    if (abs(c1 - sum(domain%delta_z(:) * bot_flux_to_tend(:))) > 1e-10) then
       write(log_message, "(A, E11.3, A)") "1 - sum(bot_flux_to_tend * dz) = ", &
                                           c1 - sum(domain%delta_z(:) * bot_flux_to_tend(:)), &
                                           ", which is too far from 0 for conservation"

--- a/src/marbl_interior_tendency_mod.F90
+++ b/src/marbl_interior_tendency_mod.F90
@@ -2718,7 +2718,7 @@ contains
      !       - MOM will apply a unit bottom flux to the bottom of a dummy
      !         tracers of 0s and then divide by dz to convert to tendency
      !-----------------------------------------------------------------------
-     bot_flux_to_tend = c0
+     bot_flux_to_tend(:) = c0
      bot_flux_to_tend(column_kmt) = c1 / delta_z(column_kmt)
 
      !-----------------------------------------------------------------------

--- a/src/marbl_interior_tendency_mod.F90
+++ b/src/marbl_interior_tendency_mod.F90
@@ -166,6 +166,7 @@ contains
     !  local variables
     !-----------------------------------------------------------------------
     character(len=*), parameter :: subname = 'marbl_interior_tendency_mod:marbl_interior_tendency_compute'
+    character(len=char_len)     :: log_message
 
     real(r8), dimension(size(tracers,1), domain%km) :: interior_restore
     real(r8), dimension(size(tracers,1), domain%km) :: tracer_local
@@ -208,6 +209,13 @@ contains
     ! computations.
 
     interior_tendencies(:, :) = c0
+    if (abs(1. - sum(domain%delta_z(:) * bot_flux_to_tend(:))) > 1e-8) then
+      write(log_message, "(A, E11.3, A)") "sum(bot_flux_to_tend * dz) = ", &
+                                          sum(domain%delta_z(:) * bot_flux_to_tend(:)), &
+                                          ", which is too far from 1 for conservation"
+      call marbl_status_log%log_error(log_message, subname)
+      return
+    end if
 
     if (.not. lsource_sink) then
        !-----------------------------------------------------------------------

--- a/src/marbl_interior_tendency_mod.F90
+++ b/src/marbl_interior_tendency_mod.F90
@@ -209,10 +209,10 @@ contains
     ! computations.
 
     interior_tendencies(:, :) = c0
-    if (abs(1. - sum(domain%delta_z(:) * bot_flux_to_tend(:))) > 1e-8) then
-      write(log_message, "(A, E11.3, A)") "sum(bot_flux_to_tend * dz) = ", &
-                                          sum(domain%delta_z(:) * bot_flux_to_tend(:)), &
-                                          ", which is too far from 1 for conservation"
+    if (abs(c1 - sum(domain%delta_z(:) * bot_flux_to_tend(:))) > 1e-12) then
+      write(log_message, "(A, E11.3, A)") "1 - sum(bot_flux_to_tend * dz) = ", &
+                                          c1 - sum(domain%delta_z(:) * bot_flux_to_tend(:)), &
+                                          ", which is too far from 0 for conservation"
       call marbl_status_log%log_error(log_message, subname)
       return
     end if

--- a/src/marbl_interior_tendency_mod.F90
+++ b/src/marbl_interior_tendency_mod.F90
@@ -91,6 +91,7 @@ contains
 
   subroutine marbl_interior_tendency_compute( &
        domain,                                &
+       bot_flux_to_tend,                      &
        interior_tendency_forcings,            &
        tracers,                               &
        surface_flux_forcing_indices,          &
@@ -134,6 +135,7 @@ contains
 
 
     type(marbl_domain_type),                                 intent(in)    :: domain
+    real(r8),                                                intent(in)    :: bot_flux_to_tend(:)  ! (km)
     type(marbl_forcing_fields_type),                         intent(in)    :: interior_tendency_forcings(:)
     real(r8),                                                intent(in)    :: tracers(:,:)         ! (tracer_cnt, km) tracer values
     type(marbl_surface_flux_forcing_indexing_type),          intent(in)    :: surface_flux_forcing_indices
@@ -167,7 +169,6 @@ contains
 
     real(r8), dimension(size(tracers,1), domain%km) :: interior_restore
     real(r8), dimension(size(tracers,1), domain%km) :: tracer_local
-    real(r8), dimension(domain%km) :: bot_flux_to_tend
 
     integer (int_kind) :: k         ! vertical level index
 
@@ -255,16 +256,6 @@ contains
          donr_ind          => marbl_tracer_indices%donr_ind,        &
          docr_ind          => marbl_tracer_indices%docr_ind         &
          )
-
-     !-----------------------------------------------------------------------
-     ! (temporary) initialize weights for applying bottom fluxes
-     ! TODO: this should be an argument from the GCM
-     !       - POP will use a similar construction as below
-     !       - MOM will apply a unit bottom flux to the bottom of a dummy
-     !         tracers of 0s and then divide by dz to convert to tendency
-     !-----------------------------------------------------------------------
-     bot_flux_to_tend(:) = c0
-     bot_flux_to_tend(kmt) = c1 / domain%delta_z(kmt)
 
     !-----------------------------------------------------------------------
     !  Compute in situ temp

--- a/src/marbl_interior_tendency_mod.F90
+++ b/src/marbl_interior_tendency_mod.F90
@@ -2668,7 +2668,7 @@ contains
           sio2_diss, & ! diss. length varies spatially with O2
           caco3_diss, &
           dust_diss
-     real (r8) :: bot_flux_to_tend(domain%kmt)
+     real (r8) :: bot_flux_to_tend(domain%km)
 
      character(len=*), parameter :: subname = 'marbl_interior_tendency_mod:compute_particulate_terms'
      character(len=char_len)     :: log_message
@@ -3198,31 +3198,31 @@ contains
         !----------------------------------------------------------------------------------
 
         if (P_CaCO3%to_floor > c0) then
-           P_CaCO3%remin(1:column_kmt) = P_CaCO3%remin(1:column_kmt) &
-                + ((P_CaCO3%to_floor - P_CaCO3%sed_loss(k)) * bot_flux_to_tend(:))
+           P_CaCO3%remin(1:k) = P_CaCO3%remin(1:k) &
+                + ((P_CaCO3%to_floor - P_CaCO3%sed_loss(k)) * bot_flux_to_tend(1:k))
         endif
 
         if (P_CaCO3_ALT_CO2%to_floor > c0) then
-           P_CaCO3_ALT_CO2%remin(1:column_kmt) = P_CaCO3_ALT_CO2%remin(1:column_kmt) &
-                + ((P_CaCO3_ALT_CO2%to_floor - P_CaCO3_ALT_CO2%sed_loss(k)) * bot_flux_to_tend(:))
+           P_CaCO3_ALT_CO2%remin(1:k) = P_CaCO3_ALT_CO2%remin(1:k) &
+                + ((P_CaCO3_ALT_CO2%to_floor - P_CaCO3_ALT_CO2%sed_loss(k)) * bot_flux_to_tend(1:k))
         endif
 
         if (P_SiO2%to_floor > c0) then
-           P_SiO2%remin(1:column_kmt) = P_SiO2%remin(1:column_kmt) &
-                + ((P_SiO2%to_floor - P_SiO2%sed_loss(k)) * bot_flux_to_tend(:))
+           P_SiO2%remin(1:k) = P_SiO2%remin(1:k) &
+                + ((P_SiO2%to_floor - P_SiO2%sed_loss(k)) * bot_flux_to_tend(1:k))
         endif
 
         if (POC%to_floor > c0) then
-           POC%remin(1:column_kmt) = POC%remin(1:column_kmt) &
-                + ((POC%to_floor - POC%sed_loss(k)) * bot_flux_to_tend(:))
+           POC%remin(1:k) = POC%remin(1:k) &
+                + ((POC%to_floor - POC%sed_loss(k)) * bot_flux_to_tend(1:k))
 
-           PON_remin(1:column_kmt) = PON_remin(1:column_kmt) &
-                + ((Q * POC%to_floor - PON_sed_loss) * bot_flux_to_tend(:))
+           PON_remin(1:k) = PON_remin(1:k) &
+                + ((Q * POC%to_floor - PON_sed_loss) * bot_flux_to_tend(1:k))
         endif
 
         if (POP%to_floor > c0) then
-           POP%remin(1:column_kmt) = POP%remin(1:column_kmt) &
-                + ((POP%to_floor - POP%sed_loss(k)) * bot_flux_to_tend(:))
+           POP%remin(1:k) = POP%remin(1:k) &
+                + ((POP%to_floor - POP%sed_loss(k)) * bot_flux_to_tend(1:k))
         endif
 
         !-----------------------------------------------------------------------

--- a/src/marbl_settings_mod.F90
+++ b/src/marbl_settings_mod.F90
@@ -233,6 +233,7 @@ module marbl_settings_mod
        particulate_flux_ref_depth    ! reference depth for particulate flux diagnostics (m)
 
   real(r8), target :: &
+       bftt_dz_sum_thres,          & ! MARBL will abort if abs(1 - sum(bot_flux_to_tend)) exceeds this threshold
        Jint_Ctot_thres_molpm2pyr,  & ! MARBL will abort if abs(Jint_Ctot) exceeds this threshold
        Jint_Ctot_thres,            & ! MARBL will abort if abs(Jint_Ctot) exceeds this threshold (derived from Jint_Ctot_thres_molpm2pyr)
        Jint_Ntot_thres,            & ! MARBL will abort if abs(Jint_Ntot) exceeds this threshold (derived from Jint_Ctot_thres)
@@ -382,6 +383,7 @@ contains
     lo2_consumption_scalef        = .false.         ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
     lp_remin_scalef               = .false.         ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
     particulate_flux_ref_depth    = 100             ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
+    bftt_dz_sum_thres             = 1.0e-14_r8      ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
     Jint_Ctot_thres_molpm2pyr     = 1.0e-9_r8       ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
     gQsi_0                        = 0.137_r8        ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
     gQsi_max                      = 0.822_r8        ! CESM USERS - DO NOT CHANGE HERE! POP calls put_setting() for this var, see CESM NOTE above
@@ -700,6 +702,15 @@ contains
     iptr      => particulate_flux_ref_depth
     call this%add_var(sname, lname, units, datatype, category,       &
                         marbl_status_log, iptr=iptr)
+    call check_and_log_add_var_error(marbl_status_log, sname, subname, labort_marbl_loc)
+
+    sname     = 'bftt_dz_sum_thres'
+    lname     = 'MARBL will abort if abs(1 - sum(bot_flux_to_tend)) exceeds this threshold'
+    units     = 'unitless'
+    datatype  = 'real'
+    rptr      => bftt_dz_sum_thres
+    call this%add_var(sname, lname, units, datatype, category,       &
+                        marbl_status_log, rptr=rptr)
     call check_and_log_add_var_error(marbl_status_log, sname, subname, labort_marbl_loc)
 
     sname     = 'Jint_Ctot_thres_molpm2pyr'


### PR DESCRIPTION
This offers a different strategy to the same problem #377 is attempting to solve. Here, the particulate that hits the sea floor is redistributed as remineralization within the entire column (rather than just in the bottom layer, which is how `development` currently handles it, and without computing a bottom flux for each tracer, which is how the other PR handles it).

This is a draft because two key pieces are missing:

1. Providing a mechanism for the GCM to pass `bot_flux_to_tend(:)` instead of assuming it is `1 / delta_z(column_kmt)` at level `column_kmt` and 0 elsewhere
2. Updating the CISO driver to behave similarly

Note that this approach should be bit-for-bit in POP (which is not the case with the other PR due to how we handle denitrification) and does not require changes to the conservation diagnostics

Fixes #360 