### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/run_test_suite.yml
+++ b/.github/workflows/run_test_suite.yml
@@ -26,6 +26,7 @@ jobs:
           sudo apt-get update
           sudo apt install make gfortran netcdf-bin libnetcdf-dev libnetcdff-dev openmpi-bin libopenmpi-dev
       - name: Build docs
+        continue-on-error: True
         run: |
           cd docs/src
           make html

--- a/.github/workflows/run_test_suite.yml
+++ b/.github/workflows/run_test_suite.yml
@@ -25,12 +25,11 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt install make gfortran netcdf-bin libnetcdf-dev libnetcdff-dev openmpi-bin libopenmpi-dev
-      - name: Build docs
-        continue-on-error: True
-        run: |
-          cd docs/src
-          make html
       - name: Run Test Suite
         run: |
           cd MARBL_tools
           ./run_test_suite.sh
+      - name: Build docs
+        run: |
+          cd docs/src
+          make html

--- a/docs/py_requirements.txt
+++ b/docs/py_requirements.txt
@@ -2,4 +2,6 @@ pylint==2.10.2
 Sphinx==1.7.5
 sphinxcontrib-bibtex==0.4.0
 pybtex==0.22
+jinja2<3
+MarkupSafe<2.1
 git+https://github.com/marbl-ecosys/sphinx_rtd_theme.git@version-dropdown


### PR DESCRIPTION
It's not unusual for the continuous integration to fail several months after it was last run -- changes in the python stack often cause problems. This PR fixes some of the CI infrastructure without relying on changes to code that gets compiled / executed by MARBL itself.