### PR TITLE
Fix CI (again)

### DIFF
--- a/.github/workflows/run_test_suite.yml
+++ b/.github/workflows/run_test_suite.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
         matrix:
             python-version:
-                - 3.11
+                - '3.10'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/run_test_suite.yml
+++ b/.github/workflows/run_test_suite.yml
@@ -7,13 +7,13 @@ jobs:
     strategy:
         matrix:
             python-version:
-                - 3.7
+                - 3.11
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/run_test_suite.yml
+++ b/.github/workflows/run_test_suite.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
         matrix:
             python-version:
-                - '3.10'
+                - 3.9
 
     steps:
       - uses: actions/checkout@v3

--- a/MARBL_tools/code_consistency.py
+++ b/MARBL_tools/code_consistency.py
@@ -9,7 +9,7 @@ import sys
 import logging
 from collections import deque # Faster pop / append than standard lists
 from collections import OrderedDict
-UNIBLOCK = u"\u2588"
+UNIBLOCK = u"\u2588" # pylint: disable=redundant-u-string-prefix
 
 ##############
 
@@ -218,8 +218,8 @@ if __name__ == "__main__":
     else:
         MARBL_ROOT = os.path.join(SCRIPT_DIR, '..')
 
-    fortran_files = [] # pylint: disable=C0103
-    python_files = []  # pylint: disable=C0103
+    fortran_files = []
+    python_files = []
     for root, dirs, files in os.walk(MARBL_ROOT):
         for thisfile in files:
             if thisfile.endswith(".F90"):
@@ -231,7 +231,7 @@ if __name__ == "__main__":
     logging.basicConfig(format='%(message)s', level=logging.DEBUG)
     LOGGER = logging.getLogger(__name__)
 
-    Tests = ConsistencyTestClass() # pylint: disable=C0103
+    Tests = ConsistencyTestClass()
 
     # Fortran error checks
     LOGGER.info("Check Fortran files for coding standard violations:")

--- a/MARBL_tools/netcdf_comparison.py
+++ b/MARBL_tools/netcdf_comparison.py
@@ -270,8 +270,8 @@ if __name__ == "__main__":
     logging.basicConfig(format='%(message)s', level=logging.INFO)
     LOGGER = logging.getLogger(__name__)
 
-    args = _parse_args() # pylint: disable=invalid-name
-    ds_base_in, ds_new_in = _open_files(args.baseline, args.new_file) # pylint: disable=invalid-name
+    args = _parse_args()
+    ds_base_in, ds_new_in = _open_files(args.baseline, args.new_file)
     if args.strict == 'loose':
         if ds_comparison_loose(ds_base_in, ds_new_in, args.rtol, args.atol, args.thres):
             LOGGER.error("Differences found between files!")


### PR DESCRIPTION
Github Actions were failing, I believe due to reliance on old software. Besides updating the specific `actions/checkout` (from v2 to v3) and `actions/setup-python` (from v2 to v4), I also updated python from 3.7 to 3.9. I tried going all the way to 3.11, but there is a [known issue](https://github.com/GrahamDumpleton/wrapt/issues/196) with a dependency of the old version of `pylint` we are using, so I tried 3.10... that got past the `pylint` test but couldn't build the documentation (presumably an issue with the old version of Sphinx we rely on).

So this PR lets a pretty fragile CI setup run again, but I will open an issue ticket about updating both the code we rely on for documentation / testing and also the code we are actually running (with python 3.9, `pylint` flagged a line of code that was introduced to allow us to support both python 2 and python 3... do we want to maintain py2 compliance? For how long?)