### PR TITLE
Update defaults for tracer_restore_vars(:)

### DIFF
--- a/MARBL_tools/MARBL_settings_file_class.py
+++ b/MARBL_tools/MARBL_settings_file_class.py
@@ -13,7 +13,12 @@ class MARBL_settings_class(object):
     # CONSTRUCTOR #
     ###############
 
-    def __init__(self, default_settings_file, saved_state_vars_source="settings_file", grid=None, input_file=None):
+    def __init__(self,
+                 default_settings_file,
+                 saved_state_vars_source="settings_file",
+                 grid=None,
+                 restore_for_CESM="TRUE",
+                 input_file=None):
         """ Class constructor: set up a dictionary of config keywords for when multiple
             default values are provided, read the JSON file, and then populate
             self.settings_dict and self.tracers_dict.
@@ -25,6 +30,7 @@ class MARBL_settings_class(object):
         self._config_keyword = []
         if grid != None:
             self._config_keyword.append('GRID == "%s"' % grid)
+        self._config_keyword.append('USE_CESM_RESTORE == "%s"' % restore_for_CESM)
         self._config_keyword.append('SAVED_STATE_VARS_SOURCE == "%s"' % saved_state_vars_source)
 
         # 2. Read settings JSON file

--- a/defaults/json/settings_cesm2.0.json
+++ b/defaults/json/settings_cesm2.0.json
@@ -1350,14 +1350,7 @@
                "ALK",
                "ALK_ALT_CO2"
             ],
-            "GRID == \"CESM_x1\"": [
-               "PO4",
-               "NO3",
-               "SiO3",
-               "ALK",
-               "ALK_ALT_CO2"
-            ],
-            "GRID == \"CESM_x3\"": [
+            "USE_CESM_RESTORE == \"TRUE\"": [
                "PO4",
                "NO3",
                "SiO3",

--- a/defaults/json/settings_cesm2.1+cocco.json
+++ b/defaults/json/settings_cesm2.1+cocco.json
@@ -1395,14 +1395,7 @@
                "ALK",
                "ALK_ALT_CO2"
             ],
-            "GRID == \"CESM_x1\"": [
-               "PO4",
-               "NO3",
-               "SiO3",
-               "ALK",
-               "ALK_ALT_CO2"
-            ],
-            "GRID == \"CESM_x3\"": [
+            "USE_CESM_RESTORE == \"TRUE\"": [
                "PO4",
                "NO3",
                "SiO3",

--- a/defaults/json/settings_cesm2.1.json
+++ b/defaults/json/settings_cesm2.1.json
@@ -1353,14 +1353,7 @@
                "ALK",
                "ALK_ALT_CO2"
             ],
-            "GRID == \"CESM_x1\"": [
-               "PO4",
-               "NO3",
-               "SiO3",
-               "ALK",
-               "ALK_ALT_CO2"
-            ],
-            "GRID == \"CESM_x3\"": [
+            "USE_CESM_RESTORE == \"TRUE\"": [
                "PO4",
                "NO3",
                "SiO3",

--- a/defaults/json/settings_latest+4p2z.json
+++ b/defaults/json/settings_latest+4p2z.json
@@ -1448,14 +1448,7 @@
                "ALK",
                "ALK_ALT_CO2"
             ],
-            "GRID == \"CESM_x1\"": [
-               "PO4",
-               "NO3",
-               "SiO3",
-               "ALK",
-               "ALK_ALT_CO2"
-            ],
-            "GRID == \"CESM_x3\"": [
+            "USE_CESM_RESTORE == \"TRUE\"": [
                "PO4",
                "NO3",
                "SiO3",

--- a/defaults/json/settings_latest+cocco.json
+++ b/defaults/json/settings_latest+cocco.json
@@ -1388,14 +1388,7 @@
                "ALK",
                "ALK_ALT_CO2"
             ],
-            "GRID == \"CESM_x1\"": [
-               "PO4",
-               "NO3",
-               "SiO3",
-               "ALK",
-               "ALK_ALT_CO2"
-            ],
-            "GRID == \"CESM_x3\"": [
+            "USE_CESM_RESTORE == \"TRUE\"": [
                "PO4",
                "NO3",
                "SiO3",

--- a/defaults/json/settings_latest.json
+++ b/defaults/json/settings_latest.json
@@ -1353,14 +1353,7 @@
                "ALK",
                "ALK_ALT_CO2"
             ],
-            "GRID == \"CESM_x1\"": [
-               "PO4",
-               "NO3",
-               "SiO3",
-               "ALK",
-               "ALK_ALT_CO2"
-            ],
-            "GRID == \"CESM_x3\"": [
+            "USE_CESM_RESTORE == \"TRUE\"": [
                "PO4",
                "NO3",
                "SiO3",

--- a/defaults/settings_cesm2.0.yaml
+++ b/defaults/settings_cesm2.0.yaml
@@ -1194,5 +1194,5 @@ tracer_dependent :
             - 'SiO3'
             - 'ALK'
             - 'ALK_ALT_CO2'
-         GRID == "CESM_x3" : *CESM_TRACER_RESTORE
-         GRID == "CESM_x1" : *CESM_TRACER_RESTORE
+         USE_CESM_RESTORE == "TRUE" : *CESM_TRACER_RESTORE
+         USE_CESM_RESTORE == "TRUE" : *CESM_TRACER_RESTORE

--- a/defaults/settings_cesm2.1+cocco.yaml
+++ b/defaults/settings_cesm2.1+cocco.yaml
@@ -1235,5 +1235,5 @@ tracer_dependent :
             - 'SiO3'
             - 'ALK'
             - 'ALK_ALT_CO2'
-         GRID == "CESM_x3" : *CESM_TRACER_RESTORE
-         GRID == "CESM_x1" : *CESM_TRACER_RESTORE
+         USE_CESM_RESTORE == "TRUE" : *CESM_TRACER_RESTORE
+         USE_CESM_RESTORE == "TRUE" : *CESM_TRACER_RESTORE

--- a/defaults/settings_cesm2.1.yaml
+++ b/defaults/settings_cesm2.1.yaml
@@ -1195,5 +1195,5 @@ tracer_dependent :
             - 'SiO3'
             - 'ALK'
             - 'ALK_ALT_CO2'
-         GRID == "CESM_x3" : *CESM_TRACER_RESTORE
-         GRID == "CESM_x1" : *CESM_TRACER_RESTORE
+         USE_CESM_RESTORE == "TRUE" : *CESM_TRACER_RESTORE
+         USE_CESM_RESTORE == "TRUE" : *CESM_TRACER_RESTORE

--- a/defaults/settings_latest+4p2z.yaml
+++ b/defaults/settings_latest+4p2z.yaml
@@ -1287,5 +1287,5 @@ tracer_dependent :
             - 'SiO3'
             - 'ALK'
             - 'ALK_ALT_CO2'
-         GRID == "CESM_x3" : *CESM_TRACER_RESTORE
-         GRID == "CESM_x1" : *CESM_TRACER_RESTORE
+         USE_CESM_RESTORE == "TRUE" : *CESM_TRACER_RESTORE
+         USE_CESM_RESTORE == "TRUE" : *CESM_TRACER_RESTORE

--- a/defaults/settings_latest+cocco.yaml
+++ b/defaults/settings_latest+cocco.yaml
@@ -1229,5 +1229,5 @@ tracer_dependent :
             - 'SiO3'
             - 'ALK'
             - 'ALK_ALT_CO2'
-         GRID == "CESM_x3" : *CESM_TRACER_RESTORE
-         GRID == "CESM_x1" : *CESM_TRACER_RESTORE
+         USE_CESM_RESTORE == "TRUE" : *CESM_TRACER_RESTORE
+         USE_CESM_RESTORE == "TRUE" : *CESM_TRACER_RESTORE

--- a/defaults/settings_latest.yaml
+++ b/defaults/settings_latest.yaml
@@ -1195,5 +1195,5 @@ tracer_dependent :
             - 'SiO3'
             - 'ALK'
             - 'ALK_ALT_CO2'
-         GRID == "CESM_x3" : *CESM_TRACER_RESTORE
-         GRID == "CESM_x1" : *CESM_TRACER_RESTORE
+         USE_CESM_RESTORE == "TRUE" : *CESM_TRACER_RESTORE
+         USE_CESM_RESTORE == "TRUE" : *CESM_TRACER_RESTORE


### PR DESCRIPTION
Instead of restoring PO4, NO3, SiO3, ALK, and ALK_ALT_CO2 when GRID is either CESM_x3 or CESM_x1, those five are set when a new variable (USE_CESM_RESTORE) is set to TRUE. TRUE is the default value, but I have a MOM_interface update that will use FALSE instead, and then I don't need the kludge in MOM's MARBL_tracers module to turn off restoring (which is good, because we want to start using restoring in the single column runs that run through solo_driver)