### PR TITLE
generate_settings_file sets tracer module logicals

### DIFF
--- a/MARBL_tools/MARBL_generate_diagnostics_file.py
+++ b/MARBL_tools/MARBL_generate_diagnostics_file.py
@@ -158,7 +158,11 @@ if __name__ == "__main__":
 
     from MARBL_tools import MARBL_settings_class
     from MARBL_tools import MARBL_diagnostics_class
-    DefaultSettings = MARBL_settings_class(args.default_settings_file, args.saved_state_vars_source, args.grid, args.settings_file_in, args.unit_system)
+    DefaultSettings = MARBL_settings_class(args.default_settings_file,
+                                           args.saved_state_vars_source,
+                                           grid=args.grid,
+                                           input_file=args.settings_file_in,
+                                           unit_system=args.unit_system)
     MARBL_diagnostics = MARBL_diagnostics_class(args.default_diagnostics_file, DefaultSettings, args.unit_system)
 
     # Write the diagnostic file

--- a/MARBL_tools/MARBL_generate_settings_file.py
+++ b/MARBL_tools/MARBL_generate_settings_file.py
@@ -82,6 +82,14 @@ def _parse_args(marbl_root):
                         help="Source of initial value for saved state vars that can come from GCM or settings file")
 
     # Command line argument to specify resolution (default is None)
+    parser.add_argument('--disable-base-bio', action='store_false', dest='base_bio_on',
+                        help='Turn off base biotic tracer module (default is on)')
+
+    # Command line argument to specify resolution (default is None)
+    parser.add_argument('--enable-abio-dic', action='store_true', dest='abio_dic_on',
+                        help='Turn on abiotic DIC tracer module (default is off)')
+
+    # Command line argument to specify resolution (default is None)
     parser.add_argument('-g', '--grid', action='store', dest='grid',
                         help='Some default values are grid-dependent')
 
@@ -115,7 +123,13 @@ if __name__ == "__main__":
     logging.basicConfig(format='%(levelname)s (%(funcName)s): %(message)s', level=logging.DEBUG)
 
     from MARBL_tools import MARBL_settings_class
-    DefaultSettings = MARBL_settings_class(args.default_settings_file, args.saved_state_vars_source, args.grid, args.settings_file_in, args.unit_system)
+    DefaultSettings = MARBL_settings_class(args.default_settings_file,
+                                           args.saved_state_vars_source,
+                                           args.base_bio_on,
+                                           args.abio_dic_on,
+                                           args.grid,
+                                           args.settings_file_in,
+                                           args.unit_system)
 
     # Write the settings file
     generate_settings_file(DefaultSettings, args.settings_file_out)

--- a/MARBL_tools/MARBL_generate_settings_file.py
+++ b/MARBL_tools/MARBL_generate_settings_file.py
@@ -81,11 +81,11 @@ def _parse_args(marbl_root):
                         default='settings_file', choices = set(('settings_file', 'GCM')),
                         help="Source of initial value for saved state vars that can come from GCM or settings file")
 
-    # Command line argument to specify resolution (default is None)
+    # Command line flag to turn off the base biotic tracers
     parser.add_argument('--disable-base-bio', action='store_false', dest='base_bio_on',
                         help='Turn off base biotic tracer module (default is on)')
 
-    # Command line argument to specify resolution (default is None)
+    # Command line flag to turn on the abiotic DIC tracers
     parser.add_argument('--enable-abio-dic', action='store_true', dest='abio_dic_on',
                         help='Turn on abiotic DIC tracer module (default is off)')
 

--- a/MARBL_tools/MARBL_settings_file_class.py
+++ b/MARBL_tools/MARBL_settings_file_class.py
@@ -13,7 +13,9 @@ class MARBL_settings_class(object):
     # CONSTRUCTOR #
     ###############
 
-    def __init__(self, default_settings_file, saved_state_vars_source="settings_file", grid=None, input_file=None, unit_system='cgs'):
+    def __init__(self, default_settings_file, saved_state_vars_source="settings_file",
+                 base_bio_on=True, abio_dic_on=False, grid=None, input_file=None,
+                 unit_system='cgs'):
         """ Class constructor: set up a dictionary of config keywords for when multiple
             default values are provided, read the JSON file, and then populate
             self.settings_dict and self.tracers_dict.
@@ -23,6 +25,10 @@ class MARBL_settings_class(object):
 
         # 1. List of configuration keywords to match in JSON if default_default is a dictionary
         self._config_keyword = []
+        if not base_bio_on:
+            self._config_keyword.append('EXCLUDE_BASE_BIO')
+        if abio_dic_on:
+            self._config_keyword.append('INCLUDE_ABIO_DIC')
         if grid != None:
             self._config_keyword.append('GRID == "%s"' % grid)
         self._config_keyword.append('SAVED_STATE_VARS_SOURCE == "%s"' % saved_state_vars_source)

--- a/MARBL_tools/MARBL_settings_file_class.py
+++ b/MARBL_tools/MARBL_settings_file_class.py
@@ -647,6 +647,9 @@ def _parse_input_file(input_file, exclude_dict):
                 # Single value
                 input_dict[var_name] = value
         f.close()
+    except TypeError:
+        # If inputfile == None then the open will result in TypeError
+        pass
     except FileNotFoundError:
         logger.error("input_file '%s' was not found" % input_file)
         MARBL_tools.abort(1)

--- a/MARBL_tools/MARBL_settings_file_class.py
+++ b/MARBL_tools/MARBL_settings_file_class.py
@@ -23,12 +23,14 @@ class MARBL_settings_class(object):
 
         logger = logging.getLogger(__name__)
 
+        # Check argument types
+        if not (type(base_bio_on) == bool and type(abio_dic_on == bool)):
+          raise ValueError("base_bio_on and abio_dic_on must be type bool")
+
         # 1. List of configuration keywords to match in JSON if default_default is a dictionary
         self._config_keyword = []
-        if not base_bio_on:
-            self._config_keyword.append('EXCLUDE_BASE_BIO')
-        if abio_dic_on:
-            self._config_keyword.append('INCLUDE_ABIO_DIC')
+        self._config_keyword.append(f'BASE_BIO_ON == {str(base_bio_on).upper()}')
+        self._config_keyword.append(f'ABIO_DIC_ON == {str(abio_dic_on).upper()}')
         if grid != None:
             self._config_keyword.append('GRID == "%s"' % grid)
         self._config_keyword.append('SAVED_STATE_VARS_SOURCE == "%s"' % saved_state_vars_source)

--- a/MARBL_tools/netcdf_metadata_check.py
+++ b/MARBL_tools/netcdf_metadata_check.py
@@ -110,9 +110,9 @@ if __name__ == "__main__":
     ds = xr.open_dataset(args.netcdf_file)
     DefaultSettings = MARBL_settings_class(args.default_settings_file,
                                            "settings_file",
-                                           None,
-                                           args.settings_file_in,
-                                           args.unit_system
+                                           grid=None,
+                                           input_file=args.settings_file_in,
+                                           unit_system=args.unit_system
                                           )
     MARBL_diagnostics = MARBL_diagnostics_class(args.default_diagnostics_file,
                                                 DefaultSettings,

--- a/defaults/json/settings_cesm2.0.json
+++ b/defaults/json/settings_cesm2.0.json
@@ -1519,7 +1519,10 @@
       "abio_dic_on": {
          "_append_to_config_keywords": true,
          "datatype": "logical",
-         "default_value": ".false.",
+         "default_value": {
+            "INCLUDE_ABIO_DIC": ".true.",
+            "default": ".false."
+         },
          "longname": "Control whether abiotic carbon tracer module is active",
          "subcategory": "1. tracer modules",
          "units": "unitless"
@@ -1527,7 +1530,10 @@
       "base_bio_on": {
          "_append_to_config_keywords": true,
          "datatype": "logical",
-         "default_value": ".true.",
+         "default_value": {
+            "EXCLUDE_BASE_BIO": ".false.",
+            "default": ".true."
+         },
          "longname": "Control whether the base ecosystem tracer module is active",
          "subcategory": "1. tracer modules",
          "units": "unitless"

--- a/defaults/json/settings_cesm2.0.json
+++ b/defaults/json/settings_cesm2.0.json
@@ -1520,7 +1520,7 @@
          "_append_to_config_keywords": true,
          "datatype": "logical",
          "default_value": {
-            "INCLUDE_ABIO_DIC": ".true.",
+            "ABIO_DIC_ON == TRUE": ".true.",
             "default": ".false."
          },
          "longname": "Control whether abiotic carbon tracer module is active",
@@ -1531,7 +1531,7 @@
          "_append_to_config_keywords": true,
          "datatype": "logical",
          "default_value": {
-            "EXCLUDE_BASE_BIO": ".false.",
+            "BASE_BIO_ON == FALSE": ".false.",
             "default": ".true."
          },
          "longname": "Control whether the base ecosystem tracer module is active",

--- a/defaults/json/settings_cesm2.1+cocco.json
+++ b/defaults/json/settings_cesm2.1+cocco.json
@@ -1565,7 +1565,7 @@
          "_append_to_config_keywords": true,
          "datatype": "logical",
          "default_value": {
-            "INCLUDE_ABIO_DIC": ".true.",
+            "ABIO_DIC_ON == TRUE": ".true.",
             "default": ".false."
          },
          "longname": "Control whether abiotic carbon tracer module is active",
@@ -1576,7 +1576,7 @@
          "_append_to_config_keywords": true,
          "datatype": "logical",
          "default_value": {
-            "EXCLUDE_BASE_BIO": ".false.",
+            "BASE_BIO_ON == FALSE": ".false.",
             "default": ".true."
          },
          "longname": "Control whether the base ecosystem tracer module is active",

--- a/defaults/json/settings_cesm2.1+cocco.json
+++ b/defaults/json/settings_cesm2.1+cocco.json
@@ -1564,7 +1564,10 @@
       "abio_dic_on": {
          "_append_to_config_keywords": true,
          "datatype": "logical",
-         "default_value": ".false.",
+         "default_value": {
+            "INCLUDE_ABIO_DIC": ".true.",
+            "default": ".false."
+         },
          "longname": "Control whether abiotic carbon tracer module is active",
          "subcategory": "1. tracer modules",
          "units": "unitless"
@@ -1572,7 +1575,10 @@
       "base_bio_on": {
          "_append_to_config_keywords": true,
          "datatype": "logical",
-         "default_value": ".true.",
+         "default_value": {
+            "EXCLUDE_BASE_BIO": ".false.",
+            "default": ".true."
+         },
          "longname": "Control whether the base ecosystem tracer module is active",
          "subcategory": "1. tracer modules",
          "units": "unitless"

--- a/defaults/json/settings_cesm2.1.json
+++ b/defaults/json/settings_cesm2.1.json
@@ -1523,7 +1523,7 @@
          "_append_to_config_keywords": true,
          "datatype": "logical",
          "default_value": {
-            "INCLUDE_ABIO_DIC": ".true.",
+            "ABIO_DIC_ON == TRUE": ".true.",
             "default": ".false."
          },
          "longname": "Control whether abiotic carbon tracer module is active",
@@ -1534,7 +1534,7 @@
          "_append_to_config_keywords": true,
          "datatype": "logical",
          "default_value": {
-            "EXCLUDE_BASE_BIO": ".false.",
+            "BASE_BIO_ON == FALSE": ".false.",
             "default": ".true."
          },
          "longname": "Control whether the base ecosystem tracer module is active",

--- a/defaults/json/settings_cesm2.1.json
+++ b/defaults/json/settings_cesm2.1.json
@@ -1522,7 +1522,10 @@
       "abio_dic_on": {
          "_append_to_config_keywords": true,
          "datatype": "logical",
-         "default_value": ".false.",
+         "default_value": {
+            "INCLUDE_ABIO_DIC": ".true.",
+            "default": ".false."
+         },
          "longname": "Control whether abiotic carbon tracer module is active",
          "subcategory": "1. tracer modules",
          "units": "unitless"
@@ -1530,7 +1533,10 @@
       "base_bio_on": {
          "_append_to_config_keywords": true,
          "datatype": "logical",
-         "default_value": ".true.",
+         "default_value": {
+            "EXCLUDE_BASE_BIO": ".false.",
+            "default": ".true."
+         },
          "longname": "Control whether the base ecosystem tracer module is active",
          "subcategory": "1. tracer modules",
          "units": "unitless"

--- a/defaults/json/settings_latest+4p2z.json
+++ b/defaults/json/settings_latest+4p2z.json
@@ -1618,7 +1618,7 @@
          "_append_to_config_keywords": true,
          "datatype": "logical",
          "default_value": {
-            "INCLUDE_ABIO_DIC": ".true.",
+            "ABIO_DIC_ON == TRUE": ".true.",
             "default": ".false."
          },
          "longname": "Control whether abiotic carbon tracer module is active",
@@ -1629,7 +1629,7 @@
          "_append_to_config_keywords": true,
          "datatype": "logical",
          "default_value": {
-            "EXCLUDE_BASE_BIO": ".false.",
+            "BASE_BIO_ON == FALSE": ".false.",
             "default": ".true."
          },
          "longname": "Control whether the base ecosystem tracer module is active",

--- a/defaults/json/settings_latest+4p2z.json
+++ b/defaults/json/settings_latest+4p2z.json
@@ -1617,7 +1617,10 @@
       "abio_dic_on": {
          "_append_to_config_keywords": true,
          "datatype": "logical",
-         "default_value": ".false.",
+         "default_value": {
+            "INCLUDE_ABIO_DIC": ".true.",
+            "default": ".false."
+         },
          "longname": "Control whether abiotic carbon tracer module is active",
          "subcategory": "1. tracer modules",
          "units": "unitless"
@@ -1625,7 +1628,10 @@
       "base_bio_on": {
          "_append_to_config_keywords": true,
          "datatype": "logical",
-         "default_value": ".true.",
+         "default_value": {
+            "EXCLUDE_BASE_BIO": ".false.",
+            "default": ".true."
+         },
          "longname": "Control whether the base ecosystem tracer module is active",
          "subcategory": "1. tracer modules",
          "units": "unitless"

--- a/defaults/json/settings_latest+cocco.json
+++ b/defaults/json/settings_latest+cocco.json
@@ -1565,7 +1565,7 @@
          "_append_to_config_keywords": true,
          "datatype": "logical",
          "default_value": {
-            "INCLUDE_ABIO_DIC": ".true.",
+            "ABIO_DIC_ON == TRUE": ".true.",
             "default": ".false."
          },
          "longname": "Control whether abiotic carbon tracer module is active",
@@ -1576,7 +1576,7 @@
          "_append_to_config_keywords": true,
          "datatype": "logical",
          "default_value": {
-            "EXCLUDE_BASE_BIO": ".false.",
+            "BASE_BIO_ON == FALSE": ".false.",
             "default": ".true."
          },
          "longname": "Control whether the base ecosystem tracer module is active",

--- a/defaults/json/settings_latest+cocco.json
+++ b/defaults/json/settings_latest+cocco.json
@@ -1564,7 +1564,10 @@
       "abio_dic_on": {
          "_append_to_config_keywords": true,
          "datatype": "logical",
-         "default_value": ".false.",
+         "default_value": {
+            "INCLUDE_ABIO_DIC": ".true.",
+            "default": ".false."
+         },
          "longname": "Control whether abiotic carbon tracer module is active",
          "subcategory": "1. tracer modules",
          "units": "unitless"
@@ -1572,7 +1575,10 @@
       "base_bio_on": {
          "_append_to_config_keywords": true,
          "datatype": "logical",
-         "default_value": ".true.",
+         "default_value": {
+            "EXCLUDE_BASE_BIO": ".false.",
+            "default": ".true."
+         },
          "longname": "Control whether the base ecosystem tracer module is active",
          "subcategory": "1. tracer modules",
          "units": "unitless"

--- a/defaults/json/settings_latest.json
+++ b/defaults/json/settings_latest.json
@@ -1529,7 +1529,7 @@
          "_append_to_config_keywords": true,
          "datatype": "logical",
          "default_value": {
-            "INCLUDE_ABIO_DIC": ".true.",
+            "ABIO_DIC_ON == TRUE": ".true.",
             "default": ".false."
          },
          "longname": "Control whether abiotic carbon tracer module is active",
@@ -1540,7 +1540,7 @@
          "_append_to_config_keywords": true,
          "datatype": "logical",
          "default_value": {
-            "EXCLUDE_BASE_BIO": ".false.",
+            "BASE_BIO_ON == FALSE": ".false.",
             "default": ".true."
          },
          "longname": "Control whether the base ecosystem tracer module is active",

--- a/defaults/json/settings_latest.json
+++ b/defaults/json/settings_latest.json
@@ -1528,7 +1528,10 @@
       "abio_dic_on": {
          "_append_to_config_keywords": true,
          "datatype": "logical",
-         "default_value": ".false.",
+         "default_value": {
+            "INCLUDE_ABIO_DIC": ".true.",
+            "default": ".false."
+         },
          "longname": "Control whether abiotic carbon tracer module is active",
          "subcategory": "1. tracer modules",
          "units": "unitless"
@@ -1536,7 +1539,10 @@
       "base_bio_on": {
          "_append_to_config_keywords": true,
          "datatype": "logical",
-         "default_value": ".true.",
+         "default_value": {
+            "EXCLUDE_BASE_BIO": ".false.",
+            "default": ".true."
+         },
          "longname": "Control whether the base ecosystem tracer module is active",
          "subcategory": "1. tracer modules",
          "units": "unitless"

--- a/defaults/settings_cesm2.0.yaml
+++ b/defaults/settings_cesm2.0.yaml
@@ -255,14 +255,18 @@ tracer_modules :
       subcategory : 1. tracer modules
       units : unitless
       datatype : logical
-      default_value : .true.
+      default_value :
+         default : .true.
+         EXCLUDE_BASE_BIO : .false.
       _append_to_config_keywords : true
    abio_dic_on :
       longname : Control whether abiotic carbon tracer module is active
       subcategory : 1. tracer modules
       units : unitless
       datatype : logical
-      default_value : .false.
+      default_value :
+         default : .false.
+         INCLUDE_ABIO_DIC : .true.
       _append_to_config_keywords : true
    ciso_on :
       longname : Control whether CISO tracer module is active

--- a/defaults/settings_cesm2.0.yaml
+++ b/defaults/settings_cesm2.0.yaml
@@ -257,7 +257,7 @@ tracer_modules :
       datatype : logical
       default_value :
          default : .true.
-         EXCLUDE_BASE_BIO : .false.
+         BASE_BIO_ON == FALSE : .false.
       _append_to_config_keywords : true
    abio_dic_on :
       longname : Control whether abiotic carbon tracer module is active
@@ -266,7 +266,7 @@ tracer_modules :
       datatype : logical
       default_value :
          default : .false.
-         INCLUDE_ABIO_DIC : .true.
+         ABIO_DIC_ON == TRUE : .true.
       _append_to_config_keywords : true
    ciso_on :
       longname : Control whether CISO tracer module is active

--- a/defaults/settings_cesm2.1+cocco.yaml
+++ b/defaults/settings_cesm2.1+cocco.yaml
@@ -255,14 +255,18 @@ tracer_modules :
       subcategory : 1. tracer modules
       units : unitless
       datatype : logical
-      default_value : .true.
+      default_value :
+         default : .true.
+         EXCLUDE_BASE_BIO : .false.
       _append_to_config_keywords : true
    abio_dic_on :
       longname : Control whether abiotic carbon tracer module is active
       subcategory : 1. tracer modules
       units : unitless
       datatype : logical
-      default_value : .false.
+      default_value :
+         default : .false.
+         INCLUDE_ABIO_DIC : .true.
       _append_to_config_keywords : true
    ciso_on :
       longname : Control whether CISO tracer module is active

--- a/defaults/settings_cesm2.1+cocco.yaml
+++ b/defaults/settings_cesm2.1+cocco.yaml
@@ -257,7 +257,7 @@ tracer_modules :
       datatype : logical
       default_value :
          default : .true.
-         EXCLUDE_BASE_BIO : .false.
+         BASE_BIO_ON == FALSE : .false.
       _append_to_config_keywords : true
    abio_dic_on :
       longname : Control whether abiotic carbon tracer module is active
@@ -266,7 +266,7 @@ tracer_modules :
       datatype : logical
       default_value :
          default : .false.
-         INCLUDE_ABIO_DIC : .true.
+         ABIO_DIC_ON == TRUE : .true.
       _append_to_config_keywords : true
    ciso_on :
       longname : Control whether CISO tracer module is active

--- a/defaults/settings_cesm2.1.yaml
+++ b/defaults/settings_cesm2.1.yaml
@@ -255,14 +255,18 @@ tracer_modules :
       subcategory : 1. tracer modules
       units : unitless
       datatype : logical
-      default_value : .true.
+      default_value :
+         default : .true.
+         EXCLUDE_BASE_BIO : .false.
       _append_to_config_keywords : true
    abio_dic_on :
       longname : Control whether abiotic carbon tracer module is active
       subcategory : 1. tracer modules
       units : unitless
       datatype : logical
-      default_value : .false.
+      default_value :
+         default : .false.
+         INCLUDE_ABIO_DIC : .true.
       _append_to_config_keywords : true
    ciso_on :
       longname : Control whether CISO tracer module is active

--- a/defaults/settings_cesm2.1.yaml
+++ b/defaults/settings_cesm2.1.yaml
@@ -257,7 +257,7 @@ tracer_modules :
       datatype : logical
       default_value :
          default : .true.
-         EXCLUDE_BASE_BIO : .false.
+         BASE_BIO_ON == FALSE : .false.
       _append_to_config_keywords : true
    abio_dic_on :
       longname : Control whether abiotic carbon tracer module is active
@@ -266,7 +266,7 @@ tracer_modules :
       datatype : logical
       default_value :
          default : .false.
-         INCLUDE_ABIO_DIC : .true.
+         ABIO_DIC_ON == TRUE : .true.
       _append_to_config_keywords : true
    ciso_on :
       longname : Control whether CISO tracer module is active

--- a/defaults/settings_latest+4p2z.yaml
+++ b/defaults/settings_latest+4p2z.yaml
@@ -268,7 +268,7 @@ tracer_modules :
       datatype : logical
       default_value :
          default : .true.
-         EXCLUDE_BASE_BIO : .false.
+         BASE_BIO_ON == FALSE : .false.
       _append_to_config_keywords : true
    abio_dic_on :
       longname : Control whether abiotic carbon tracer module is active
@@ -277,7 +277,7 @@ tracer_modules :
       datatype : logical
       default_value :
          default : .false.
-         INCLUDE_ABIO_DIC : .true.
+         ABIO_DIC_ON == TRUE : .true.
       _append_to_config_keywords : true
    ciso_on :
       longname : Control whether CISO tracer module is active

--- a/defaults/settings_latest+4p2z.yaml
+++ b/defaults/settings_latest+4p2z.yaml
@@ -266,14 +266,18 @@ tracer_modules :
       subcategory : 1. tracer modules
       units : unitless
       datatype : logical
-      default_value : .true.
+      default_value :
+         default : .true.
+         EXCLUDE_BASE_BIO : .false.
       _append_to_config_keywords : true
    abio_dic_on :
       longname : Control whether abiotic carbon tracer module is active
       subcategory : 1. tracer modules
       units : unitless
       datatype : logical
-      default_value : .false.
+      default_value :
+         default : .false.
+         INCLUDE_ABIO_DIC : .true.
       _append_to_config_keywords : true
    ciso_on :
       longname : Control whether CISO tracer module is active

--- a/defaults/settings_latest+cocco.yaml
+++ b/defaults/settings_latest+cocco.yaml
@@ -255,14 +255,18 @@ tracer_modules :
       subcategory : 1. tracer modules
       units : unitless
       datatype : logical
-      default_value : .true.
+      default_value :
+         default : .true.
+         EXCLUDE_BASE_BIO : .false.
       _append_to_config_keywords : true
    abio_dic_on :
       longname : Control whether abiotic carbon tracer module is active
       subcategory : 1. tracer modules
       units : unitless
       datatype : logical
-      default_value : .false.
+      default_value :
+         default : .false.
+         INCLUDE_ABIO_DIC : .true.
       _append_to_config_keywords : true
    ciso_on :
       longname : Control whether CISO tracer module is active

--- a/defaults/settings_latest+cocco.yaml
+++ b/defaults/settings_latest+cocco.yaml
@@ -257,7 +257,7 @@ tracer_modules :
       datatype : logical
       default_value :
          default : .true.
-         EXCLUDE_BASE_BIO : .false.
+         BASE_BIO_ON == FALSE : .false.
       _append_to_config_keywords : true
    abio_dic_on :
       longname : Control whether abiotic carbon tracer module is active
@@ -266,7 +266,7 @@ tracer_modules :
       datatype : logical
       default_value :
          default : .false.
-         INCLUDE_ABIO_DIC : .true.
+         ABIO_DIC_ON == TRUE : .true.
       _append_to_config_keywords : true
    ciso_on :
       longname : Control whether CISO tracer module is active

--- a/defaults/settings_latest.yaml
+++ b/defaults/settings_latest.yaml
@@ -255,14 +255,18 @@ tracer_modules :
       subcategory : 1. tracer modules
       units : unitless
       datatype : logical
-      default_value : .true.
+      default_value :
+         default : .true.
+         EXCLUDE_BASE_BIO : .false.
       _append_to_config_keywords : true
    abio_dic_on :
       longname : Control whether abiotic carbon tracer module is active
       subcategory : 1. tracer modules
       units : unitless
       datatype : logical
-      default_value : .false.
+      default_value :
+         default : .false.
+         INCLUDE_ABIO_DIC : .true.
       _append_to_config_keywords : true
    ciso_on :
       longname : Control whether CISO tracer module is active

--- a/defaults/settings_latest.yaml
+++ b/defaults/settings_latest.yaml
@@ -257,7 +257,7 @@ tracer_modules :
       datatype : logical
       default_value :
          default : .true.
-         EXCLUDE_BASE_BIO : .false.
+         BASE_BIO_ON == FALSE : .false.
       _append_to_config_keywords : true
    abio_dic_on :
       longname : Control whether abiotic carbon tracer module is active
@@ -266,7 +266,7 @@ tracer_modules :
       datatype : logical
       default_value :
          default : .false.
-         INCLUDE_ABIO_DIC : .true.
+         ABIO_DIC_ON == TRUE : .true.
       _append_to_config_keywords : true
    ciso_on :
       longname : Control whether CISO tracer module is active


### PR DESCRIPTION
Command line arguments for `MARBL_generate_settings_file.py` determine value of `base_bio_on` and `abio_dic_on`: by default, `base_bio_on=T` but running `--exclude-base-bio` sets it to F. Similarly, `abio_dic_on=F` but running `--include-abio-dic` sets it to T.