### PR TITLE
Add diag_mode to default diagnostics

### DIFF
--- a/MARBL_tools/MARBL_diagnostics_file_class.py
+++ b/MARBL_tools/MARBL_diagnostics_file_class.py
@@ -53,10 +53,11 @@ class MARBL_diagnostics_class(object):
                 diags_to_delete.append(diag_name)
                 continue
 
-            #    iii. frequency and operator should always be lists
+            #    iii. frequency, operator, and diag_mode should always be lists
             if not isinstance(self.diagnostics_dict[diag_name]['frequency'], list):
                 self.diagnostics_dict[diag_name]['frequency'] = [self.diagnostics_dict[diag_name]['frequency']]
                 self.diagnostics_dict[diag_name]['operator'] = [self.diagnostics_dict[diag_name]['operator']]
+                self.diagnostics_dict[diag_name]['diag_mode'] = [self.diagnostics_dict[diag_name]['diag_mode']]
 
             #    iv. update units
             fix_units = {}

--- a/MARBL_tools/MARBL_generate_diagnostics_file.py
+++ b/MARBL_tools/MARBL_generate_diagnostics_file.py
@@ -45,13 +45,13 @@ optional arguments:
   -a, --append          Append to existing diagnostics file (default: False)
 """
 
-import MARBL_utils
 #######################################
 
 def generate_diagnostics_file(MARBL_diagnostics, diagnostics_file_out, diag_mode="full", append=False):
     """ Produce a list of MARBL diagnostic frequencies and operators from a JSON parameter file
     """
 
+    from MARBL_tools import valid_diag_modes
     import logging
     logger = logging.getLogger(__name__)
 
@@ -85,7 +85,7 @@ def generate_diagnostics_file(MARBL_diagnostics, diagnostics_file_out, diag_mode
     # is also a dictionary containing frequency and operator information. Note that
     # string values of frequency and operator are converted to lists of len 1 when the
     # JSON file that generates this list is processed
-    diag_mode_opts = MARBL_utils.diag_mode_opts()
+    diag_mode_opts = valid_diag_modes()
     diag_mode_in = diag_mode_opts.index(diag_mode)
     for diag_name in sorted(MARBL_diagnostics.diagnostics_dict.keys()):
         frequencies = MARBL_diagnostics.diagnostics_dict[diag_name]['frequency']
@@ -107,6 +107,7 @@ def _parse_args(marbl_root):
     """
 
     import argparse
+    from MARBL_tools import valid_diag_modes
 
     parser = argparse.ArgumentParser(description="Generate a MARBL settings file from a JSON file",
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -144,7 +145,7 @@ def _parse_args(marbl_root):
 
     # Diagnostic mode (level of output to include)
     parser.add_argument('-m', '--diag-mode', action='store', dest='diag_mode', default='full',
-                        choices=MARBL_utils.diag_mode_opts(),
+                        choices=valid_diag_modes(),
                         help='Level of output to include')
 
     # Append to existing diagnostics file?

--- a/MARBL_tools/MARBL_generate_diagnostics_file.py
+++ b/MARBL_tools/MARBL_generate_diagnostics_file.py
@@ -95,7 +95,7 @@ def generate_diagnostics_file(MARBL_diagnostics, diagnostics_file_out, diag_mode
         for freq, op, dm in zip(frequencies, operators, diag_modes):
             if diag_mode_in >= diag_mode_opts.index(dm):
                 freq_op.append(freq + '_' + op)
-            else:
+            elif not freq_op: # Only append "never_{op}" if freq_op is empty list
                 freq_op.append('never_' + op)
         fout.write("%s : %s\n" % (diag_name, ", ".join(freq_op)))
     fout.close()

--- a/MARBL_tools/MARBL_generate_diagnostics_file.py
+++ b/MARBL_tools/MARBL_generate_diagnostics_file.py
@@ -45,14 +45,25 @@ optional arguments:
   -a, --append          Append to existing diagnostics file (default: False)
 """
 
+if __name__ == "__main__":
+    # We need marbl_root in python path so we can import MARBL_tools from generate_settings_file()
+    import argparse
+    import os
+    import sys
+    marbl_root = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), '..'))
+    sys.path.append(marbl_root)
+    from MARBL_tools import MARBL_settings_class
+    from MARBL_tools import MARBL_diagnostics_class
+
+import logging
+from MARBL_tools.MARBL_utils import valid_diag_modes
+
 #######################################
 
 def generate_diagnostics_file(MARBL_diagnostics, diagnostics_file_out, diag_mode="full", append=False):
     """ Produce a list of MARBL diagnostic frequencies and operators from a JSON parameter file
     """
 
-    from MARBL_tools import valid_diag_modes
-    import logging
     logger = logging.getLogger(__name__)
 
     if not append:
@@ -106,9 +117,6 @@ def _parse_args(marbl_root):
     """ Parse command line arguments
     """
 
-    import argparse
-    from MARBL_tools import valid_diag_modes
-
     parser = argparse.ArgumentParser(description="Generate a MARBL settings file from a JSON file",
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
@@ -157,8 +165,6 @@ def _parse_args(marbl_root):
 #######################################
 
 if __name__ == "__main__":
-    # We need marbl_root in python path so we can import MARBL_tools from generate_settings_file()
-    import sys, os
     marbl_root = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), '..'))
     sys.path.append(marbl_root)
 
@@ -166,11 +172,8 @@ if __name__ == "__main__":
     args = _parse_args(marbl_root)
 
     # Set up logging
-    import logging
     logging.basicConfig(format='%(levelname)s (%(funcName)s): %(message)s', level=logging.DEBUG)
 
-    from MARBL_tools import MARBL_settings_class
-    from MARBL_tools import MARBL_diagnostics_class
     DefaultSettings = MARBL_settings_class(args.default_settings_file,
                                            args.saved_state_vars_source,
                                            grid=args.grid,

--- a/MARBL_tools/MARBL_utils.py
+++ b/MARBL_tools/MARBL_utils.py
@@ -8,7 +8,7 @@
 #                            PUBLIC MODULE METHODS                             #
 ################################################################################
 
-def diag_mode_opts():
+def valid_diag_modes():
     """ Return ordered list of the valid values for diag_mode.
         (Ordered list => selecting diag mode includes variables)
     """
@@ -98,7 +98,7 @@ def diagnostics_dictionary_is_consistent(DiagsDict):
            ii.  If they are all lists, must be same length
         5. Allowable frequencies are never, low, medium, and high
         6. Allowable operators are instantaneous, average, minimum, and maximum
-        7. Allowable diag_modes are defined in diag_mode_opts()
+        7. Allowable diag_modes are defined in valid_diag_modes()
     """
 
     import logging
@@ -157,11 +157,11 @@ def diagnostics_dictionary_is_consistent(DiagsDict):
 
         # 5. Allowable frequencies are never, low, medium, and high
         # 6. Allowable operators are instantaneous, average, minimum, and maximum
-        # 7. Allowable diag_modes are defined in diag_mode_opts()
+        # 7. Allowable diag_modes are defined in valid_diag_modes()
         #    * "none" should not appear in the dictionary
         ok_freqs = ['never', 'low', 'medium', 'high']
         ok_ops = ['instantaneous', 'average', 'minimum', 'maximum']
-        ok_dms = diag_mode_opts()[1:] # do not include 'none' in ok_dms
+        ok_dms = valid_diag_modes()[1:] # do not include 'none' in ok_dms
         invalid_freq_op_dm = False
         if not isinstance(diag_dict['frequency'], dict):
             if isinstance(diag_dict['frequency'], list):

--- a/MARBL_tools/MARBL_utils.py
+++ b/MARBL_tools/MARBL_utils.py
@@ -9,8 +9,10 @@
 ################################################################################
 
 def valid_diag_modes():
-    """ Return ordered list of the valid values for diag_mode.
-        (Ordered list => selecting diag mode includes variables)
+    """ Return list of the valid values for diag_mode.
+        Order of list => selecting specific diag mode includes all
+        diagnostics with lower index as well (e.g. "diag_mode = full"
+        will also provide diagnostics defined with minimal diag mode)
     """
     return ['none', 'minimal', 'full']
 

--- a/MARBL_tools/MARBL_utils.py
+++ b/MARBL_tools/MARBL_utils.py
@@ -8,6 +8,14 @@
 #                            PUBLIC MODULE METHODS                             #
 ################################################################################
 
+def diag_mode_opts():
+    """ Return ordered list of the valid values for diag_mode.
+        (Ordered list => selecting diag mode includes variables)
+    """
+    return ['none', 'minimal', 'full']
+
+################################################################################
+
 def settings_dictionary_is_consistent(SettingsDict):
     """ Make sure dictionary generated from JSON settings file conforms to MARBL
         parameter file standards:
@@ -82,13 +90,15 @@ def diagnostics_dictionary_is_consistent(DiagsDict):
            iii. vertical_grid (2D vars should explicitly list "none")
            iv.  frequency
            v.   operator
+           vi.  diag_mode
         3. Diagnostic variable dictionaries may contain 'dependencies' key as well,
            but it must be a dictionary itself.
-        4. Consistency between frequency and operator
-           i.   frequency and operator are both lists, or neither are
-           ii.  If they are both lists, must be same size
+        4. Consistency among frequency, operator, and diag_mode
+           i.   frequency, operator, and diag_mode are all lists, or none are
+           ii.  If they are all lists, must be same length
         5. Allowable frequencies are never, low, medium, and high
         6. Allowable operators are instantaneous, average, minimum, and maximum
+        7. Allowable diag_modes are defined in diag_mode_opts()
     """
 
     import logging
@@ -109,8 +119,8 @@ def diagnostics_dictionary_is_consistent(DiagsDict):
             continue
 
         # 2. diag_dict must have the following keys:
-        valid_keys = ["longname", "units", "vertical_grid", "frequency", "operator"]
-        for key_check in valid_keys:
+        required_keys = ["longname", "units", "vertical_grid", "frequency", "operator", "diag_mode"]
+        for key_check in required_keys:
             if key_check not in diag_dict.keys():
                 message = "Diagnostic %s is not well-defined in YAML" % diag_name
                 message = message + "\n     * Expecting %s as a key" % key_check
@@ -124,11 +134,13 @@ def diagnostics_dictionary_is_consistent(DiagsDict):
                 logger.error(message)
                 invalid_file = True
 
-        # 4. Consistency between frequency and operator
+        # 4. Consistency among frequency, operator, diag_mode
         err_prefix = "Inconsistency in DiagsDict['%s']:" % diag_name
         #    i.   frequency and operator are both lists, or neither are
-        if isinstance(diag_dict['frequency'], list) != isinstance(diag_dict['operator'], list):
-            logger.error("%s either both frequency and operator must be lists or neither can be" % err_prefix)
+        if (isinstance(diag_dict['frequency'], list) != isinstance(diag_dict['operator'], list)) or \
+           (isinstance(diag_dict['frequency'], list) != isinstance(diag_dict['diag_mode'], list)):
+            err_message = "either all of frequency, operator, and diag_mode must be lists or neither can be"
+            logger.error(f"{err_prefix} {err_message}")
             invalid_file = True
             continue
 
@@ -136,36 +148,53 @@ def diagnostics_dictionary_is_consistent(DiagsDict):
         if isinstance(diag_dict['frequency'], list):
             freq_len = len(diag_dict['frequency'])
             op_len = len(diag_dict['operator'])
-            if freq_len != op_len:
-                logger.error("%s frequency is length %d but operator is length %d" %
-                             (err_prefix, diag_name, freq_len, op_len))
+            dm_len = len(diag_dict['diag_mode'])
+            if (freq_len != op_len) or (freq_len != op_len):
+                err_message = f"frequency, operator, diag_mode lengths are {freq_len}, {op_len}, {diag_mode}"
+                logger.error(f"{err_prefix} {err_message}")
                 invalid_file = True
                 continue
 
         # 5. Allowable frequencies are never, low, medium, and high
         # 6. Allowable operators are instantaneous, average, minimum, and maximum
+        # 7. Allowable diag_modes are defined in diag_mode_opts()
+        #    * "none" should not appear in the dictionary
         ok_freqs = ['never', 'low', 'medium', 'high']
         ok_ops = ['instantaneous', 'average', 'minimum', 'maximum']
-        invalid_freq_op = False
+        ok_dms = diag_mode_opts()[1:] # do not include 'none' in ok_dms
+        invalid_freq_op_dm = False
         if not isinstance(diag_dict['frequency'], dict):
             if isinstance(diag_dict['frequency'], list):
-                for freq, op in zip(diag_dict['frequency'], diag_dict['operator']):
+                for freq, op, dm in zip(diag_dict['frequency'], diag_dict['operator'], diag_dict['diag_mode']):
                     if freq not in ok_freqs:
-                        logger.error("%s '%s' is not a valid frequency" % (err_prefix, freq))
-                        invalid_freq_op = True
+                        err_message = f"'{freq}' is not a valid frequency"
+                        logger.error(f'{err_prefix} {err_message}')
+                        invalid_freq_op_dm = True
                     if op not in ok_ops:
-                        logger.error("%s '%s' is not a valid operator" % (err_prefix, op))
-                        invalid_freq_op = True
+                        err_message = f"'{op}' is not a valid operator"
+                        logger.error(f'{err_prefix} {err_message}')
+                        invalid_freq_op_dm = True
+                    if dm not in ok_dms:
+                        err_message = f"'{dm}' is not a valid diag_mode"
+                        logger.error(f'{err_prefix} {err_message}')
+                        invalid_freq_op_dm = True
             else:
                 freq = diag_dict['frequency']
                 op = diag_dict['operator']
+                dm = diag_dict['diag_mode']
                 if freq not in ok_freqs:
-                    logger.error("%s '%s' is not a valid frequency" % (err_prefix, freq))
-                    invalid_freq_op = True
+                    err_message = f"'{freq}' is not a valid frequency"
+                    logger.error(f'{err_prefix} {err_message}')
+                    invalid_freq_op_dm = True
                 if op not in ok_ops:
-                    logger.error("%s '%s' is not a valid operator" % (err_prefix, op))
-                    invalid_freq_op = True
-        if invalid_freq_op:
+                    err_message = f"'{op}' is not a valid operator"
+                    logger.error(f'{err_prefix} {err_message}')
+                    invalid_freq_op_dm = True
+                if dm not in ok_dms:
+                    err_message = f"'{dm}' is not a valid diag_mode"
+                    logger.error(f'{err_prefix} {err_message}')
+                    invalid_freq_op_dm = True
+        if invalid_freq_op_dm:
             invalid_file = True
 
     return (not invalid_file)

--- a/MARBL_tools/__init__.py
+++ b/MARBL_tools/__init__.py
@@ -4,6 +4,7 @@ from .MARBL_generate_diagnostics_file import generate_diagnostics_file
 from .MARBL_diagnostics_file_class import MARBL_diagnostics_class
 from .MARBL_utils import settings_dictionary_is_consistent
 from .MARBL_utils import diagnostics_dictionary_is_consistent
+from .MARBL_utils import valid_diag_modes
 from .MARBL_share import abort
 from .MARBL_share import LogFormatter
 from .MARBL_share import sort

--- a/MARBL_tools/__init__.py
+++ b/MARBL_tools/__init__.py
@@ -4,7 +4,6 @@ from .MARBL_generate_diagnostics_file import generate_diagnostics_file
 from .MARBL_diagnostics_file_class import MARBL_diagnostics_class
 from .MARBL_utils import settings_dictionary_is_consistent
 from .MARBL_utils import diagnostics_dictionary_is_consistent
-from .MARBL_utils import valid_diag_modes
 from .MARBL_share import abort
 from .MARBL_share import LogFormatter
 from .MARBL_share import sort

--- a/MARBL_tools/run_test_suite.sh
+++ b/MARBL_tools/run_test_suite.sh
@@ -85,6 +85,12 @@ done
 
 # Test MARBL_generate_diagnostics_file.py
 cd ${MARBL_ROOT}/MARBL_tools
+(set -x ; ./MARBL_generate_diagnostics_file.py --diag-mode none -o marbl.diags.none)
+STATUS=$(check_return $?)
+print_status "MARBL_generate_diagnostics_file.py --diag-mode none -o marbl.diags.none" >> ${RESULTS_CACHE}
+(set -x ; ./MARBL_generate_diagnostics_file.py --diag-mode minimal -o marbl.diags.minimal)
+STATUS=$(check_return $?)
+print_status "MARBL_generate_diagnostics_file.py --diag-mode minimal marbl.diags.minimal" >> ${RESULTS_CACHE}
 (set -x ; ./MARBL_generate_diagnostics_file.py)
 STATUS=$(check_return $?)
 print_status "MARBL_generate_diagnostics_file.py" >> ${RESULTS_CACHE}

--- a/defaults/diagnostics_latest.yaml
+++ b/defaults/diagnostics_latest.yaml
@@ -35,6 +35,9 @@ ECOSYS_IFRAC :
    operator :
       - average
       - average
+   diag_mode :
+      - minimal
+      - full
 ECOSYS_XKW :
    dependencies :
       lflux_gas_o2 : .true.
@@ -49,6 +52,9 @@ ECOSYS_XKW :
    operator :
       - average
       - average
+   diag_mode :
+      - full
+      - full
 ECOSYS_ATM_PRESS :
    dependencies :
       lflux_gas_o2 : .true.
@@ -59,6 +65,7 @@ ECOSYS_ATM_PRESS :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 PV_CO2 :
    dependencies :
       lflux_gas_co2 : .true.
@@ -67,6 +74,7 @@ PV_CO2 :
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 SCHMIDT_CO2 :
    dependencies :
       lflux_gas_co2 : .true.
@@ -75,6 +83,7 @@ SCHMIDT_CO2 :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 
 ###############
 # Base module #
@@ -88,6 +97,7 @@ PV_O2 :
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 SCHMIDT_O2 :
    dependencies :
       base_bio_on : .true.
@@ -96,6 +106,7 @@ SCHMIDT_O2 :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 O2SAT :
    dependencies :
       base_bio_on : .true.
@@ -104,6 +115,7 @@ O2SAT :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 CO2STAR : &CO2STAR
    dependencies :
       base_bio_on : .true.
@@ -112,6 +124,7 @@ CO2STAR : &CO2STAR
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 CO2STAR_ALT_CO2 :
    << : *CO2STAR
    longname : CO2 Star, Alternative CO2
@@ -123,6 +136,7 @@ DCO2STAR : &DCO2STAR
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 DCO2STAR_ALT_CO2 :
    << : *DCO2STAR
    longname : D CO2 Star, Alternative CO2
@@ -134,11 +148,13 @@ pCO2SURF : &pCO2SURF
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : minimal
 pCO2SURF_ALT_CO2 :
    << : *pCO2SURF
    longname : surface pCO2, Alternative CO2
    frequency : never
    operator : average
+   diag_mode : full
 DpCO2 : &DpCO2
    dependencies :
       base_bio_on : .true.
@@ -151,11 +167,15 @@ DpCO2 : &DpCO2
    operator :
       - average
       - average
+   diag_mode :
+      - minimal
+      - full
 DpCO2_ALT_CO2 :
    << : *DpCO2
    longname : D pCO2, Alternative CO2
    frequency : medium
    operator : average
+   diag_mode : full
 FG_CO2 : &FG_CO2 # rename ind%DIC_GAS_FLUX -> ind%FG_CO2
    dependencies :
       base_bio_on : .true.
@@ -168,11 +188,15 @@ FG_CO2 : &FG_CO2 # rename ind%DIC_GAS_FLUX -> ind%FG_CO2
    operator :
       - average
       - average
+   diag_mode :
+      - minimal
+      - full
 FG_ALT_CO2 : # rename ind%DIC_GAS_FLUX_ALT_CO2 -> ind%FG_ALT_CO2
    << : *FG_CO2
    longname : DIC Surface Gas Flux, Alternative CO2
    frequency : medium
    operator : average
+   diag_mode : full
 PH : &PH
    dependencies :
       base_bio_on : .true.
@@ -181,6 +205,7 @@ PH : &PH
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 PH_ALT_CO2 :
    << : *PH
    longname : Surface pH, Alternative CO2
@@ -192,6 +217,7 @@ ATM_CO2 : &ATM_CO2
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 ATM_ALT_CO2 :
    << : *ATM_CO2
    longname : Atmospheric Alternative CO2
@@ -203,6 +229,7 @@ IRON_FLUX :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : minimal
 DUST_FLUX :
    dependencies :
       base_bio_on : .true.
@@ -211,6 +238,7 @@ DUST_FLUX :
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : minimal
 NOx_FLUX :
    dependencies :
       base_bio_on : .true.
@@ -219,6 +247,7 @@ NOx_FLUX :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : minimal
 NHy_FLUX :
    dependencies :
       base_bio_on : .true.
@@ -227,6 +256,7 @@ NHy_FLUX :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : minimal
 NHx_SURFACE_EMIS :
    dependencies :
       base_bio_on : .true.
@@ -235,6 +265,7 @@ NHx_SURFACE_EMIS :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : minimal
 
 ###############
 # abio module #
@@ -249,6 +280,7 @@ ABIO_pCO2 :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 ABIO_D14C_atm :
    dependencies :
       abio_dic_on : .true.
@@ -258,6 +290,7 @@ ABIO_D14C_atm :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 ABIO_CO2STAR :
    dependencies :
       abio_dic_on : .true.
@@ -267,6 +300,7 @@ ABIO_CO2STAR :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 ABIO_DCO2STAR :
    dependencies :
       abio_dic_on : .true.
@@ -276,6 +310,7 @@ ABIO_DCO2STAR :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 ABIO_pCO2SURF :
    dependencies :
       abio_dic_on : .true.
@@ -285,6 +320,7 @@ ABIO_pCO2SURF :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 ABIO_DpCO2 :
    dependencies :
       abio_dic_on : .true.
@@ -294,6 +330,7 @@ ABIO_DpCO2 :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 ABIO_PH :
    dependencies :
       abio_dic_on : .true.
@@ -303,6 +340,7 @@ ABIO_PH :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 ABIO_ALK_SURF :
    dependencies :
       abio_dic_on : .true.
@@ -312,6 +350,7 @@ ABIO_ALK_SURF :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 ABIO_FG_DIC :
    dependencies :
       abio_dic_on : .true.
@@ -321,6 +360,7 @@ ABIO_FG_DIC :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 ABIO_FG_DI14C :
    dependencies :
       abio_dic_on : .true.
@@ -330,6 +370,7 @@ ABIO_FG_DI14C :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 d_SF_ABIO_DIC_d_ABIO_DIC :
    dependencies :
       abio_dic_on : .true.
@@ -340,6 +381,7 @@ d_SF_ABIO_DIC_d_ABIO_DIC :
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 d_SF_ABIO_DI14C_d_ABIO_DIC :
    dependencies :
       abio_dic_on : .true.
@@ -350,6 +392,7 @@ d_SF_ABIO_DI14C_d_ABIO_DIC :
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 d_SF_ABIO_DI14C_d_ABIO_DI14C :
    dependencies :
       abio_dic_on : .true.
@@ -360,6 +403,7 @@ d_SF_ABIO_DI14C_d_ABIO_DI14C :
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 
 ###############
 # ciso module #
@@ -373,6 +417,7 @@ CISO_FG_13CO2 :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_FG_as_13CO2 :
    dependencies :
       ciso_on : .true.
@@ -381,6 +426,7 @@ CISO_FG_as_13CO2 :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_FG_sa_13CO2 :
    dependencies :
       ciso_on : .true.
@@ -389,6 +435,7 @@ CISO_FG_sa_13CO2 :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_FG_d13C :
    dependencies :
       ciso_on : .true.
@@ -397,6 +444,7 @@ CISO_FG_d13C :
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 CISO_D13C_atm :
    dependencies :
       ciso_on : .true.
@@ -405,6 +453,7 @@ CISO_D13C_atm :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_R13C_DIC_surf :
    dependencies :
       ciso_on : .true.
@@ -413,6 +462,7 @@ CISO_R13C_DIC_surf :
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 CISO_R13C_atm :
    dependencies :
       ciso_on : .true.
@@ -421,6 +471,7 @@ CISO_R13C_atm :
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 CISO_eps_aq_g_surf :
    dependencies :
       ciso_on : .true.
@@ -429,6 +480,7 @@ CISO_eps_aq_g_surf :
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 CISO_eps_dic_g_surf :
    dependencies :
       ciso_on : .true.
@@ -437,6 +489,7 @@ CISO_eps_dic_g_surf :
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 CISO_FG_14CO2 :
    dependencies :
       ciso_on : .true.
@@ -445,6 +498,7 @@ CISO_FG_14CO2 :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_FG_as_14CO2 :
    dependencies :
       ciso_on : .true.
@@ -453,6 +507,7 @@ CISO_FG_as_14CO2 :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_FG_sa_14CO2 :
    dependencies :
       ciso_on : .true.
@@ -461,6 +516,7 @@ CISO_FG_sa_14CO2 :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_FG_d14C :
    dependencies :
       ciso_on : .true.
@@ -469,6 +525,7 @@ CISO_FG_d14C :
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 CISO_D14C_atm :
    dependencies :
       ciso_on : .true.
@@ -477,6 +534,7 @@ CISO_D14C_atm :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_R14C_DIC_surf :
    dependencies :
       ciso_on : .true.
@@ -485,6 +543,7 @@ CISO_R14C_DIC_surf :
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 CISO_R14C_atm :
    dependencies :
       ciso_on : .true.
@@ -493,6 +552,7 @@ CISO_R14C_atm :
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 
 ################################################################################
 #                         Interior forcing diagnostics                         #
@@ -510,6 +570,7 @@ zsatcalc :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 zsatarag :
    dependencies :
       base_bio_on : .true.
@@ -518,6 +579,7 @@ zsatarag :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 O2_ZMIN :
    dependencies :
       base_bio_on : .true.
@@ -526,6 +588,7 @@ O2_ZMIN :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : minimal
 O2_ZMIN_DEPTH :
    dependencies :
       base_bio_on : .true.
@@ -534,6 +597,7 @@ O2_ZMIN_DEPTH :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : minimal
 photoC_TOT_zint :
    dependencies :
       base_bio_on : .true.
@@ -542,6 +606,7 @@ photoC_TOT_zint :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : minimal
 photoC_TOT_zint_100m :
    dependencies :
       base_bio_on : .true.
@@ -550,6 +615,7 @@ photoC_TOT_zint_100m :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : minimal
 photoC_NO3_TOT_zint :
    dependencies :
       base_bio_on : .true.
@@ -558,6 +624,7 @@ photoC_NO3_TOT_zint :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 photoC_NO3_TOT_zint_100m :
    dependencies :
       base_bio_on : .true.
@@ -566,6 +633,7 @@ photoC_NO3_TOT_zint_100m :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 DOC_prod_zint :
    dependencies :
       base_bio_on : .true.
@@ -574,6 +642,7 @@ DOC_prod_zint :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 DOC_prod_zint_100m :
    dependencies :
       base_bio_on : .true.
@@ -582,6 +651,7 @@ DOC_prod_zint_100m :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 DOC_remin_zint :
    dependencies :
       base_bio_on : .true.
@@ -590,6 +660,7 @@ DOC_remin_zint :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 DOC_remin_zint_100m :
    dependencies :
       base_bio_on : .true.
@@ -598,6 +669,7 @@ DOC_remin_zint_100m :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 DOCr_remin_zint :
    dependencies :
       base_bio_on : .true.
@@ -606,6 +678,7 @@ DOCr_remin_zint :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 DOCr_remin_zint_100m :
    dependencies :
       base_bio_on : .true.
@@ -614,6 +687,7 @@ DOCr_remin_zint_100m :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 Jint_Ctot :
    dependencies :
       base_bio_on : .true.
@@ -622,6 +696,7 @@ Jint_Ctot :
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 Jint_Ntot :
    dependencies :
       base_bio_on : .true.
@@ -630,6 +705,7 @@ Jint_Ntot :
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 Jint_Ptot :
    dependencies :
       base_bio_on : .true.
@@ -638,6 +714,7 @@ Jint_Ptot :
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 Jint_Sitot :
    dependencies :
       base_bio_on : .true.
@@ -646,6 +723,7 @@ Jint_Sitot :
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 Jint_Fetot :
    dependencies :
       base_bio_on : .true.
@@ -654,6 +732,7 @@ Jint_Fetot :
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 
 # Particulate 2D diags
 calcToFloor :
@@ -664,6 +743,7 @@ calcToFloor :
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 calcToSed :
    dependencies :
       base_bio_on : .true.
@@ -672,6 +752,7 @@ calcToSed :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : minimal
 calcToSed_ALT_CO2 :
    dependencies :
       base_bio_on : .true.
@@ -680,6 +761,7 @@ calcToSed_ALT_CO2 :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 pocToFloor :
    dependencies :
       base_bio_on : .true.
@@ -692,6 +774,9 @@ pocToFloor :
    operator :
       - average
       - average
+   diag_mode :
+      - full
+      - full
 pocToSed :
    dependencies :
       base_bio_on : .true.
@@ -700,6 +785,7 @@ pocToSed :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : minimal
 ponToSed :
    dependencies :
       base_bio_on : .true.
@@ -708,6 +794,7 @@ ponToSed :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 SedDenitrif :
    dependencies :
       base_bio_on : .true.
@@ -716,6 +803,7 @@ SedDenitrif :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 OtherRemin :
    dependencies :
       base_bio_on : .true.
@@ -724,6 +812,7 @@ OtherRemin :
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 popToSed :
    dependencies :
       base_bio_on : .true.
@@ -732,6 +821,7 @@ popToSed :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 bsiToSed :
    dependencies :
       base_bio_on : .true.
@@ -740,6 +830,7 @@ bsiToSed :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : minimal
 dustToSed :
    dependencies :
       base_bio_on : .true.
@@ -748,6 +839,7 @@ dustToSed :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 pfeToSed :
    dependencies :
       base_bio_on : .true.
@@ -756,6 +848,7 @@ pfeToSed :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 CaCO3_form_zint :
    dependencies :
       base_bio_on : .true.
@@ -768,6 +861,9 @@ CaCO3_form_zint :
    operator :
       - average
       - average
+   diag_mode :
+      - full
+      - full
 CaCO3_form_zint_100m :
    dependencies :
       base_bio_on : .true.
@@ -776,6 +872,7 @@ CaCO3_form_zint_100m :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 
 # General 3D diags
 insitu_temp :
@@ -786,6 +883,7 @@ insitu_temp :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 CO3 :
    dependencies :
       base_bio_on : .true.
@@ -794,6 +892,7 @@ CO3 :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 HCO3 :
    dependencies :
       base_bio_on : .true.
@@ -802,6 +901,7 @@ HCO3 :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 H2CO3 :
    dependencies :
       base_bio_on : .true.
@@ -810,6 +910,7 @@ H2CO3 :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 pH_3D :
    dependencies :
       base_bio_on : .true.
@@ -818,6 +919,7 @@ pH_3D :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 CO3_ALT_CO2 :
    dependencies :
       base_bio_on : .true.
@@ -826,6 +928,7 @@ CO3_ALT_CO2 :
    vertical_grid : layer_avg
    frequency : never
    operator : average
+   diag_mode : full
 HCO3_ALT_CO2 :
    dependencies :
       base_bio_on : .true.
@@ -834,6 +937,7 @@ HCO3_ALT_CO2 :
    vertical_grid : layer_avg
    frequency : never
    operator : average
+   diag_mode : full
 H2CO3_ALT_CO2 :
    dependencies :
       base_bio_on : .true.
@@ -842,6 +946,7 @@ H2CO3_ALT_CO2 :
    vertical_grid : layer_avg
    frequency : never
    operator : average
+   diag_mode : full
 pH_3D_ALT_CO2 :
    dependencies :
       base_bio_on : .true.
@@ -850,6 +955,7 @@ pH_3D_ALT_CO2 :
    vertical_grid : layer_avg
    frequency : never
    operator : average
+   diag_mode : full
 co3_sat_calc :
    dependencies :
       base_bio_on : .true.
@@ -858,6 +964,7 @@ co3_sat_calc :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 co3_sat_arag :
    dependencies :
       base_bio_on : .true.
@@ -866,6 +973,7 @@ co3_sat_arag :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 NITRIF :
    dependencies :
       base_bio_on : .true.
@@ -874,6 +982,7 @@ NITRIF :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 DENITRIF :
    dependencies :
       base_bio_on : .true.
@@ -882,6 +991,7 @@ DENITRIF :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : minimal
 O2_PRODUCTION :
    dependencies :
       base_bio_on : .true.
@@ -890,6 +1000,7 @@ O2_PRODUCTION :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 O2_CONSUMPTION_SCALEF :
    dependencies :
       base_bio_on : .true.
@@ -899,6 +1010,7 @@ O2_CONSUMPTION_SCALEF :
    vertical_grid : layer_avg
    frequency : never
    operator : average
+   diag_mode : full
 O2_CONSUMPTION :
    dependencies :
       base_bio_on : .true.
@@ -907,6 +1019,7 @@ O2_CONSUMPTION :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 AOU :
    dependencies :
       base_bio_on : .true.
@@ -915,6 +1028,7 @@ AOU :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 PAR_avg :
    dependencies :
       base_bio_on : .true.
@@ -923,6 +1037,7 @@ PAR_avg :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 graze_auto_TOT :
    dependencies :
       base_bio_on : .true.
@@ -931,6 +1046,7 @@ graze_auto_TOT :
    vertical_grid : layer_avg
    frequency : low
    operator : average
+   diag_mode : full
 photoC_TOT :
    dependencies :
       base_bio_on : .true.
@@ -939,6 +1055,7 @@ photoC_TOT :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 photoC_NO3_TOT :
    dependencies :
       base_bio_on : .true.
@@ -947,6 +1064,7 @@ photoC_NO3_TOT :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 DOC_prod :
    dependencies :
       base_bio_on : .true.
@@ -955,6 +1073,7 @@ DOC_prod :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 DOC_remin :
    dependencies :
       base_bio_on : .true.
@@ -963,6 +1082,7 @@ DOC_remin :
    vertical_grid : layer_avg
    frequency : low
    operator : average
+   diag_mode : full
 DOCr_remin :
    dependencies :
       base_bio_on : .true.
@@ -971,6 +1091,7 @@ DOCr_remin :
    vertical_grid : layer_avg
    frequency : low
    operator : average
+   diag_mode : full
 DON_prod :
    dependencies :
       base_bio_on : .true.
@@ -979,6 +1100,7 @@ DON_prod :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 DON_remin :
    dependencies :
       base_bio_on : .true.
@@ -987,6 +1109,7 @@ DON_remin :
    vertical_grid : layer_avg
    frequency : low
    operator : average
+   diag_mode : full
 DONr_remin :
    dependencies :
       base_bio_on : .true.
@@ -995,6 +1118,7 @@ DONr_remin :
    vertical_grid : layer_avg
    frequency : low
    operator : average
+   diag_mode : full
 DOP_prod :
    dependencies :
       base_bio_on : .true.
@@ -1003,6 +1127,7 @@ DOP_prod :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 DOP_remin :
    dependencies :
       base_bio_on : .true.
@@ -1011,6 +1136,7 @@ DOP_remin :
    vertical_grid : layer_avg
    frequency : low
    operator : average
+   diag_mode : full
 DOPr_remin :
    dependencies :
       base_bio_on : .true.
@@ -1019,6 +1145,7 @@ DOPr_remin :
    vertical_grid : layer_avg
    frequency : low
    operator : average
+   diag_mode : full
 DOP_loss_P_bal :
    dependencies :
       base_bio_on : .true.
@@ -1027,6 +1154,7 @@ DOP_loss_P_bal :
    vertical_grid : layer_avg
    frequency : never
    operator : average
+   diag_mode : full
 Fe_scavenge :
    dependencies :
       base_bio_on : .true.
@@ -1035,6 +1163,7 @@ Fe_scavenge :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 Fe_scavenge_rate :
    dependencies :
       base_bio_on : .true.
@@ -1043,6 +1172,7 @@ Fe_scavenge_rate :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 Lig_prod :
    dependencies :
       base_bio_on : .true.
@@ -1051,6 +1181,7 @@ Lig_prod :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 Lig_loss :
    dependencies :
       base_bio_on : .true.
@@ -1059,6 +1190,7 @@ Lig_loss :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 Lig_scavenge :
    dependencies :
       base_bio_on : .true.
@@ -1067,6 +1199,7 @@ Lig_scavenge :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 Fefree :
    dependencies :
       base_bio_on : .true.
@@ -1075,6 +1208,7 @@ Fefree :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 Lig_photochem :
    dependencies :
       base_bio_on : .true.
@@ -1083,6 +1217,7 @@ Lig_photochem :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 Lig_deg :
    dependencies :
       base_bio_on : .true.
@@ -1091,6 +1226,7 @@ Lig_deg :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 FESEDFLUX :
    dependencies :
       base_bio_on : .true.
@@ -1099,6 +1235,7 @@ FESEDFLUX :
    vertical_grid : layer_avg
    frequency : never
    operator : average
+   diag_mode : full
 
 # Particulate 2D diags
 POC_FLUX_((particulate_flux_ref_depth_str)) :
@@ -1109,6 +1246,7 @@ POC_FLUX_((particulate_flux_ref_depth_str)) :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : minimal
 POP_FLUX_((particulate_flux_ref_depth_str)) :
    dependencies :
       base_bio_on : .true.
@@ -1117,6 +1255,7 @@ POP_FLUX_((particulate_flux_ref_depth_str)) :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 CaCO3_FLUX_((particulate_flux_ref_depth_str)) :
    dependencies :
       base_bio_on : .true.
@@ -1125,6 +1264,7 @@ CaCO3_FLUX_((particulate_flux_ref_depth_str)) :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : minimal
 SiO2_FLUX_((particulate_flux_ref_depth_str)) :
    dependencies :
       base_bio_on : .true.
@@ -1133,6 +1273,7 @@ SiO2_FLUX_((particulate_flux_ref_depth_str)) :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : minimal
 P_iron_FLUX_((particulate_flux_ref_depth_str)) :
    dependencies :
       base_bio_on : .true.
@@ -1141,6 +1282,7 @@ P_iron_FLUX_((particulate_flux_ref_depth_str)) :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : minimal
 POC_PROD_zint :
    dependencies :
       base_bio_on : .true.
@@ -1149,6 +1291,7 @@ POC_PROD_zint :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : minimal
 POC_PROD_zint_100m :
    dependencies :
       base_bio_on : .true.
@@ -1157,6 +1300,7 @@ POC_PROD_zint_100m :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 POC_REMIN_DOCr_zint :
    dependencies :
       base_bio_on : .true.
@@ -1165,6 +1309,7 @@ POC_REMIN_DOCr_zint :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 POC_REMIN_DOCr_zint_100m :
    dependencies :
       base_bio_on : .true.
@@ -1173,6 +1318,7 @@ POC_REMIN_DOCr_zint_100m :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 POC_REMIN_DIC_zint :
    dependencies :
       base_bio_on : .true.
@@ -1181,6 +1327,7 @@ POC_REMIN_DIC_zint :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 POC_REMIN_DIC_zint_100m :
    dependencies :
       base_bio_on : .true.
@@ -1189,6 +1336,7 @@ POC_REMIN_DIC_zint_100m :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 CaCO3_PROD_zint :
    dependencies :
       base_bio_on : .true.
@@ -1197,6 +1345,7 @@ CaCO3_PROD_zint :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : minimal
 CaCO3_PROD_zint_100m :
    dependencies :
       base_bio_on : .true.
@@ -1205,6 +1354,7 @@ CaCO3_PROD_zint_100m :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 CaCO3_REMIN_zint :
    dependencies :
       base_bio_on : .true.
@@ -1213,6 +1363,7 @@ CaCO3_REMIN_zint :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 CaCO3_REMIN_zint_100m :
    dependencies :
       base_bio_on : .true.
@@ -1221,6 +1372,7 @@ CaCO3_REMIN_zint_100m :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 
 # Particulate 3D diags
 P_REMIN_SCALEF :
@@ -1232,6 +1384,7 @@ P_REMIN_SCALEF :
    vertical_grid : layer_avg
    frequency : never
    operator : average
+   diag_mode : full
 POC_FLUX_IN :
    dependencies :
       base_bio_on : .true.
@@ -1240,6 +1393,7 @@ POC_FLUX_IN :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 POC_sFLUX_IN :
    dependencies :
       base_bio_on : .true.
@@ -1248,6 +1402,7 @@ POC_sFLUX_IN :
    vertical_grid : layer_avg
    frequency : never
    operator : average
+   diag_mode : full
 POC_hFLUX_IN :
    dependencies :
       base_bio_on : .true.
@@ -1256,6 +1411,7 @@ POC_hFLUX_IN :
    vertical_grid : layer_avg
    frequency : never
    operator : average
+   diag_mode : full
 POC_PROD :
    dependencies :
       base_bio_on : .true.
@@ -1264,6 +1420,7 @@ POC_PROD :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 POC_REMIN_DOCr :
    dependencies :
       base_bio_on : .true.
@@ -1272,6 +1429,7 @@ POC_REMIN_DOCr :
    vertical_grid : layer_avg
    frequency : low
    operator : average
+   diag_mode : full
 POC_REMIN_DIC :
    dependencies :
       base_bio_on : .true.
@@ -1280,6 +1438,7 @@ POC_REMIN_DIC :
    vertical_grid : layer_avg
    frequency : low
    operator : average
+   diag_mode : full
 POP_FLUX_IN :
    dependencies :
       base_bio_on : .true.
@@ -1288,6 +1447,7 @@ POP_FLUX_IN :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 POP_PROD :
    dependencies :
       base_bio_on : .true.
@@ -1296,6 +1456,7 @@ POP_PROD :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 POP_REMIN_DOPr :
    dependencies :
       base_bio_on : .true.
@@ -1304,6 +1465,7 @@ POP_REMIN_DOPr :
    vertical_grid : layer_avg
    frequency : low
    operator : average
+   diag_mode : full
 POP_REMIN_PO4 :
    dependencies :
       base_bio_on : .true.
@@ -1312,6 +1474,7 @@ POP_REMIN_PO4 :
    vertical_grid : layer_avg
    frequency : low
    operator : average
+   diag_mode : full
 PON_REMIN_DONr :
    dependencies :
       base_bio_on : .true.
@@ -1320,6 +1483,7 @@ PON_REMIN_DONr :
    vertical_grid : layer_avg
    frequency : low
    operator : average
+   diag_mode : full
 PON_REMIN_NH4 :
    dependencies :
       base_bio_on : .true.
@@ -1328,6 +1492,7 @@ PON_REMIN_NH4 :
    vertical_grid : layer_avg
    frequency : low
    operator : average
+   diag_mode : full
 CaCO3_FLUX_IN :
    dependencies :
       base_bio_on : .true.
@@ -1336,6 +1501,7 @@ CaCO3_FLUX_IN :
    vertical_grid : layer_avg
    frequency : low
    operator : average
+   diag_mode : full
 CaCO3_PROD :
    dependencies :
       base_bio_on : .true.
@@ -1344,6 +1510,7 @@ CaCO3_PROD :
    vertical_grid : layer_avg
    frequency : low
    operator : average
+   diag_mode : full
 CaCO3_REMIN :
    dependencies :
       base_bio_on : .true.
@@ -1352,6 +1519,7 @@ CaCO3_REMIN :
    vertical_grid : layer_avg
    frequency : low
    operator : average
+   diag_mode : full
 CaCO3_ALT_CO2_FLUX_IN :
    dependencies :
       base_bio_on : .true.
@@ -1360,6 +1528,7 @@ CaCO3_ALT_CO2_FLUX_IN :
    vertical_grid : layer_avg
    frequency : low
    operator : average
+   diag_mode : full
 CaCO3_ALT_CO2_PROD :
    dependencies :
       base_bio_on : .true.
@@ -1368,6 +1537,7 @@ CaCO3_ALT_CO2_PROD :
    vertical_grid : layer_avg
    frequency : never
    operator : average
+   diag_mode : full
 CaCO3_ALT_CO2_REMIN :
    dependencies :
       base_bio_on : .true.
@@ -1376,6 +1546,7 @@ CaCO3_ALT_CO2_REMIN :
    vertical_grid : layer_avg
    frequency : low
    operator : average
+   diag_mode : full
 SiO2_FLUX_IN :
    dependencies :
       base_bio_on : .true.
@@ -1384,6 +1555,7 @@ SiO2_FLUX_IN :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 SiO2_PROD :
    dependencies :
       base_bio_on : .true.
@@ -1392,6 +1564,7 @@ SiO2_PROD :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : minimal
 SiO2_REMIN :
    dependencies :
       base_bio_on : .true.
@@ -1400,6 +1573,7 @@ SiO2_REMIN :
    vertical_grid : layer_avg
    frequency : never
    operator : average
+   diag_mode : full
 dust_FLUX_IN :
    dependencies :
       base_bio_on : .true.
@@ -1408,6 +1582,7 @@ dust_FLUX_IN :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 dust_REMIN :
    dependencies :
       base_bio_on : .true.
@@ -1416,6 +1591,7 @@ dust_REMIN :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 P_iron_FLUX_IN :
    dependencies :
       base_bio_on : .true.
@@ -1424,6 +1600,7 @@ P_iron_FLUX_IN :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 P_iron_PROD :
    dependencies :
       base_bio_on : .true.
@@ -1432,6 +1609,7 @@ P_iron_PROD :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 P_iron_REMIN :
    dependencies :
       base_bio_on : .true.
@@ -1440,6 +1618,7 @@ P_iron_REMIN :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 bSi_form :
    dependencies :
       base_bio_on : .true.
@@ -1448,6 +1627,7 @@ bSi_form :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 CaCO3_form :
    dependencies :
       base_bio_on : .true.
@@ -1456,6 +1636,7 @@ CaCO3_form :
    vertical_grid : layer_avg
    frequency : low
    operator : average
+   diag_mode : full
 Nfix :
    dependencies :
       base_bio_on : .true.
@@ -1464,6 +1645,7 @@ Nfix :
    vertical_grid : layer_avg
    frequency : never
    operator : average
+   diag_mode : minimal
 
 ###############
 # abio module #
@@ -1477,6 +1659,7 @@ ABIO_D14C_ocn :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : minimal
 
 ###############
 # ciso module #
@@ -1491,6 +1674,7 @@ CISO_photo13C_TOT_zint :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_photo14C_TOT_zint :
    dependencies :
       ciso_on : .true.
@@ -1499,6 +1683,7 @@ CISO_photo14C_TOT_zint :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_Jint_13Ctot :
    dependencies :
       ciso_on : .true.
@@ -1507,6 +1692,7 @@ CISO_Jint_13Ctot :
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 CISO_Jint_14Ctot :
    dependencies :
       ciso_on : .true.
@@ -1515,6 +1701,7 @@ CISO_Jint_14Ctot :
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 calcToSed_13C :
    dependencies :
       ciso_on : .true.
@@ -1523,6 +1710,7 @@ calcToSed_13C :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 pocToSed_13C :
    dependencies :
       ciso_on : .true.
@@ -1531,6 +1719,7 @@ pocToSed_13C :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 calcToSed_14C :
    dependencies :
       ciso_on : .true.
@@ -1539,6 +1728,7 @@ calcToSed_14C :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 pocToSed_14C :
    dependencies :
       ciso_on : .true.
@@ -1547,6 +1737,7 @@ pocToSed_14C :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 
 # 3D fields
 CISO_PO13C_FLUX_IN :
@@ -1557,6 +1748,7 @@ CISO_PO13C_FLUX_IN :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_PO13C_PROD :
    dependencies :
       ciso_on : .true.
@@ -1565,6 +1757,7 @@ CISO_PO13C_PROD :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_PO13C_REMIN :
    dependencies :
       ciso_on : .true.
@@ -1573,6 +1766,7 @@ CISO_PO13C_REMIN :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_DO13Ctot_prod :
    dependencies :
       ciso_on : .true.
@@ -1581,6 +1775,7 @@ CISO_DO13Ctot_prod :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_DO13Ctot_remin :
    dependencies :
       ciso_on : .true.
@@ -1589,6 +1784,7 @@ CISO_DO13Ctot_remin :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_Ca13CO3_FLUX_IN :
    dependencies :
       ciso_on : .true.
@@ -1597,6 +1793,7 @@ CISO_Ca13CO3_FLUX_IN :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_Ca13CO3_PROD :
    dependencies :
       ciso_on : .true.
@@ -1605,6 +1802,7 @@ CISO_Ca13CO3_PROD :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_Ca13CO3_REMIN :
    dependencies :
       ciso_on : .true.
@@ -1613,6 +1811,7 @@ CISO_Ca13CO3_REMIN :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_photo13C_TOT :
    dependencies :
       ciso_on : .true.
@@ -1621,6 +1820,7 @@ CISO_photo13C_TOT :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_DIC_d13C :
    dependencies :
       ciso_on : .true.
@@ -1629,6 +1829,7 @@ CISO_DIC_d13C :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_DOCtot_d13C :
    dependencies :
       ciso_on : .true.
@@ -1637,6 +1838,7 @@ CISO_DOCtot_d13C :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_zoototC_d13C :
    dependencies :
       ciso_on : .true.
@@ -1645,6 +1847,7 @@ CISO_zoototC_d13C :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_PO14C_FLUX_IN :
    dependencies :
       ciso_on : .true.
@@ -1653,6 +1856,7 @@ CISO_PO14C_FLUX_IN :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_PO14C_PROD :
    dependencies :
       ciso_on : .true.
@@ -1661,6 +1865,7 @@ CISO_PO14C_PROD :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_PO14C_REMIN :
    dependencies :
       ciso_on : .true.
@@ -1669,6 +1874,7 @@ CISO_PO14C_REMIN :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_DO14Ctot_prod :
    dependencies :
       ciso_on : .true.
@@ -1677,6 +1883,7 @@ CISO_DO14Ctot_prod :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_DO14Ctot_remin :
    dependencies :
       ciso_on : .true.
@@ -1685,6 +1892,7 @@ CISO_DO14Ctot_remin :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_Ca14CO3_FLUX_IN :
    dependencies :
       ciso_on : .true.
@@ -1693,6 +1901,7 @@ CISO_Ca14CO3_FLUX_IN :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_Ca14CO3_PROD :
    dependencies :
       ciso_on : .true.
@@ -1701,6 +1910,7 @@ CISO_Ca14CO3_PROD :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_Ca14CO3_REMIN :
    dependencies :
       ciso_on : .true.
@@ -1709,6 +1919,7 @@ CISO_Ca14CO3_REMIN :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_photo14C_TOT :
    dependencies :
       ciso_on : .true.
@@ -1717,6 +1928,7 @@ CISO_photo14C_TOT :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_DIC_d14C :
    dependencies :
       ciso_on : .true.
@@ -1725,6 +1937,7 @@ CISO_DIC_d14C :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_DOCtot_d14C :
    dependencies :
       ciso_on : .true.
@@ -1733,6 +1946,7 @@ CISO_DOCtot_d14C :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_zoototC_d14C :
    dependencies :
       ciso_on : .true.
@@ -1741,6 +1955,7 @@ CISO_zoototC_d14C :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_eps_aq_g :
    dependencies :
       ciso_on : .true.
@@ -1749,6 +1964,7 @@ CISO_eps_aq_g :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_eps_dic_g :
    dependencies :
       ciso_on : .true.
@@ -1757,6 +1973,7 @@ CISO_eps_dic_g :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 
 ##########################
 # Per-tracer Diagnostics #
@@ -1770,6 +1987,7 @@ CISO_eps_dic_g :
       default : never
       ((restore_this_tracer)) : medium
    operator : average
+   diag_mode : full
 
 #############################
 # Per-autotroph Diagnostics #
@@ -1783,6 +2001,7 @@ CISO_eps_dic_g :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : minimal
 ((autotroph_sname))_C_lim_Cweight_avg_100m :
    dependencies :
       ((autotroph_is_carbon_limited)) : true
@@ -1791,6 +2010,7 @@ CISO_eps_dic_g :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : minimal
 ((autotroph_sname))_N_lim_surf :
    longname : ((autotroph_lname)) N Limitation, Surface
    units : 1
@@ -1799,6 +2019,7 @@ CISO_eps_dic_g :
       default : medium
       ((autotroph_Nfixer)) : never
    operator : average
+   diag_mode : minimal
 ((autotroph_sname))_N_lim_Cweight_avg_100m :
    longname : ((autotroph_lname)) N Limitation, carbon biomass weighted average over 0-100m
    units : 1
@@ -1807,30 +2028,35 @@ CISO_eps_dic_g :
       default : medium
       ((autotroph_Nfixer)) : never
    operator : average
+   diag_mode : minimal
 ((autotroph_sname))_P_lim_surf :
    longname : ((autotroph_lname)) P Limitation, Surface
    units : 1
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : minimal
 ((autotroph_sname))_P_lim_Cweight_avg_100m :
    longname : ((autotroph_lname)) P Limitation, carbon biomass weighted average over 0-100m
    units : 1
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : minimal
 ((autotroph_sname))_Fe_lim_surf :
    longname : ((autotroph_lname)) Fe Limitation, Surface
    units : 1
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : minimal
 ((autotroph_sname))_Fe_lim_Cweight_avg_100m :
    longname : ((autotroph_lname)) Fe Limitation, carbon biomass weighted average over 0-100m
    units : 1
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : minimal
 ((autotroph_sname))_SiO3_lim_surf :
    dependencies :
       ((autotroph_silicifier)) : true
@@ -1839,6 +2065,7 @@ CISO_eps_dic_g :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : minimal
 ((autotroph_sname))_SiO3_lim_Cweight_avg_100m :
    dependencies :
       ((autotroph_silicifier)) : true
@@ -1847,18 +2074,21 @@ CISO_eps_dic_g :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : minimal
 ((autotroph_sname))_light_lim_surf :
    longname : ((autotroph_lname)) Light Limitation, Surface
    units : 1
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 ((autotroph_sname))_light_lim_Cweight_avg_100m :
    longname : ((autotroph_lname)) Light Limitation, carbon biomass weighted average over 0-100m
    units : 1
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : minimal
 photoC_((autotroph_sname))_zint :
    longname : ((autotroph_lname)) C Fixation Vertical Integral
    units : mmol/m^3 cm/s
@@ -1869,114 +2099,135 @@ photoC_((autotroph_sname))_zint :
    operator :
       - average
       - average
+   diag_mode :
+      - minimal
+      - full
 photoC_((autotroph_sname))_zint_100m :
    longname : ((autotroph_lname)) C Fixation Vertical Integral, 0-100m
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 photoC_NO3_((autotroph_sname))_zint :
    longname : ((autotroph_lname)) C Fixation from NO3 Vertical Integral
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 graze_((autotroph_sname))_zint :
    longname : ((autotroph_lname)) Grazing Vertical Integral
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 graze_((autotroph_sname))_zint_100m :
    longname : ((autotroph_lname)) Grazing Vertical Integral, 0-100m
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 graze_((autotroph_sname))_poc_zint :
    longname : ((autotroph_lname)) Grazing to POC Vertical Integral
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 graze_((autotroph_sname))_poc_zint_100m :
    longname : ((autotroph_lname)) Grazing to POC Vertical Integral, 0-100m
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 graze_((autotroph_sname))_doc_zint :
    longname : ((autotroph_lname)) Grazing to DOC Vertical Integral
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 graze_((autotroph_sname))_doc_zint_100m :
    longname : ((autotroph_lname)) Grazing to DOC Vertical Integral, 0-100m
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 graze_((autotroph_sname))_((zooplankton_sname))_zint :
    longname : ((autotroph_lname)) Grazing to ((zooplankton_lname)) Vertical Integral
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 graze_((autotroph_sname))_((zooplankton_sname))_zint_100m :
    longname : ((autotroph_lname)) Grazing to ((zooplankton_lname)) Vertical Integral, 0-100m
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 ((autotroph_sname))_loss_zint :
    longname : ((autotroph_lname)) Loss Vertical Integral
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 ((autotroph_sname))_loss_zint_100m :
    longname : ((autotroph_lname)) Loss Vertical Integral, 0-100m
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 ((autotroph_sname))_loss_poc_zint :
    longname : ((autotroph_lname)) Loss to POC Vertical Integral
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 ((autotroph_sname))_loss_poc_zint_100m :
    longname : ((autotroph_lname)) Loss to POC Vertical Integral, 0-100m
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 ((autotroph_sname))_loss_doc_zint :
    longname : ((autotroph_lname)) Loss to DOC Vertical Integral
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 ((autotroph_sname))_loss_doc_zint_100m :
    longname : ((autotroph_lname)) Loss to DOC Vertical Integral, 0-100m
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 ((autotroph_sname))_agg_zint :
    longname : ((autotroph_lname)) Aggregation Vertical Integral
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 ((autotroph_sname))_agg_zint_100m :
    longname : ((autotroph_lname)) Aggregation Vertical Integral, 0-100m
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 ((autotroph_sname))_CaCO3_form_zint :
    dependencies :
       ((autotroph_calcifier)) : true
@@ -1985,6 +2236,7 @@ graze_((autotroph_sname))_((zooplankton_sname))_zint_100m :
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 ((autotroph_sname))_CaCO3_form_zint_100m :
    dependencies :
       ((autotroph_calcifier)) : true
@@ -1993,6 +2245,7 @@ graze_((autotroph_sname))_((zooplankton_sname))_zint_100m :
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 ((autotroph_sname))_Qp :
    dependencies: # NOTE: POP treats this as a dependency, though MARBL defines
                  #       these diagnostics independent of lvariable_PtoC; my
@@ -2005,6 +2258,7 @@ graze_((autotroph_sname))_((zooplankton_sname))_zint_100m :
    truncate : true
    frequency : medium
    operator : average
+   diag_mode : full
 photoC_((autotroph_sname)) :
    longname : ((autotroph_lname)) C Fixation
    units : mmol/m^3/s
@@ -2012,6 +2266,7 @@ photoC_((autotroph_sname)) :
    truncate : true
    frequency : never
    operator : average
+   diag_mode : full
 photoC_NO3_((autotroph_sname)) :
    longname : ((autotroph_lname)) C Fixation from NO3
    units : mmol/m^3/s
@@ -2019,6 +2274,7 @@ photoC_NO3_((autotroph_sname)) :
    truncate : true
    frequency : never
    operator : average
+   diag_mode : full
 photoFe_((autotroph_sname)) :
    longname : ((autotroph_lname)) Fe Uptake
    units : mmol/m^3/s
@@ -2026,6 +2282,7 @@ photoFe_((autotroph_sname)) :
    truncate : true
    frequency : medium
    operator : average
+   diag_mode : full
 photoNO3_((autotroph_sname)) :
    longname : ((autotroph_lname)) NO3 Uptake
    units : mmol/m^3/s
@@ -2033,6 +2290,7 @@ photoNO3_((autotroph_sname)) :
    truncate : true
    frequency : medium
    operator : average
+   diag_mode : full
 photoNH4_((autotroph_sname)) :
    longname : ((autotroph_lname)) NH4 Uptake
    units : mmol/m^3/s
@@ -2040,6 +2298,7 @@ photoNH4_((autotroph_sname)) :
    truncate : true
    frequency : medium
    operator : average
+   diag_mode : full
 DOP_((autotroph_sname))_uptake :
    longname : ((autotroph_lname)) DOP Uptake
    units : mmol/m^3/s
@@ -2047,6 +2306,7 @@ DOP_((autotroph_sname))_uptake :
    truncate : true
    frequency : medium
    operator : average
+   diag_mode : full
 PO4_((autotroph_sname))_uptake :
    longname : ((autotroph_lname)) PO4 Uptake
    units : mmol/m^3/s
@@ -2054,6 +2314,7 @@ PO4_((autotroph_sname))_uptake :
    truncate : true
    frequency : medium
    operator : average
+   diag_mode : full
 graze_((autotroph_sname)) :
    longname : ((autotroph_lname)) Grazing
    units : mmol/m^3/s
@@ -2061,6 +2322,7 @@ graze_((autotroph_sname)) :
    truncate : true
    frequency : never
    operator : average
+   diag_mode : full
 graze_((autotroph_sname))_poc :
    longname : ((autotroph_lname)) Grazing to POC
    units : mmol/m^3/s
@@ -2068,6 +2330,7 @@ graze_((autotroph_sname))_poc :
    truncate : true
    frequency : never
    operator : average
+   diag_mode : full
 graze_((autotroph_sname))_doc :
    longname : ((autotroph_lname)) Grazing to DOC
    units : mmol/m^3/s
@@ -2075,6 +2338,7 @@ graze_((autotroph_sname))_doc :
    truncate : true
    frequency : never
    operator : average
+   diag_mode : full
 graze_((autotroph_sname))_zootot :
    longname : ((autotroph_lname)) Grazing to ZOO TOT
    units : mmol/m^3/s
@@ -2082,6 +2346,7 @@ graze_((autotroph_sname))_zootot :
    truncate : true
    frequency : medium
    operator : average
+   diag_mode : full
 graze_((autotroph_sname))_((zooplankton_sname)) :
    longname : ((autotroph_lname)) Grazing to ((zooplankton_lname))
    units : mmol/m^3/s
@@ -2089,6 +2354,7 @@ graze_((autotroph_sname))_((zooplankton_sname)) :
    truncate : true
    frequency : medium
    operator : average
+   diag_mode : full
 ((autotroph_sname))_loss :
    longname : ((autotroph_lname)) Loss
    units : mmol/m^3/s
@@ -2096,6 +2362,7 @@ graze_((autotroph_sname))_((zooplankton_sname)) :
    truncate : true
    frequency : never
    operator : average
+   diag_mode : full
 ((autotroph_sname))_loss_poc :
    longname : ((autotroph_lname)) Loss to POC
    units : mmol/m^3/s
@@ -2103,6 +2370,7 @@ graze_((autotroph_sname))_((zooplankton_sname)) :
    truncate : true
    frequency : never
    operator : average
+   diag_mode : full
 ((autotroph_sname))_loss_doc :
    longname : ((autotroph_lname)) Loss to DOC
    units : mmol/m^3/s
@@ -2110,6 +2378,7 @@ graze_((autotroph_sname))_((zooplankton_sname)) :
    truncate : true
    frequency : never
    operator : average
+   diag_mode : full
 ((autotroph_sname))_agg :
    longname : ((autotroph_lname)) Aggregation
    units : mmol/m^3/s
@@ -2117,6 +2386,7 @@ graze_((autotroph_sname))_((zooplankton_sname)) :
    truncate : true
    frequency : medium
    operator : average
+   diag_mode : full
 ((autotroph_sname))_bSi_form :
    dependencies :
       ((autotroph_silicifier)) : true
@@ -2126,6 +2396,7 @@ graze_((autotroph_sname))_((zooplankton_sname)) :
    truncate : true
    frequency : never
    operator : average
+   diag_mode : full
 ((autotroph_sname))_CaCO3_form :
    dependencies :
       ((autotroph_calcifier)) : true
@@ -2135,6 +2406,7 @@ graze_((autotroph_sname))_((zooplankton_sname)) :
    truncate : true
    frequency : never
    operator : average
+   diag_mode : full
 ((autotroph_sname))_Nfix :
    dependencies :
       ((autotroph_Nfixer)) : true
@@ -2144,6 +2416,7 @@ graze_((autotroph_sname))_((zooplankton_sname)) :
    truncate : true
    frequency : medium
    operator : average
+   diag_mode : minimal
 
 # ciso module
 CISO_((autotroph_sname))_Ca13CO3_form :
@@ -2156,6 +2429,7 @@ CISO_((autotroph_sname))_Ca13CO3_form :
    truncate : true
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_((autotroph_sname))_Ca13CO3_form_zint :
    dependencies :
       ciso_on : .true.
@@ -2165,6 +2439,7 @@ CISO_((autotroph_sname))_Ca13CO3_form_zint :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_((autotroph_sname))_Ca14CO3_form :
    dependencies :
       ciso_on : .true.
@@ -2175,6 +2450,7 @@ CISO_((autotroph_sname))_Ca14CO3_form :
    truncate : true
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_((autotroph_sname))_Ca14CO3_form_zint :
    dependencies :
       ciso_on : .true.
@@ -2184,6 +2460,7 @@ CISO_((autotroph_sname))_Ca14CO3_form_zint :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_autotrophCaCO3_d13C_((autotroph_sname)) :
    dependencies :
       ciso_on : .true.
@@ -2193,6 +2470,7 @@ CISO_autotrophCaCO3_d13C_((autotroph_sname)) :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_autotrophCaCO3_d14C_((autotroph_sname)) :
    dependencies :
       ciso_on : .true.
@@ -2202,6 +2480,7 @@ CISO_autotrophCaCO3_d14C_((autotroph_sname)) :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_photo13C_((autotroph_sname)) :
    dependencies :
       ciso_on : .true.
@@ -2211,6 +2490,7 @@ CISO_photo13C_((autotroph_sname)) :
    truncate : true
    frequency : never
    operator : average
+   diag_mode : full
 CISO_photo14C_((autotroph_sname)) :
    dependencies :
       ciso_on : .true.
@@ -2220,6 +2500,7 @@ CISO_photo14C_((autotroph_sname)) :
    truncate : true
    frequency : never
    operator : average
+   diag_mode : full
 CISO_photo13C_((autotroph_sname))_zint :
    dependencies :
       ciso_on : .true.
@@ -2228,6 +2509,7 @@ CISO_photo13C_((autotroph_sname))_zint :
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 CISO_photo14C_((autotroph_sname))_zint :
    dependencies :
       ciso_on : .true.
@@ -2236,6 +2518,7 @@ CISO_photo14C_((autotroph_sname))_zint :
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 CISO_eps_autotroph_((autotroph_sname)) :
    dependencies :
       ciso_on : .true.
@@ -2244,6 +2527,7 @@ CISO_eps_autotroph_((autotroph_sname)) :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_d13C_((autotroph_sname)) :
    dependencies :
       ciso_on : .true.
@@ -2252,6 +2536,7 @@ CISO_d13C_((autotroph_sname)) :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_d14C_((autotroph_sname)) :
    dependencies :
       ciso_on : .true.
@@ -2260,6 +2545,7 @@ CISO_d14C_((autotroph_sname)) :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 CISO_mui_to_co2star_((autotroph_sname)) :
    dependencies :
       ciso_on : .true.
@@ -2268,6 +2554,7 @@ CISO_mui_to_co2star_((autotroph_sname)) :
    vertical_grid : layer_avg
    frequency : medium
    operator : average
+   diag_mode : full
 
 
 ###############################
@@ -2280,114 +2567,133 @@ CISO_mui_to_co2star_((autotroph_sname)) :
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 ((zooplankton_sname))_loss_zint_100m :
    longname : ((zooplankton_lname)) Loss Vertical Integral, 0-100m
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 ((zooplankton_sname))_loss_zint_150m :
    longname : ((zooplankton_lname)) Loss Vertical Integral, 0-150m
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : high
    operator : average
+   diag_mode : full
 ((zooplankton_sname))_loss_basal_zint :
    longname : ((zooplankton_lname)) Basal Respiration Vertical Integral
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 ((zooplankton_sname))_loss_basal_zint_100m :
    longname : ((zooplankton_lname)) Basal Respiration Vertical Integral, 0-100m
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 ((zooplankton_sname))_loss_poc_zint :
    longname : ((zooplankton_lname)) Loss to POC Vertical Integral
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 ((zooplankton_sname))_loss_poc_zint_100m :
    longname : ((zooplankton_lname)) Loss to POC Vertical Integral, 0-100m
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 ((zooplankton_sname))_loss_doc_zint :
    longname : ((zooplankton_lname)) Loss to DOC Vertical Integral
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 ((zooplankton_sname))_loss_doc_zint_100m :
    longname : ((zooplankton_lname)) Loss to DOC Vertical Integral, 0-100m
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 graze_((zooplankton_sname))_zint :
    longname : ((zooplankton_lname)) Grazing Vertical Integral
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 graze_((zooplankton_sname))_zint_100m :
    longname : ((zooplankton_lname)) Grazing Vertical Integral, 0-100m
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 graze_((zooplankton_sname))_poc_zint :
    longname : ((zooplankton_lname)) Grazing to POC Vertical Integral
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 graze_((zooplankton_sname))_poc_zint_100m :
    longname : ((zooplankton_lname)) Grazing to POC Vertical Integral, 0-100m
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 graze_((zooplankton_sname))_doc_zint :
    longname : ((zooplankton_lname)) Grazing to DOC Vertical Integral
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 graze_((zooplankton_sname))_doc_zint_100m :
    longname : ((zooplankton_lname)) Grazing to DOC Vertical Integral, 0-100m
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 graze_((zooplankton_sname))_((zooplankton_sname))_zint :
    longname : ((zooplankton_lname1)) Grazing to ((zooplankton_lname2)) Vertical Integral
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 graze_((zooplankton_sname))_((zooplankton_sname))_zint_100m :
    longname : ((zooplankton_lname1)) Grazing to ((zooplankton_lname2)) Vertical Integral, 0-100m
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : never
    operator : average
+   diag_mode : full
 x_graze_((zooplankton_sname))_zint :
    longname : ((zooplankton_lname)) Grazing Gain Vertical Integral
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : minimal
 x_graze_((zooplankton_sname))_zint_100m :
    longname : ((zooplankton_lname)) Grazing Gain Vertical Integral, 0-100m
    units : mmol/m^3 cm/s
    vertical_grid : none
    frequency : medium
    operator : average
+   diag_mode : full
 ((zooplankton_sname))_loss :
    longname : ((zooplankton_lname)) Loss
    units : mmol/m^3/s
@@ -2395,6 +2701,7 @@ x_graze_((zooplankton_sname))_zint_100m :
    truncate : true
    frequency : never
    operator : average
+   diag_mode : full
 ((zooplankton_sname))_loss_basal :
    longname : ((zooplankton_lname)) Basal Respiration
    units : mmol/m^3/s
@@ -2402,6 +2709,7 @@ x_graze_((zooplankton_sname))_zint_100m :
    truncate : true
    frequency : never
    operator : average
+   diag_mode : full
 ((zooplankton_sname))_loss_poc :
    longname : ((zooplankton_lname)) Loss to POC
    units : mmol/m^3/s
@@ -2409,6 +2717,7 @@ x_graze_((zooplankton_sname))_zint_100m :
    truncate : true
    frequency : never
    operator : average
+   diag_mode : full
 ((zooplankton_sname))_loss_doc :
    longname : ((zooplankton_lname)) Loss to DOC
    units : mmol/m^3/s
@@ -2416,6 +2725,7 @@ x_graze_((zooplankton_sname))_zint_100m :
    truncate : true
    frequency : never
    operator : average
+   diag_mode : full
 graze_((zooplankton_sname)) :
    longname : ((zooplankton_lname)) grazing loss
    units : mmol/m^3/s
@@ -2423,6 +2733,7 @@ graze_((zooplankton_sname)) :
    truncate : true
    frequency : never
    operator : average
+   diag_mode : full
 graze_((zooplankton_sname))_poc :
    longname : ((zooplankton_lname)) grazing loss to POC
    units : mmol/m^3/s
@@ -2430,6 +2741,7 @@ graze_((zooplankton_sname))_poc :
    truncate : true
    frequency : never
    operator : average
+   diag_mode : full
 graze_((zooplankton_sname))_doc :
    longname : ((zooplankton_lname)) grazing loss to DOC
    units : mmol/m^3/s
@@ -2437,6 +2749,7 @@ graze_((zooplankton_sname))_doc :
    truncate : true
    frequency : never
    operator : average
+   diag_mode : full
 graze_((zooplankton_sname))_zootot :
    longname : ((zooplankton_lname)) grazing loss to ZOO TOT
    units : mmol/m^3/s
@@ -2444,6 +2757,7 @@ graze_((zooplankton_sname))_zootot :
    truncate : true
    frequency : never
    operator : average
+   diag_mode : full
 graze_((zooplankton_sname))_((zooplankton_sname)) :
    longname : ((zooplankton_lname1)) grazing loss to ((zooplankton_lname2))
    units : mmol/m^3/s
@@ -2451,6 +2765,7 @@ graze_((zooplankton_sname))_((zooplankton_sname)) :
    truncate : true
    frequency : never
    operator : average
+   diag_mode : full
 x_graze_((zooplankton_sname)) :
    longname : ((zooplankton_lname)) grazing gain
    units : mmol/m^3/s
@@ -2458,3 +2773,4 @@ x_graze_((zooplankton_sname)) :
    truncate : true
    frequency : never
    operator : average
+   diag_mode : full

--- a/defaults/json/diagnostics_latest.json
+++ b/defaults/json/diagnostics_latest.json
@@ -3,6 +3,7 @@
       "dependencies": {
          "((autotroph_is_carbon_limited))": true
       },
+      "diag_mode": "minimal",
       "frequency": "medium",
       "longname": "((autotroph_lname)) C Limitation, carbon biomass weighted average over 0-100m",
       "operator": "average",
@@ -13,6 +14,7 @@
       "dependencies": {
          "((autotroph_is_carbon_limited))": true
       },
+      "diag_mode": "minimal",
       "frequency": "medium",
       "longname": "((autotroph_lname)) C Limitation, Surface",
       "operator": "average",
@@ -23,6 +25,7 @@
       "dependencies": {
          "((autotroph_calcifier))": true
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((autotroph_lname)) CaCO3 Formation",
       "operator": "average",
@@ -34,6 +37,7 @@
       "dependencies": {
          "((autotroph_calcifier))": true
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((autotroph_lname)) CaCO3 Formation Vertical Integral",
       "operator": "average",
@@ -44,6 +48,7 @@
       "dependencies": {
          "((autotroph_calcifier))": true
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((autotroph_lname)) CaCO3 Formation Vertical Integral, 0-100m",
       "operator": "average",
@@ -51,6 +56,7 @@
       "vertical_grid": "none"
    },
    "((autotroph_sname))_Fe_lim_Cweight_avg_100m": {
+      "diag_mode": "minimal",
       "frequency": "medium",
       "longname": "((autotroph_lname)) Fe Limitation, carbon biomass weighted average over 0-100m",
       "operator": "average",
@@ -58,6 +64,7 @@
       "vertical_grid": "none"
    },
    "((autotroph_sname))_Fe_lim_surf": {
+      "diag_mode": "minimal",
       "frequency": "medium",
       "longname": "((autotroph_lname)) Fe Limitation, Surface",
       "operator": "average",
@@ -65,6 +72,7 @@
       "vertical_grid": "none"
    },
    "((autotroph_sname))_N_lim_Cweight_avg_100m": {
+      "diag_mode": "minimal",
       "frequency": {
          "((autotroph_Nfixer))": "never",
          "default": "medium"
@@ -75,6 +83,7 @@
       "vertical_grid": "none"
    },
    "((autotroph_sname))_N_lim_surf": {
+      "diag_mode": "minimal",
       "frequency": {
          "((autotroph_Nfixer))": "never",
          "default": "medium"
@@ -88,6 +97,7 @@
       "dependencies": {
          "((autotroph_Nfixer))": true
       },
+      "diag_mode": "minimal",
       "frequency": "medium",
       "longname": "((autotroph_lname)) N Fixation",
       "operator": "average",
@@ -96,6 +106,7 @@
       "vertical_grid": "layer_avg"
    },
    "((autotroph_sname))_P_lim_Cweight_avg_100m": {
+      "diag_mode": "minimal",
       "frequency": "medium",
       "longname": "((autotroph_lname)) P Limitation, carbon biomass weighted average over 0-100m",
       "operator": "average",
@@ -103,6 +114,7 @@
       "vertical_grid": "none"
    },
    "((autotroph_sname))_P_lim_surf": {
+      "diag_mode": "minimal",
       "frequency": "medium",
       "longname": "((autotroph_lname)) P Limitation, Surface",
       "operator": "average",
@@ -113,6 +125,7 @@
       "dependencies": {
          "lvariable_PtoC": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((autotroph_lname)) P:C ratio",
       "operator": "average",
@@ -124,6 +137,7 @@
       "dependencies": {
          "((autotroph_silicifier))": true
       },
+      "diag_mode": "minimal",
       "frequency": "medium",
       "longname": "((autotroph_lname)) SiO3 Limitation, carbon biomass weighted average over 0-100m",
       "operator": "average",
@@ -134,6 +148,7 @@
       "dependencies": {
          "((autotroph_silicifier))": true
       },
+      "diag_mode": "minimal",
       "frequency": "medium",
       "longname": "((autotroph_lname)) SiO3 Limitation, Surface",
       "operator": "average",
@@ -141,6 +156,7 @@
       "vertical_grid": "none"
    },
    "((autotroph_sname))_agg": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((autotroph_lname)) Aggregation",
       "operator": "average",
@@ -149,6 +165,7 @@
       "vertical_grid": "layer_avg"
    },
    "((autotroph_sname))_agg_zint": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((autotroph_lname)) Aggregation Vertical Integral",
       "operator": "average",
@@ -156,6 +173,7 @@
       "vertical_grid": "none"
    },
    "((autotroph_sname))_agg_zint_100m": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((autotroph_lname)) Aggregation Vertical Integral, 0-100m",
       "operator": "average",
@@ -166,6 +184,7 @@
       "dependencies": {
          "((autotroph_silicifier))": true
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((autotroph_lname)) Si Uptake",
       "operator": "average",
@@ -174,6 +193,7 @@
       "vertical_grid": "layer_avg"
    },
    "((autotroph_sname))_light_lim_Cweight_avg_100m": {
+      "diag_mode": "minimal",
       "frequency": "medium",
       "longname": "((autotroph_lname)) Light Limitation, carbon biomass weighted average over 0-100m",
       "operator": "average",
@@ -181,6 +201,7 @@
       "vertical_grid": "none"
    },
    "((autotroph_sname))_light_lim_surf": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((autotroph_lname)) Light Limitation, Surface",
       "operator": "average",
@@ -188,6 +209,7 @@
       "vertical_grid": "none"
    },
    "((autotroph_sname))_loss": {
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((autotroph_lname)) Loss",
       "operator": "average",
@@ -196,6 +218,7 @@
       "vertical_grid": "layer_avg"
    },
    "((autotroph_sname))_loss_doc": {
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((autotroph_lname)) Loss to DOC",
       "operator": "average",
@@ -204,6 +227,7 @@
       "vertical_grid": "layer_avg"
    },
    "((autotroph_sname))_loss_doc_zint": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((autotroph_lname)) Loss to DOC Vertical Integral",
       "operator": "average",
@@ -211,6 +235,7 @@
       "vertical_grid": "none"
    },
    "((autotroph_sname))_loss_doc_zint_100m": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((autotroph_lname)) Loss to DOC Vertical Integral, 0-100m",
       "operator": "average",
@@ -218,6 +243,7 @@
       "vertical_grid": "none"
    },
    "((autotroph_sname))_loss_poc": {
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((autotroph_lname)) Loss to POC",
       "operator": "average",
@@ -226,6 +252,7 @@
       "vertical_grid": "layer_avg"
    },
    "((autotroph_sname))_loss_poc_zint": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((autotroph_lname)) Loss to POC Vertical Integral",
       "operator": "average",
@@ -233,6 +260,7 @@
       "vertical_grid": "none"
    },
    "((autotroph_sname))_loss_poc_zint_100m": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((autotroph_lname)) Loss to POC Vertical Integral, 0-100m",
       "operator": "average",
@@ -240,6 +268,7 @@
       "vertical_grid": "none"
    },
    "((autotroph_sname))_loss_zint": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((autotroph_lname)) Loss Vertical Integral",
       "operator": "average",
@@ -247,6 +276,7 @@
       "vertical_grid": "none"
    },
    "((autotroph_sname))_loss_zint_100m": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((autotroph_lname)) Loss Vertical Integral, 0-100m",
       "operator": "average",
@@ -254,6 +284,7 @@
       "vertical_grid": "none"
    },
    "((tracer_short_name))_RESTORE_TEND": {
+      "diag_mode": "full",
       "frequency": {
          "((restore_this_tracer))": "medium",
          "default": "never"
@@ -264,6 +295,7 @@
       "vertical_grid": "layer_avg"
    },
    "((zooplankton_sname))_loss": {
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((zooplankton_lname)) Loss",
       "operator": "average",
@@ -272,6 +304,7 @@
       "vertical_grid": "layer_avg"
    },
    "((zooplankton_sname))_loss_basal": {
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((zooplankton_lname)) Basal Respiration",
       "operator": "average",
@@ -280,6 +313,7 @@
       "vertical_grid": "layer_avg"
    },
    "((zooplankton_sname))_loss_basal_zint": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((zooplankton_lname)) Basal Respiration Vertical Integral",
       "operator": "average",
@@ -287,6 +321,7 @@
       "vertical_grid": "none"
    },
    "((zooplankton_sname))_loss_basal_zint_100m": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((zooplankton_lname)) Basal Respiration Vertical Integral, 0-100m",
       "operator": "average",
@@ -294,6 +329,7 @@
       "vertical_grid": "none"
    },
    "((zooplankton_sname))_loss_doc": {
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((zooplankton_lname)) Loss to DOC",
       "operator": "average",
@@ -302,6 +338,7 @@
       "vertical_grid": "layer_avg"
    },
    "((zooplankton_sname))_loss_doc_zint": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((zooplankton_lname)) Loss to DOC Vertical Integral",
       "operator": "average",
@@ -309,6 +346,7 @@
       "vertical_grid": "none"
    },
    "((zooplankton_sname))_loss_doc_zint_100m": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((zooplankton_lname)) Loss to DOC Vertical Integral, 0-100m",
       "operator": "average",
@@ -316,6 +354,7 @@
       "vertical_grid": "none"
    },
    "((zooplankton_sname))_loss_poc": {
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((zooplankton_lname)) Loss to POC",
       "operator": "average",
@@ -324,6 +363,7 @@
       "vertical_grid": "layer_avg"
    },
    "((zooplankton_sname))_loss_poc_zint": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((zooplankton_lname)) Loss to POC Vertical Integral",
       "operator": "average",
@@ -331,6 +371,7 @@
       "vertical_grid": "none"
    },
    "((zooplankton_sname))_loss_poc_zint_100m": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((zooplankton_lname)) Loss to POC Vertical Integral, 0-100m",
       "operator": "average",
@@ -338,6 +379,7 @@
       "vertical_grid": "none"
    },
    "((zooplankton_sname))_loss_zint": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((zooplankton_lname)) Loss Vertical Integral",
       "operator": "average",
@@ -345,6 +387,7 @@
       "vertical_grid": "none"
    },
    "((zooplankton_sname))_loss_zint_100m": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((zooplankton_lname)) Loss Vertical Integral, 0-100m",
       "operator": "average",
@@ -352,6 +395,7 @@
       "vertical_grid": "none"
    },
    "((zooplankton_sname))_loss_zint_150m": {
+      "diag_mode": "full",
       "frequency": "high",
       "longname": "((zooplankton_lname)) Loss Vertical Integral, 0-150m",
       "operator": "average",
@@ -363,6 +407,7 @@
          "abio_dic_on": ".true.",
          "lflux_gas_co2": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Surface Alkalinity for Abiotic DIC Tracer Fluxes",
       "operator": "average",
@@ -374,6 +419,7 @@
          "abio_dic_on": ".true.",
          "lflux_gas_co2": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "CO2 Star for Abiotic DIC Tracer Fluxes",
       "operator": "average",
@@ -385,6 +431,7 @@
          "abio_dic_on": ".true.",
          "lflux_gas_co2": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Atmospheric Delta 14C for Abiotic DIC Tracer Fluxes",
       "operator": "average",
@@ -395,6 +442,7 @@
       "dependencies": {
          "abio_dic_on": ".true."
       },
+      "diag_mode": "minimal",
       "frequency": "medium",
       "longname": "Oceanic Delta 14C for Abiotic DIC Tracer Fluxes",
       "operator": "average",
@@ -406,6 +454,7 @@
          "abio_dic_on": ".true.",
          "lflux_gas_co2": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "D CO2 Star for Abiotic DIC Tracer Fluxes",
       "operator": "average",
@@ -417,6 +466,7 @@
          "abio_dic_on": ".true.",
          "lflux_gas_co2": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "D pCO2 for Abiotic DIC Tracer Fluxes",
       "operator": "average",
@@ -428,6 +478,7 @@
          "abio_dic_on": ".true.",
          "lflux_gas_co2": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Surface Gas Flux of Abiotic DI14C",
       "operator": "average",
@@ -439,6 +490,7 @@
          "abio_dic_on": ".true.",
          "lflux_gas_co2": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Surface Gas Flux of Abiotic DIC",
       "operator": "average",
@@ -450,6 +502,7 @@
          "abio_dic_on": ".true.",
          "lflux_gas_co2": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Surface pH for Abiotic DIC Tracer Fluxes",
       "operator": "average",
@@ -461,6 +514,7 @@
          "abio_dic_on": ".true.",
          "lflux_gas_co2": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "CO2 Atmospheric Partial Pressure for Abiotic DIC Tracer Fluxes",
       "operator": "average",
@@ -472,6 +526,7 @@
          "abio_dic_on": ".true.",
          "lflux_gas_co2": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Surface pCO2 for Abiotic DIC Tracer Fluxes",
       "operator": "average",
@@ -482,6 +537,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Apparent O2 Utilization",
       "operator": "average",
@@ -492,6 +548,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Atmospheric Alternative CO2",
       "operator": "average",
@@ -502,6 +559,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Atmospheric CO2",
       "operator": "average",
@@ -513,6 +571,7 @@
          "((autotroph_calcifier))": true,
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((autotroph_lname)) Ca13CO3 Formation",
       "operator": "average",
@@ -525,6 +584,7 @@
          "((autotroph_calcifier))": true,
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((autotroph_lname)) Ca13CO3 Formation Vertical Integral",
       "operator": "average",
@@ -536,6 +596,7 @@
          "((autotroph_calcifier))": true,
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((autotroph_lname)) Ca14CO3 Formation",
       "operator": "average",
@@ -548,6 +609,7 @@
          "((autotroph_calcifier))": true,
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((autotroph_lname)) Ca14CO3 Formation Vertical Integral",
       "operator": "average",
@@ -558,6 +620,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Ca13CO3 flux into cell",
       "operator": "average",
@@ -568,6 +631,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Ca13CO3 Production",
       "operator": "average",
@@ -578,6 +642,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Ca13CO3 Remineralization",
       "operator": "average",
@@ -588,6 +653,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Ca14CO3 flux into cell",
       "operator": "average",
@@ -598,6 +664,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Ca14CO3 Production",
       "operator": "average",
@@ -608,6 +675,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Ca14CO3 Remineralization",
       "operator": "average",
@@ -618,6 +686,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Atmospheric Delta 13C",
       "operator": "average",
@@ -628,6 +697,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Atmospheric Delta 14C",
       "operator": "average",
@@ -638,6 +708,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "d13C of DIC",
       "operator": "average",
@@ -648,6 +719,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "d14C of DIC",
       "operator": "average",
@@ -658,6 +730,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "DO13Ctot Production",
       "operator": "average",
@@ -668,6 +741,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "DO13Ctot Remineralization",
       "operator": "average",
@@ -678,6 +752,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "DO14Ctot Production",
       "operator": "average",
@@ -688,6 +763,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "DO14Ctot Remineralization",
       "operator": "average",
@@ -698,6 +774,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "d13C of DOCtot",
       "operator": "average",
@@ -708,6 +785,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "d14C of DOCtot",
       "operator": "average",
@@ -718,6 +796,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "DI13C Surface Gas Flux",
       "operator": "average",
@@ -728,6 +807,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "DI14C Surface Gas Flux",
       "operator": "average",
@@ -738,6 +818,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "DI13C Surface Air-Sea Gas Flux",
       "operator": "average",
@@ -748,6 +829,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "DI14C Surface Air-Sea Gas Flux",
       "operator": "average",
@@ -758,6 +840,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "D13C Surface GAS FLUX",
       "operator": "average",
@@ -768,6 +851,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "D14C Surface GAS FLUX",
       "operator": "average",
@@ -778,6 +862,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "DI13C Surface Sea-Air Gas Flux",
       "operator": "average",
@@ -788,6 +873,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "DI14C Surface Sea-Air Gas Flux",
       "operator": "average",
@@ -798,6 +884,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "13Ctot Source Sink Term Vertical Integral",
       "operator": "average",
@@ -808,6 +895,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "14Ctot Source Sink Term Vertical Integral",
       "operator": "average",
@@ -818,6 +906,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "PO13C Flux into Cell",
       "operator": "average",
@@ -828,6 +917,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "PO13C Production",
       "operator": "average",
@@ -838,6 +928,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "PO13C Remineralization",
       "operator": "average",
@@ -848,6 +939,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "PO14C Flux into Cell",
       "operator": "average",
@@ -858,6 +950,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "PO14C Production",
       "operator": "average",
@@ -868,6 +961,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "PO14C Remineralization",
       "operator": "average",
@@ -878,6 +972,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "13C/12C ratio in total DIC",
       "operator": "average",
@@ -888,6 +983,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "13C/12C ratio in atmosphere",
       "operator": "average",
@@ -898,6 +994,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "14C/12C ratio in total DIC",
       "operator": "average",
@@ -908,6 +1005,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "14C/12C ratio in atmosphere",
       "operator": "average",
@@ -919,6 +1017,7 @@
          "((autotroph_calcifier))": true,
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((autotroph_lname)) d13C of CaCO3",
       "operator": "average",
@@ -930,6 +1029,7 @@
          "((autotroph_calcifier))": true,
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((autotroph_lname)) d14C of CaCO3",
       "operator": "average",
@@ -940,6 +1040,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((autotroph_lname)) d13C",
       "operator": "average",
@@ -950,6 +1051,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((autotroph_lname)) d14C",
       "operator": "average",
@@ -960,6 +1062,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Equilibrium fractionation (CO2_gaseous <-> CO2_aq)",
       "operator": "average",
@@ -970,6 +1073,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "Surface equilibrium fractionation (CO2_gaseous <-> CO2_aq)",
       "operator": "average",
@@ -980,6 +1084,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((autotroph_lname)) discrimination factor (eps)",
       "operator": "average",
@@ -990,6 +1095,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Equilibrium fractionation between total DIC and gaseous CO2",
       "operator": "average",
@@ -1000,6 +1106,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "Surface equilibrium fractionation between total DIC and gaseous CO2",
       "operator": "average",
@@ -1010,6 +1117,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((autotroph_lname)) instanteous growth rate over [CO2*]",
       "operator": "average",
@@ -1020,6 +1128,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((autotroph_lname)) 13C Fixation",
       "operator": "average",
@@ -1031,6 +1140,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((autotroph_lname)) 13C Fixation Vertical Integral",
       "operator": "average",
@@ -1041,6 +1151,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Total 13C Fixation",
       "operator": "average",
@@ -1051,6 +1162,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Total 13C Fixation Vertical Integral",
       "operator": "average",
@@ -1061,6 +1173,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((autotroph_lname)) 14C Fixation",
       "operator": "average",
@@ -1072,6 +1185,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((autotroph_lname)) 14C Fixation Vertical Integral",
       "operator": "average",
@@ -1082,6 +1196,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Total 14C Fixation",
       "operator": "average",
@@ -1092,6 +1207,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Total 14C Fixation Vertical Integral",
       "operator": "average",
@@ -1102,6 +1218,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "d13C of total zooC",
       "operator": "average",
@@ -1112,6 +1229,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "d14C of total zooC",
       "operator": "average",
@@ -1122,6 +1240,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "CO2 Star",
       "operator": "average",
@@ -1132,6 +1251,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "CO2 Star, Alternative CO2",
       "operator": "average",
@@ -1142,6 +1262,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Carbonate Ion Concentration",
       "operator": "average",
@@ -1152,6 +1273,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "Carbonate Ion Concentration, Alternative CO2",
       "operator": "average",
@@ -1162,6 +1284,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "low",
       "longname": "CaCO3 Flux into Cell, Alternative CO2",
       "operator": "average",
@@ -1172,6 +1295,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "CaCO3 Production, Alternative CO2",
       "operator": "average",
@@ -1182,6 +1306,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "low",
       "longname": "CaCO3 Remineralization, Alternative CO2",
       "operator": "average",
@@ -1192,6 +1317,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "minimal",
       "frequency": "medium",
       "longname": "CaCO3 Flux at ((particulate_flux_ref_depth_str))",
       "operator": "average",
@@ -1202,6 +1328,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "low",
       "longname": "CaCO3 Flux into Cell",
       "operator": "average",
@@ -1212,6 +1339,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "low",
       "longname": "CaCO3 Production",
       "operator": "average",
@@ -1222,6 +1350,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "minimal",
       "frequency": "medium",
       "longname": "Vertical Integral of CaCO3 Production",
       "operator": "average",
@@ -1232,6 +1361,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Vertical Integral of CaCO3 Production, 0-100m",
       "operator": "average",
@@ -1242,6 +1372,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "low",
       "longname": "CaCO3 Remineralization",
       "operator": "average",
@@ -1252,6 +1383,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Vertical Integral of CaCO3 Remineralization",
       "operator": "average",
@@ -1262,6 +1394,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Vertical Integral of CaCO3 Remineralization, 0-100m",
       "operator": "average",
@@ -1272,6 +1405,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "low",
       "longname": "Total CaCO3 Formation",
       "operator": "average",
@@ -1282,6 +1416,10 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": [
+         "full",
+         "full"
+      ],
       "frequency": [
          "medium",
          "high"
@@ -1298,6 +1436,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Total CaCO3 Formation Vertical Integral, 0-100m",
       "operator": "average",
@@ -1308,6 +1447,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "D CO2 Star",
       "operator": "average",
@@ -1318,6 +1458,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "D CO2 Star, Alternative CO2",
       "operator": "average",
@@ -1328,6 +1469,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "minimal",
       "frequency": "medium",
       "longname": "Denitrification",
       "operator": "average",
@@ -1338,6 +1480,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "DOC Production",
       "operator": "average",
@@ -1348,6 +1491,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Vertical Integral of DOC Production",
       "operator": "average",
@@ -1358,6 +1502,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Vertical Integral of DOC Production, 0-100m",
       "operator": "average",
@@ -1368,6 +1513,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "low",
       "longname": "DOC Remineralization",
       "operator": "average",
@@ -1378,6 +1524,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Vertical Integral of DOC Remineralization",
       "operator": "average",
@@ -1388,6 +1535,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Vertical Integral of DOC Remineralization, 0-100m",
       "operator": "average",
@@ -1398,6 +1546,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "low",
       "longname": "DOCr Remineralization",
       "operator": "average",
@@ -1408,6 +1557,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Vertical Integral of DOCr Remineralization",
       "operator": "average",
@@ -1418,6 +1568,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Vertical Integral of DOCr Remineralization, 0-100m",
       "operator": "average",
@@ -1428,6 +1579,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "DON Production",
       "operator": "average",
@@ -1438,6 +1590,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "low",
       "longname": "DON Remineralization",
       "operator": "average",
@@ -1448,6 +1601,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "low",
       "longname": "DONr Remineralization",
       "operator": "average",
@@ -1455,6 +1609,7 @@
       "vertical_grid": "layer_avg"
    },
    "DOP_((autotroph_sname))_uptake": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((autotroph_lname)) DOP Uptake",
       "operator": "average",
@@ -1466,6 +1621,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "DOP loss, due to P budget balancing",
       "operator": "average",
@@ -1476,6 +1632,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "DOP Production",
       "operator": "average",
@@ -1486,6 +1643,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "low",
       "longname": "DOP Remineralization",
       "operator": "average",
@@ -1496,6 +1654,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "low",
       "longname": "DOPr Remineralization",
       "operator": "average",
@@ -1506,6 +1665,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "minimal",
       "frequency": "never",
       "longname": "Atmospheric Dust Flux",
       "operator": "average",
@@ -1516,6 +1676,10 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": [
+         "minimal",
+         "full"
+      ],
       "frequency": [
          "medium",
          "high"
@@ -1532,6 +1696,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "D pCO2, Alternative CO2",
       "operator": "average",
@@ -1544,6 +1709,7 @@
          "lflux_gas_o2": ".true."
       },
       "dependencies_or": true,
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Atmospheric Pressure",
       "operator": "average",
@@ -1556,6 +1722,10 @@
          "lflux_gas_o2": ".true."
       },
       "dependencies_or": true,
+      "diag_mode": [
+         "minimal",
+         "full"
+      ],
       "frequency": [
          "medium",
          "high"
@@ -1574,6 +1744,10 @@
          "lflux_gas_o2": ".true."
       },
       "dependencies_or": true,
+      "diag_mode": [
+         "full",
+         "full"
+      ],
       "frequency": [
          "medium",
          "high"
@@ -1590,6 +1764,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "Iron Sediment Flux",
       "operator": "average",
@@ -1600,6 +1775,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "DIC Surface Gas Flux, Alternative CO2",
       "operator": "average",
@@ -1610,6 +1786,10 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": [
+         "minimal",
+         "full"
+      ],
       "frequency": [
          "medium",
          "high"
@@ -1626,6 +1806,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Iron Scavenging",
       "operator": "average",
@@ -1636,6 +1817,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Iron Scavenging Rate",
       "operator": "average",
@@ -1646,6 +1828,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Fe not bound to Ligand",
       "operator": "average",
@@ -1656,6 +1839,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Carbonic Acid Concentration",
       "operator": "average",
@@ -1666,6 +1850,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "Carbonic Acid Concentration, Alternative CO2",
       "operator": "average",
@@ -1676,6 +1861,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Bicarbonate Ion Concentration",
       "operator": "average",
@@ -1686,6 +1872,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "Bicarbonate Ion Concentration, Alternative CO2",
       "operator": "average",
@@ -1696,6 +1883,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "minimal",
       "frequency": "medium",
       "longname": "Atmospheric Iron Flux",
       "operator": "average",
@@ -1706,6 +1894,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "Vertical Integral of Conservative Subterms of Source Sink Term for Ctot",
       "operator": "average",
@@ -1716,6 +1905,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "Vertical Integral of Conservative Subterms of Source Sink Term for Fetot",
       "operator": "average",
@@ -1726,6 +1916,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "Vertical Integral of Conservative Subterms of Source Sink Term for Ntot",
       "operator": "average",
@@ -1736,6 +1927,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "Vertical Integral of Conservative Subterms of Source Sink Term for Ptot",
       "operator": "average",
@@ -1746,6 +1938,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "Vertical Integral of Conservative Subterms of Source Sink Term for Sitot",
       "operator": "average",
@@ -1756,6 +1949,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Loss of Fe-binding Ligand from Bacterial Degradation",
       "operator": "average",
@@ -1766,6 +1960,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Loss of Fe-binding Ligand",
       "operator": "average",
@@ -1776,6 +1971,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Loss of Fe-binding Ligand from UV radiation",
       "operator": "average",
@@ -1786,6 +1982,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Production of Fe-binding Ligand",
       "operator": "average",
@@ -1796,6 +1993,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Loss of Fe-binding Ligand from Scavenging",
       "operator": "average",
@@ -1806,6 +2004,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "minimal",
       "frequency": "medium",
       "longname": "Emission of NHx to Atmosphere",
       "operator": "average",
@@ -1816,6 +2015,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "minimal",
       "frequency": "medium",
       "longname": "Flux of NHy from Atmosphere",
       "operator": "average",
@@ -1826,6 +2026,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Nitrification",
       "operator": "average",
@@ -1836,6 +2037,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "minimal",
       "frequency": "medium",
       "longname": "Flux of NOx from Atmosphere",
       "operator": "average",
@@ -1846,6 +2048,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "minimal",
       "frequency": "never",
       "longname": "Total N Fixation",
       "operator": "average",
@@ -1856,6 +2059,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "O2 Saturation",
       "operator": "average",
@@ -1866,6 +2070,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "O2 Consumption",
       "operator": "average",
@@ -1877,6 +2082,7 @@
          "base_bio_on": ".true.",
          "lo2_consumption_scalef": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "O2 Consumption Scale Factor",
       "operator": "average",
@@ -1887,6 +2093,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "O2 Production",
       "operator": "average",
@@ -1897,6 +2104,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "minimal",
       "frequency": "medium",
       "longname": "Vertical Minimum of O2",
       "operator": "average",
@@ -1907,6 +2115,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "minimal",
       "frequency": "medium",
       "longname": "Depth of Vertical Minimum of O2",
       "operator": "average",
@@ -1917,6 +2126,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "non-oxic,non-dentr remin in Sediments",
       "operator": "average",
@@ -1927,6 +2137,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "PAR Average over Model Cell",
       "operator": "average",
@@ -1937,6 +2148,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Surface pH",
       "operator": "average",
@@ -1947,6 +2159,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Surface pH, Alternative CO2",
       "operator": "average",
@@ -1954,6 +2167,7 @@
       "vertical_grid": "none"
    },
    "PO4_((autotroph_sname))_uptake": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((autotroph_lname)) PO4 Uptake",
       "operator": "average",
@@ -1965,6 +2179,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "minimal",
       "frequency": "medium",
       "longname": "POC Flux at ((particulate_flux_ref_depth_str))",
       "operator": "average",
@@ -1975,6 +2190,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "POC Flux into Cell",
       "operator": "average",
@@ -1985,6 +2201,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "POC Production",
       "operator": "average",
@@ -1995,6 +2212,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "minimal",
       "frequency": "medium",
       "longname": "Vertical Integral of POC Production",
       "operator": "average",
@@ -2005,6 +2223,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Vertical Integral of POC Production, 0-100m",
       "operator": "average",
@@ -2015,6 +2234,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "low",
       "longname": "POC Remineralization routed to DIC",
       "operator": "average",
@@ -2025,6 +2245,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Vertical Integral of POC Remineralization routed to DIC",
       "operator": "average",
@@ -2035,6 +2256,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Vertical Integral of POC Remineralization routed to DIC, 0-100m",
       "operator": "average",
@@ -2045,6 +2267,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "low",
       "longname": "POC Remineralization routed to DOCr",
       "operator": "average",
@@ -2055,6 +2278,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Vertical Integral of POC Remineralization routed to DOCr",
       "operator": "average",
@@ -2065,6 +2289,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Vertical Integral of POC Remineralization routed to DOCr, 0-100m",
       "operator": "average",
@@ -2075,6 +2300,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "POC hFlux into Cell",
       "operator": "average",
@@ -2085,6 +2311,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "POC sFlux into Cell",
       "operator": "average",
@@ -2095,6 +2322,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "low",
       "longname": "PON Remineralization routed to DONr",
       "operator": "average",
@@ -2105,6 +2333,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "low",
       "longname": "PON Remineralization routed to NH4",
       "operator": "average",
@@ -2115,6 +2344,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "POP Flux at ((particulate_flux_ref_depth_str))",
       "operator": "average",
@@ -2125,6 +2355,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "POP Flux into Cell",
       "operator": "average",
@@ -2135,6 +2366,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "POP Production",
       "operator": "average",
@@ -2145,6 +2377,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "low",
       "longname": "POP Remineralization routed to DOPr",
       "operator": "average",
@@ -2155,6 +2388,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "low",
       "longname": "POP Remineralization routed to PO4",
       "operator": "average",
@@ -2165,6 +2399,7 @@
       "dependencies": {
          "lflux_gas_co2": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "CO2 Piston Velocity",
       "operator": "average",
@@ -2175,6 +2410,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "O2 Piston Velocity",
       "operator": "average",
@@ -2186,6 +2422,7 @@
          "base_bio_on": ".true.",
          "lp_remin_scalef": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "Particulate Remin Scale Factor",
       "operator": "average",
@@ -2196,6 +2433,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "minimal",
       "frequency": "medium",
       "longname": "P_iron Flux at ((particulate_flux_ref_depth_str))",
       "operator": "average",
@@ -2206,6 +2444,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "P_iron Flux into Cell",
       "operator": "average",
@@ -2216,6 +2455,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "P_iron Production",
       "operator": "average",
@@ -2226,6 +2466,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "P_iron Remineralization",
       "operator": "average",
@@ -2236,6 +2477,7 @@
       "dependencies": {
          "lflux_gas_co2": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "CO2 Schmidt Number for base biotic tracers fluxes",
       "operator": "average",
@@ -2246,6 +2488,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "O2 Schmidt Number",
       "operator": "average",
@@ -2256,6 +2499,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "nitrogen loss in Sediments",
       "operator": "average",
@@ -2266,6 +2510,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "minimal",
       "frequency": "medium",
       "longname": "SiO2 Flux at ((particulate_flux_ref_depth_str))",
       "operator": "average",
@@ -2276,6 +2521,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "SiO2 Flux into Cell",
       "operator": "average",
@@ -2286,6 +2532,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "minimal",
       "frequency": "medium",
       "longname": "SiO2 Production",
       "operator": "average",
@@ -2296,6 +2543,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "SiO2 Remineralization",
       "operator": "average",
@@ -2306,6 +2554,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Total Si Uptake",
       "operator": "average",
@@ -2316,6 +2565,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "minimal",
       "frequency": "medium",
       "longname": "biogenic Si Flux to Sediments",
       "operator": "average",
@@ -2326,6 +2576,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "CaCO3 Flux Hitting Sea Floor",
       "operator": "average",
@@ -2336,6 +2587,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "minimal",
       "frequency": "medium",
       "longname": "CaCO3 Flux to Sediments",
       "operator": "average",
@@ -2346,6 +2598,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Ca13CO3 Flux to Sediments",
       "operator": "average",
@@ -2356,6 +2609,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Ca14CO3 Flux to Sediments",
       "operator": "average",
@@ -2366,6 +2620,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "CaCO3 Flux to Sediments, Alternative CO2",
       "operator": "average",
@@ -2376,6 +2631,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "CO3 concentration at aragonite saturation",
       "operator": "average",
@@ -2386,6 +2642,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "CO3 concentration at calcite saturation",
       "operator": "average",
@@ -2398,6 +2655,7 @@
          "labio_derivative_diags": ".true.",
          "lflux_gas_co2": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "Derivative of ABIO_FG_DI14C wrt ABIO_DI14C",
       "operator": "average",
@@ -2410,6 +2668,7 @@
          "labio_derivative_diags": ".true.",
          "lflux_gas_co2": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "Derivative of ABIO_FG_DI14C wrt ABIO_DIC",
       "operator": "average",
@@ -2422,6 +2681,7 @@
          "labio_derivative_diags": ".true.",
          "lflux_gas_co2": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "Derivative of ABIO_FG_DIC wrt ABIO_DIC",
       "operator": "average",
@@ -2432,6 +2692,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "dust Flux to Sediments",
       "operator": "average",
@@ -2442,6 +2703,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Dust Flux into Cell",
       "operator": "average",
@@ -2452,6 +2714,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Dust Remineralization",
       "operator": "average",
@@ -2459,6 +2722,7 @@
       "vertical_grid": "layer_avg"
    },
    "graze_((autotroph_sname))": {
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((autotroph_lname)) Grazing",
       "operator": "average",
@@ -2467,6 +2731,7 @@
       "vertical_grid": "layer_avg"
    },
    "graze_((autotroph_sname))_((zooplankton_sname))": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((autotroph_lname)) Grazing to ((zooplankton_lname))",
       "operator": "average",
@@ -2475,6 +2740,7 @@
       "vertical_grid": "layer_avg"
    },
    "graze_((autotroph_sname))_((zooplankton_sname))_zint": {
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((autotroph_lname)) Grazing to ((zooplankton_lname)) Vertical Integral",
       "operator": "average",
@@ -2482,6 +2748,7 @@
       "vertical_grid": "none"
    },
    "graze_((autotroph_sname))_((zooplankton_sname))_zint_100m": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((autotroph_lname)) Grazing to ((zooplankton_lname)) Vertical Integral, 0-100m",
       "operator": "average",
@@ -2489,6 +2756,7 @@
       "vertical_grid": "none"
    },
    "graze_((autotroph_sname))_doc": {
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((autotroph_lname)) Grazing to DOC",
       "operator": "average",
@@ -2497,6 +2765,7 @@
       "vertical_grid": "layer_avg"
    },
    "graze_((autotroph_sname))_doc_zint": {
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((autotroph_lname)) Grazing to DOC Vertical Integral",
       "operator": "average",
@@ -2504,6 +2773,7 @@
       "vertical_grid": "none"
    },
    "graze_((autotroph_sname))_doc_zint_100m": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((autotroph_lname)) Grazing to DOC Vertical Integral, 0-100m",
       "operator": "average",
@@ -2511,6 +2781,7 @@
       "vertical_grid": "none"
    },
    "graze_((autotroph_sname))_poc": {
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((autotroph_lname)) Grazing to POC",
       "operator": "average",
@@ -2519,6 +2790,7 @@
       "vertical_grid": "layer_avg"
    },
    "graze_((autotroph_sname))_poc_zint": {
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((autotroph_lname)) Grazing to POC Vertical Integral",
       "operator": "average",
@@ -2526,6 +2798,7 @@
       "vertical_grid": "none"
    },
    "graze_((autotroph_sname))_poc_zint_100m": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((autotroph_lname)) Grazing to POC Vertical Integral, 0-100m",
       "operator": "average",
@@ -2533,6 +2806,7 @@
       "vertical_grid": "none"
    },
    "graze_((autotroph_sname))_zint": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((autotroph_lname)) Grazing Vertical Integral",
       "operator": "average",
@@ -2540,6 +2814,7 @@
       "vertical_grid": "none"
    },
    "graze_((autotroph_sname))_zint_100m": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((autotroph_lname)) Grazing Vertical Integral, 0-100m",
       "operator": "average",
@@ -2547,6 +2822,7 @@
       "vertical_grid": "none"
    },
    "graze_((autotroph_sname))_zootot": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((autotroph_lname)) Grazing to ZOO TOT",
       "operator": "average",
@@ -2555,6 +2831,7 @@
       "vertical_grid": "layer_avg"
    },
    "graze_((zooplankton_sname))": {
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((zooplankton_lname)) grazing loss",
       "operator": "average",
@@ -2563,6 +2840,7 @@
       "vertical_grid": "layer_avg"
    },
    "graze_((zooplankton_sname))_((zooplankton_sname))": {
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((zooplankton_lname1)) grazing loss to ((zooplankton_lname2))",
       "operator": "average",
@@ -2571,6 +2849,7 @@
       "vertical_grid": "layer_avg"
    },
    "graze_((zooplankton_sname))_((zooplankton_sname))_zint": {
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((zooplankton_lname1)) Grazing to ((zooplankton_lname2)) Vertical Integral",
       "operator": "average",
@@ -2578,6 +2857,7 @@
       "vertical_grid": "none"
    },
    "graze_((zooplankton_sname))_((zooplankton_sname))_zint_100m": {
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((zooplankton_lname1)) Grazing to ((zooplankton_lname2)) Vertical Integral, 0-100m",
       "operator": "average",
@@ -2585,6 +2865,7 @@
       "vertical_grid": "none"
    },
    "graze_((zooplankton_sname))_doc": {
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((zooplankton_lname)) grazing loss to DOC",
       "operator": "average",
@@ -2593,6 +2874,7 @@
       "vertical_grid": "layer_avg"
    },
    "graze_((zooplankton_sname))_doc_zint": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((zooplankton_lname)) Grazing to DOC Vertical Integral",
       "operator": "average",
@@ -2600,6 +2882,7 @@
       "vertical_grid": "none"
    },
    "graze_((zooplankton_sname))_doc_zint_100m": {
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((zooplankton_lname)) Grazing to DOC Vertical Integral, 0-100m",
       "operator": "average",
@@ -2607,6 +2890,7 @@
       "vertical_grid": "none"
    },
    "graze_((zooplankton_sname))_poc": {
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((zooplankton_lname)) grazing loss to POC",
       "operator": "average",
@@ -2615,6 +2899,7 @@
       "vertical_grid": "layer_avg"
    },
    "graze_((zooplankton_sname))_poc_zint": {
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((zooplankton_lname)) Grazing to POC Vertical Integral",
       "operator": "average",
@@ -2622,6 +2907,7 @@
       "vertical_grid": "none"
    },
    "graze_((zooplankton_sname))_poc_zint_100m": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((zooplankton_lname)) Grazing to POC Vertical Integral, 0-100m",
       "operator": "average",
@@ -2629,6 +2915,7 @@
       "vertical_grid": "none"
    },
    "graze_((zooplankton_sname))_zint": {
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((zooplankton_lname)) Grazing Vertical Integral",
       "operator": "average",
@@ -2636,6 +2923,7 @@
       "vertical_grid": "none"
    },
    "graze_((zooplankton_sname))_zint_100m": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((zooplankton_lname)) Grazing Vertical Integral, 0-100m",
       "operator": "average",
@@ -2643,6 +2931,7 @@
       "vertical_grid": "none"
    },
    "graze_((zooplankton_sname))_zootot": {
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((zooplankton_lname)) grazing loss to ZOO TOT",
       "operator": "average",
@@ -2654,6 +2943,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "low",
       "longname": "Total Autotroph Grazing",
       "operator": "average",
@@ -2664,6 +2954,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "in situ temperature",
       "operator": "average",
@@ -2674,6 +2965,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "minimal",
       "frequency": "medium",
       "longname": "surface pCO2",
       "operator": "average",
@@ -2684,6 +2976,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "surface pCO2, Alternative CO2",
       "operator": "average",
@@ -2694,6 +2987,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "pH",
       "operator": "average",
@@ -2704,6 +2998,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "pH, Alternative CO2",
       "operator": "average",
@@ -2714,6 +3009,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "pFe Flux to Sediments",
       "operator": "average",
@@ -2721,6 +3017,7 @@
       "vertical_grid": "none"
    },
    "photoC_((autotroph_sname))": {
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((autotroph_lname)) C Fixation",
       "operator": "average",
@@ -2729,6 +3026,10 @@
       "vertical_grid": "layer_avg"
    },
    "photoC_((autotroph_sname))_zint": {
+      "diag_mode": [
+         "minimal",
+         "full"
+      ],
       "frequency": [
          "medium",
          "high"
@@ -2742,6 +3043,7 @@
       "vertical_grid": "none"
    },
    "photoC_((autotroph_sname))_zint_100m": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((autotroph_lname)) C Fixation Vertical Integral, 0-100m",
       "operator": "average",
@@ -2749,6 +3051,7 @@
       "vertical_grid": "none"
    },
    "photoC_NO3_((autotroph_sname))": {
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((autotroph_lname)) C Fixation from NO3",
       "operator": "average",
@@ -2757,6 +3060,7 @@
       "vertical_grid": "layer_avg"
    },
    "photoC_NO3_((autotroph_sname))_zint": {
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((autotroph_lname)) C Fixation from NO3 Vertical Integral",
       "operator": "average",
@@ -2767,6 +3071,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Total C Fixation from NO3",
       "operator": "average",
@@ -2777,6 +3082,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Total C Fixation from NO3 Vertical Integral",
       "operator": "average",
@@ -2787,6 +3093,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Total C Fixation from NO3 Vertical Integral, 0-100m",
       "operator": "average",
@@ -2797,6 +3104,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Total C Fixation",
       "operator": "average",
@@ -2807,6 +3115,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "minimal",
       "frequency": "medium",
       "longname": "Total C Fixation Vertical Integral",
       "operator": "average",
@@ -2817,6 +3126,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "minimal",
       "frequency": "medium",
       "longname": "Total C Fixation Vertical Integral, 0-100m",
       "operator": "average",
@@ -2824,6 +3134,7 @@
       "vertical_grid": "none"
    },
    "photoFe_((autotroph_sname))": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((autotroph_lname)) Fe Uptake",
       "operator": "average",
@@ -2832,6 +3143,7 @@
       "vertical_grid": "layer_avg"
    },
    "photoNH4_((autotroph_sname))": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((autotroph_lname)) NH4 Uptake",
       "operator": "average",
@@ -2840,6 +3152,7 @@
       "vertical_grid": "layer_avg"
    },
    "photoNO3_((autotroph_sname))": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((autotroph_lname)) NO3 Uptake",
       "operator": "average",
@@ -2851,6 +3164,10 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": [
+         "full",
+         "full"
+      ],
       "frequency": [
          "medium",
          "high"
@@ -2867,6 +3184,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "minimal",
       "frequency": "medium",
       "longname": "POC Flux to Sediments",
       "operator": "average",
@@ -2877,6 +3195,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "PO13C Flux to Sediments",
       "operator": "average",
@@ -2887,6 +3206,7 @@
       "dependencies": {
          "ciso_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "PO14C Flux to Sediments",
       "operator": "average",
@@ -2897,6 +3217,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "nitrogen burial Flux to Sediments",
       "operator": "average",
@@ -2907,6 +3228,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "phosphorus Flux to Sediments",
       "operator": "average",
@@ -2914,6 +3236,7 @@
       "vertical_grid": "none"
    },
    "x_graze_((zooplankton_sname))": {
+      "diag_mode": "full",
       "frequency": "never",
       "longname": "((zooplankton_lname)) grazing gain",
       "operator": "average",
@@ -2922,6 +3245,7 @@
       "vertical_grid": "layer_avg"
    },
    "x_graze_((zooplankton_sname))_zint": {
+      "diag_mode": "minimal",
       "frequency": "medium",
       "longname": "((zooplankton_lname)) Grazing Gain Vertical Integral",
       "operator": "average",
@@ -2929,6 +3253,7 @@
       "vertical_grid": "none"
    },
    "x_graze_((zooplankton_sname))_zint_100m": {
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "((zooplankton_lname)) Grazing Gain Vertical Integral, 0-100m",
       "operator": "average",
@@ -2939,6 +3264,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Aragonite Saturation Depth",
       "operator": "average",
@@ -2949,6 +3275,7 @@
       "dependencies": {
          "base_bio_on": ".true."
       },
+      "diag_mode": "full",
       "frequency": "medium",
       "longname": "Calcite Saturation Depth",
       "operator": "average",


### PR DESCRIPTION
Introduce new `diag_mode` option to `MARBL_generate_diagnostics_file.py`; when `diag_mode = 'none'`, output diagnostic file should be `'never_{op}'` for all variables. When `diag_mode = 'minimal'`, only variables with `diag_mode = 'minimal'` in `diagnostics_latest.json` have non-never output frequencies. When `diag_mode is 'full'`, variables with `diag_mode = 'minimal'` or `'full'` will have non-never output frequencies.