### PR TITLE
Introduce new bury_coeff test

### DIFF
--- a/MARBL_tools/run_test_suite.sh
+++ b/MARBL_tools/run_test_suite.sh
@@ -136,6 +136,9 @@ if [ "${STATUS}" == "PASS" ]; then
   print_status "init.py" >> ${RESULTS_CACHE}
   # Initialize MARBL with settings from tests/input_files/settings/
   for settingsfile in `find ../../input_files/settings -type f`; do
+    if [ "`basename $settingsfile`" == "marbl_with_ladjust_bury_coeff.settings" ]; then
+      continue
+    fi
     (set -x ; ./init.py -s $settingsfile)
     STATUS=$(check_return $?)
     print_status "init.py ($(basename ${settingsfile}))" >> ${RESULTS_CACHE}
@@ -361,6 +364,12 @@ if [ "${STATUS}" == "PASS" ]; then
   (set -x ; ./requested_tracers.py)
   STATUS=$(check_return $?)
   print_status "requested_tracers.py" >> ${RESULTS_CACHE}
+
+  # Print all fields MARBL needs running means of
+  cd ${MARBL_ROOT}/tests/regression_tests/bury_coeff
+  (set -x ; ./bury_coeff.py)
+  STATUS=$(check_return $?)
+  print_status "bury_coeff.py" >> ${RESULTS_CACHE}
 
   # Print all output_for_GCM variables
   cd ${MARBL_ROOT}/tests/regression_tests/available_output

--- a/tests/driver_src/marbl.F90
+++ b/tests/driver_src/marbl.F90
@@ -410,7 +410,6 @@ Program marbl
                ' (units: ', trim(marbl_instances(1)%interior_tendency_forcings(n)%metadata%field_units),')'
           call driver_status_log%log_noerror(log_message, subname)
         end do
-
         call marbl_instances(1)%shutdown()
       end if
 
@@ -436,6 +435,66 @@ Program marbl
         if (cnt.eq.0) then
           call driver_status_log%log_noerror('No tracers to restore!', subname)
         end if
+        call marbl_instances(1)%shutdown()
+      end if
+
+    ! -- bury_coeff test -- !
+    case ('bury_coeff')
+      call verify_single_instance(num_inst, trim(testname))
+      lprint_marbl_log = .false.
+      call marbl_init_test(marbl_instances(1), unit_system_opt, lshutdown = .false., lhas_global_ops=.true.)
+      if (.not. marbl_instances(1)%StatusLog%labort_marbl) then
+        ! Log requested surface forcing fields
+        call driver_status_log%log_header('Requested surface forcing fields', subname)
+        do n=1,size(marbl_instances(1)%surface_flux_forcings)
+          write(log_message, "(I0, 5A)") n, '. ', &
+                trim(marbl_instances(1)%surface_flux_forcings(n)%metadata%varname), &
+                ' (units: ', trim(marbl_instances(1)%surface_flux_forcings(n)%metadata%field_units),')'
+          call driver_status_log%log_noerror(log_message, subname)
+        end do
+
+        ! Log requested interior forcing fields
+        call driver_status_log%log_header('Requested interior forcing fields', subname)
+        ! Provide message if no itnerior tendency forcings are requested
+        if (size(marbl_instances(1)%interior_tendency_forcings) == 0) &
+          call driver_status_log%log_noerror('No forcing fields requested for interior_tendency_compute()!', subname)
+        do n=1,size(marbl_instances(1)%interior_tendency_forcings)
+          write(log_message, "(I0, 5A)") n, '. ', &
+               trim(marbl_instances(1)%interior_tendency_forcings(n)%metadata%varname), &
+               ' (units: ', trim(marbl_instances(1)%interior_tendency_forcings(n)%metadata%field_units),')'
+          call driver_status_log%log_noerror(log_message, subname)
+        end do
+
+        ! Print info about burial coefficient vars as well
+        call driver_status_log%log_header('Size of arrays for running means', subname)
+        write(log_message, "(A, I0)") "size(glo_avg_rmean_interior_tendency): ", &
+                                      size(marbl_instances(1)%glo_avg_rmean_interior_tendency)
+        call driver_status_log%log_noerror(log_message, subname)
+        do n=1,size(marbl_instances(1)%glo_avg_rmean_interior_tendency)
+          write(log_message, "(2A)") "  -- ", trim(marbl_instances(1)%glo_avg_rmean_interior_tendency(n)%sname)
+          call driver_status_log%log_noerror(log_message, subname)
+        end do
+        write(log_message, "(A, I0)") "size(glo_avg_rmean_surface_flux): ", &
+                                      size(marbl_instances(1)%glo_avg_rmean_surface_flux)
+        call driver_status_log%log_noerror(log_message, subname)
+        do n=1,size(marbl_instances(1)%glo_avg_rmean_surface_flux)
+          write(log_message, "(2A)") "  -- ", trim(marbl_instances(1)%glo_avg_rmean_surface_flux(n)%sname)
+          call driver_status_log%log_noerror(log_message, subname)
+        end do
+        write(log_message, "(A, I0)") "size(glo_scalar_rmean_interior_tendency): ", &
+                                      size(marbl_instances(1)%glo_scalar_rmean_interior_tendency)
+        call driver_status_log%log_noerror(log_message, subname)
+        do n=1,size(marbl_instances(1)%glo_scalar_rmean_interior_tendency)
+          write(log_message, "(2A)") "  -- ", trim(marbl_instances(1)%glo_scalar_rmean_interior_tendency(n)%sname)
+          call driver_status_log%log_noerror(log_message, subname)
+        end do
+        write(log_message, "(A, I0)") "size(glo_scalar_rmean_surface_flux): ", &
+                                      size(marbl_instances(1)%glo_scalar_rmean_surface_flux)
+        call driver_status_log%log_noerror(log_message, subname)
+        do n=1,size(marbl_instances(1)%glo_scalar_rmean_surface_flux)
+          write(log_message, "(2A)") "  -- ", trim(marbl_instances(1)%glo_scalar_rmean_surface_flux(n)%sname)
+          call driver_status_log%log_noerror(log_message, subname)
+        end do
         call marbl_instances(1)%shutdown()
       end if
 

--- a/tests/driver_src/marbl_init_drv.F90
+++ b/tests/driver_src/marbl_init_drv.F90
@@ -14,17 +14,18 @@ module marbl_init_drv
 
 Contains
 
-  subroutine test(marbl_instance, unit_system_opt, lshutdown, num_PAR_subcols)
+  subroutine test(marbl_instance, unit_system_opt, lshutdown, num_PAR_subcols, lhas_global_ops)
 
     type(marbl_interface_class), intent(inout) :: marbl_instance
     character(len=*),            intent(in)    :: unit_system_opt
     logical, optional,           intent(in)    :: lshutdown
     integer, optional,           intent(in)    :: num_PAR_subcols
+    logical, optional,           intent(in)    :: lhas_global_ops
 
     character(*), parameter      :: subname = 'marbl_init_drv:test'
     real(kind=r8), dimension(km) :: delta_z, zw, zt
     integer                      :: k, num_PAR_subcols_loc
-    logical                      :: lshutdown_loc
+    logical                      :: lshutdown_loc, lhas_global_ops_loc
 
     ! Run marbl_instance%shutdown? (Skip when running get_setting() from driver)
     if (present(lshutdown)) then
@@ -37,6 +38,12 @@ Contains
       num_PAR_subcols_loc = num_PAR_subcols
     else
       num_PAR_subcols_loc = 1
+    end if
+
+    if (present(lhas_global_ops)) then
+      lhas_global_ops_loc = lhas_global_ops
+    else
+      lhas_global_ops_loc = .false.
     end if
 
     ! Initialize levels
@@ -57,7 +64,8 @@ Contains
                              gcm_delta_z = delta_z,                     &
                              gcm_zw = zw,                               &
                              gcm_zt = zt,                               &
-                             unit_system_opt = unit_system_opt)
+                             unit_system_opt = unit_system_opt,         &
+                             lgcm_has_global_ops=lhas_global_ops_loc)
     if (marbl_instance%StatusLog%labort_marbl) then
       call marbl_instance%StatusLog%log_error_trace('marbl%init', subname)
       return

--- a/tests/input_files/settings/marbl_with_ladjust_bury_coeff.settings
+++ b/tests/input_files/settings/marbl_with_ladjust_bury_coeff.settings
@@ -1,0 +1,1 @@
+ladjust_bury_coeff = .true.

--- a/tests/regression_tests/bury_coeff/bury_coeff.py
+++ b/tests/regression_tests/bury_coeff/bury_coeff.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+from sys import path
+import os
+
+path.insert(0, os.path.join('..', '..', 'python_for_tests'))
+from marbl_testing_class import MARBL_testcase
+
+mt = MARBL_testcase()
+
+mt.parse_args(desc='Run full MARBL setup (config, init, and complete) and print '
+                   'output relating to burial coefficients',
+                   DefaultSettingsFile='../../input_files/settings/marbl_with_ladjust_bury_coeff.settings')
+
+mt.build_exe()
+
+mt.run_exe()

--- a/tests/regression_tests/bury_coeff/test.nml
+++ b/tests/regression_tests/bury_coeff/test.nml
@@ -1,0 +1,3 @@
+&marbl_driver_nml
+testname="bury_coeff"
+/


### PR DESCRIPTION
Sets `lgcm_has_global_ops = .true.` during initialization, and runs with `ladjust_bury_coeff = .true.`; it then prints out requested forcings (because we add three new surface flux forcings) and also prints out short names of all the running means that MARBL wants the GCM to track

```
Beginning bury_coeff test...

--------------------------------
Requested surface forcing fields
--------------------------------

1. u10_sqr (units: cm^2/s^2)
2. sss (units: psu)
3. sst (units: degC)
4. Ice Fraction (units: unitless)
5. Atmospheric Pressure (units: atmospheres)
6. xco2 (units: ppmv)
7. xco2_alt_co2 (units: ppmv)
8. Dust Flux (units: g/cm^2/s)
9. Iron Flux (units: nmol/cm^2/s)
10. NOx Flux (units: nmol/cm^2/s)
11. NHy Flux (units: nmol/cm^2/s)
12. external C Flux (units: nmol/cm^2/s)
13. external P Flux (units: nmol/cm^2/s)
14. external Si Flux (units: nmol/cm^2/s)

---------------------------------
Requested interior forcing fields
---------------------------------

1. Dust Flux (units: g/cm^2/s)
2. Surface Shortwave (units: W/m^2)
3. Potential Temperature (units: degC)
4. Salinity (units: psu)
5. Pressure (units: bars)
6. Iron Sediment Flux (units: nmol/cm^2/s)

--------------------------------
Size of arrays for running means
--------------------------------

size(glo_avg_rmean_interior_tendency): 7
  -- MARBL_rmean_glo_avg_CaCO3_bury
  -- MARBL_rmean_glo_avg_POC_bury
  -- MARBL_rmean_glo_avg_POP_bury
  -- MARBL_rmean_glo_avg_bSi_bury
  -- MARBL_rmean_glo_avg_d_POC_bury_d_bury_coeff
  -- MARBL_rmean_glo_avg_d_POP_bury_d_bury_coeff
  -- MARBL_rmean_glo_avg_d_bSi_bury_d_bury_coeff
size(glo_avg_rmean_surface_flux): 3
  -- MARBL_rmean_glo_avg_C_input
  -- MARBL_rmean_glo_avg_P_input
  -- MARBL_rmean_glo_avg_Si_input
size(glo_scalar_rmean_interior_tendency): 3
  -- MARBL_rmean_glo_scalar_POC_bury_coeff
  -- MARBL_rmean_glo_scalar_POP_bury_coeff
  -- MARBL_rmean_glo_scalar_bSi_bury_coeff
size(glo_scalar_rmean_surface_flux): 0
```

Having this info readily available will help figure out what MOM6 needs to do in terms of running means and global sums / averages.