### PR TITLE
Refactor how total Chlorophyll is summed

### DIFF
--- a/src/marbl_interface.F90
+++ b/src/marbl_interface.F90
@@ -151,6 +151,7 @@ module marbl_interface
      procedure, public  :: extract_timing
      procedure, private :: glo_vars_init
      procedure, public  :: get_tracer_index
+     procedure, public  :: compute_totChl
      procedure, public  :: interior_tendency_compute
      procedure, public  :: surface_flux_compute
      procedure, public  :: set_global_scalars
@@ -188,6 +189,7 @@ module marbl_interface
   private :: reset_timers
   private :: extract_timing
   private :: glo_vars_init
+  private :: compute_totChl
   private :: interior_tendency_compute
   private :: surface_flux_compute
   private :: shutdown
@@ -969,6 +971,18 @@ contains
     end associate
 
   end subroutine glo_vars_init
+
+  !***********************************************************************
+
+  subroutine compute_totChl(this)
+
+    use marbl_interior_tendency_mod, only : marbl_interior_tendency_compute_totChl
+
+    class(marbl_interface_class), intent(inout) :: this
+
+    call marbl_interior_tendency_compute_totChl(this%tracers, this%tracer_indices, this%interior_tendency_output)
+
+  end subroutine compute_totChl
 
   !***********************************************************************
 


### PR DESCRIPTION
Created a `new marbl_interior_tendency_compute_totChl()` routine to populate `interior_tendency_output%outputs_for_GCM(ofg_ind%total_Chl_id)`, which is called from `interior_tendency_compute()`. This function is also available through the `compute_totChl()` function on the `MARBL_interface_class`, so GCMs can get the initial Chl field during initialization -- just need to copy non-negative values of tracers into `tracers(:,:)` component of the class after reading from IC / restart file.