### PR TITLE
Force older docutils in environment

### DIFF
--- a/docs/py_requirements.txt
+++ b/docs/py_requirements.txt
@@ -3,6 +3,7 @@ Sphinx==1.7.5
 alabaster==0.7.13
 sphinxcontrib-bibtex==0.4.0
 pybtex==0.22
+docutils<0.22
 jinja2<3
 MarkupSafe<2.1
 git+https://github.com/marbl-ecosys/sphinx_rtd_theme.git@version-dropdown


### PR DESCRIPTION
CI tests were failing with

Could not import extension sphinx.builders.latex (exception: No module named 'docutils.utils.roman')

According to https://docutils.sourceforge.io/RELEASE-NOTES.html the docutils/utils/roman.py file was removed in 0.22, so we require something older