### PR TITLE
Updates to fix nvhpc compiler issues

### DIFF
--- a/src/marbl_interior_tendency_mod.F90
+++ b/src/marbl_interior_tendency_mod.F90
@@ -1541,7 +1541,7 @@ contains
 
           !P-limitation effect (CaCO2/organicC ratio increases when P limitation term is low)
           ! max out picpoc at one to prevent crashing due to "ballast exceeds POC" error
-          picpoc = min(1., max(0.0_r8, -0.48_r8 * Plim(auto_ind,:) + picpoc(:) + 0.48_r8))
+          picpoc = min(1.0_r8, max(0.0_r8, -0.48_r8 * Plim(auto_ind,:) + picpoc(:) + 0.48_r8))
 
           !multiply cocco growth rate by picpoc to get CaCO3 formation
           CaCO3_form(auto_ind,:) = picpoc(:) * photoC(auto_ind,:)
@@ -1697,7 +1697,7 @@ contains
     !-----------------------------------------------------------------------
     !  local variables
     !-----------------------------------------------------------------------
-    integer  :: auto_ind
+    integer  :: auto_ind, k
     !-----------------------------------------------------------------------
 
     associate(                                              &
@@ -1721,21 +1721,23 @@ contains
 
       do auto_ind = 1, autotroph_cnt
 
-        where (VNtot(auto_ind,:) > c0)
-          NO3_V(auto_ind,:) = (VNO3(auto_ind,:) / VNtot(auto_ind,:)) * photoC(auto_ind,:) * Q
-          NH4_V(auto_ind,:) = (VNH4(auto_ind,:) / VNtot(auto_ind,:)) * photoC(auto_ind,:) * Q
-        else where
-          NO3_V(auto_ind,:) = c0
-          NH4_V(auto_ind,:) = c0
-        end where
+        do k=1,size(VNtot,2)
+          if (VNtot(auto_ind,k) > c0) then
+            NO3_V(auto_ind,k) = (VNO3(auto_ind,k) / VNtot(auto_ind,k)) * photoC(auto_ind,k) * Q
+            NH4_V(auto_ind,k) = (VNH4(auto_ind,k) / VNtot(auto_ind,k)) * photoC(auto_ind,k) * Q
+          else
+            NO3_V(auto_ind,k) = c0
+            NH4_V(auto_ind,k) = c0
+          end if
 
-        where (VPtot(auto_ind,:) > c0)
-          PO4_V(auto_ind,:) = (VPO4(auto_ind,:) / VPtot(auto_ind,:)) * photoC(auto_ind,:) * gQp(auto_ind,:)
-          DOP_V(auto_ind,:) = (VDOP(auto_ind,:) / VPtot(auto_ind,:)) * photoC(auto_ind,:) * gQp(auto_ind,:)
-        else where
-          PO4_V(auto_ind,:) = c0
-          DOP_V(auto_ind,:) = c0
-        end where
+          if (VPtot(auto_ind,k) > c0) then
+            PO4_V(auto_ind,k) = (VPO4(auto_ind,k) / VPtot(auto_ind,k)) * photoC(auto_ind,k) * gQp(auto_ind,k)
+            DOP_V(auto_ind,k) = (VDOP(auto_ind,k) / VPtot(auto_ind,k)) * photoC(auto_ind,k) * gQp(auto_ind,k)
+          else
+            PO4_V(auto_ind,k) = c0
+            DOP_V(auto_ind,k) = c0
+          end if
+        end do
 
         !-----------------------------------------------------------------------
         !  Get nutrient uptake by diatoms based on C fixation

--- a/tests/python_for_tests/machines.py
+++ b/tests/python_for_tests/machines.py
@@ -33,16 +33,21 @@ def load_module(mach, compiler, module_name):
         module('load', 'ncarenv/23.06')
         module('load', 'craype')
     elif compiler == 'nvhpc':
-        module('load', 'ncarenv/23.06')
+        module('load', 'ncarenv/24.12')
     else:
         module('load', 'ncarenv/23.09')
     module('load', module_name)
     module('load', 'ncarcompilers/1.0.0')
     if compiler == 'cray':
         module('load', 'cray-mpich/8.1.25')
+    elif compiler == 'nvhpc':
+        module('load', 'cray-mpich/8.1.29')
     else:
         module('load', 'cray-mpich/8.1.27')
-    module('load', 'netcdf/4.9.2')
+    if compiler == 'nvhpc':
+        module('load', 'netcdf/4.9.3')
+    else:
+        module('load', 'netcdf/4.9.2')
     if compiler in ['gnu', 'cray']:
         module('load', 'cray-libsci/23.02.1.1')
 
@@ -101,7 +106,7 @@ def machine_specific(mach, supported_compilers, module_names):
     module_names['intel'] = 'intel/2023.2.1'
     module_names['gnu'] = 'gcc/12.2.0'
     module_names['cray'] = 'cce/15.0.1'
-    module_names['nvhpc'] = 'nvhpc/23.1'
+    module_names['nvhpc'] = 'nvhpc/25.9'
     return
 
   if mach == 'cheyenne':
@@ -144,6 +149,8 @@ def machine_specific(mach, supported_compilers, module_names):
       supported_compilers.append('pgi')
     if _compiler_is_present('ifort'):
       supported_compilers.append('intel')
+    if _compiler_is_present('nvfortran'):
+      supported_compilers.append('nvhpc')
     if _compiler_is_present('nagfor'):
       supported_compilers.append('nag')
     if supported_compilers == []:


### PR DESCRIPTION
To run the standalone tests on derecho, we want to use nvhpc/25.9 (this includes a bug fix we reported where nvhpc/25.7 was not handling associate statements correctly).

The compiler also rightly complained about an instance of a missing kind number when using a real variable (although 1.0 is exactly representable so there shouldn't be any difference between 1.0 and 1.0_r8).

Thirdly, I replaced a couple of where statements with the do-loop if-statement combination to avoid dividing by zero. It is unfortunate that the compiler doesn't handle this very well, but it is not a very invasive change.