### PR TITLE
Add new burial diagnostics

### DIFF
--- a/defaults/diagnostics_latest.yaml
+++ b/defaults/diagnostics_latest.yaml
@@ -849,6 +849,33 @@ pfeToSed :
    frequency : medium
    operator : average
    diag_mode : minimal
+d_POC_bury_d_bury_coeff :
+   dependencies :
+      base_bio_on : .true.
+   longname : d[POC burial]/d[POC burial coefficient]
+   units : nmol/cm^2/s
+   vertical_grid : none
+   frequency : never
+   operator : average
+   diag_mode : full
+d_POP_bury_d_bury_coeff :
+   dependencies :
+      base_bio_on : .true.
+   longname : d[POP burial]/d[POP burial coefficient]
+   units : nmol/cm^2/s
+   vertical_grid : none
+   frequency : never
+   operator : average
+   diag_mode : full
+d_bSi_bury_d_bury_coeff :
+   dependencies :
+      base_bio_on : .true.
+   longname : d[bSi burial]/d[bSi burial coefficient]
+   units : nmol/cm^2/s
+   vertical_grid : none
+   frequency : never
+   operator : average
+   diag_mode : full
 CaCO3_form_zint :
    dependencies :
       base_bio_on : .true.

--- a/defaults/json/diagnostics_latest.json
+++ b/defaults/json/diagnostics_latest.json
@@ -2649,6 +2649,28 @@
       "units": "mmol/m^3",
       "vertical_grid": "layer_avg"
    },
+   "d_POC_bury_d_bury_coeff": {
+      "dependencies": {
+         "base_bio_on": ".true."
+      },
+      "diag_mode": "full",
+      "frequency": "never",
+      "longname": "d[POC burial]/d[POC burial coefficient]",
+      "operator": "average",
+      "units": "nmol/cm^2/s",
+      "vertical_grid": "none"
+   },
+   "d_POP_bury_d_bury_coeff": {
+      "dependencies": {
+         "base_bio_on": ".true."
+      },
+      "diag_mode": "full",
+      "frequency": "never",
+      "longname": "d[POP burial]/d[POP burial coefficient]",
+      "operator": "average",
+      "units": "nmol/cm^2/s",
+      "vertical_grid": "none"
+   },
    "d_SF_ABIO_DI14C_d_ABIO_DI14C": {
       "dependencies": {
          "abio_dic_on": ".true.",
@@ -2686,6 +2708,17 @@
       "longname": "Derivative of ABIO_FG_DIC wrt ABIO_DIC",
       "operator": "average",
       "units": "cm/s",
+      "vertical_grid": "none"
+   },
+   "d_bSi_bury_d_bury_coeff": {
+      "dependencies": {
+         "base_bio_on": ".true."
+      },
+      "diag_mode": "full",
+      "frequency": "never",
+      "longname": "d[bSi burial]/d[bSi burial coefficient]",
+      "operator": "average",
+      "units": "nmol/cm^2/s",
       "vertical_grid": "none"
    },
    "dustToSed": {

--- a/src/marbl_diagnostics_mod.F90
+++ b/src/marbl_diagnostics_mod.F90
@@ -848,6 +848,42 @@ contains
           return
         end if
 
+        lname = 'd[POC burial]/d[POC burial coefficient]'
+        sname = 'd_POC_bury_d_bury_coeff'
+        units = unit_system%conc_flux_units
+        vgrid = 'none'
+        truncate = .false.
+        call diags%add_diagnostic(lname, sname, units, vgrid, truncate,     &
+            ind%d_POC_bury_d_bury_coeff, marbl_status_log)
+        if (marbl_status_log%labort_marbl) then
+          call marbl_logging_add_diagnostics_error(marbl_status_log, sname, subname)
+          return
+        end if
+
+        lname = 'd[POP burial]/d[POP burial coefficient]'
+        sname = 'd_POP_bury_d_bury_coeff'
+        units = unit_system%conc_flux_units
+        vgrid = 'none'
+        truncate = .false.
+        call diags%add_diagnostic(lname, sname, units, vgrid, truncate,     &
+            ind%d_POP_bury_d_bury_coeff, marbl_status_log)
+        if (marbl_status_log%labort_marbl) then
+          call marbl_logging_add_diagnostics_error(marbl_status_log, sname, subname)
+          return
+        end if
+
+        lname = 'd[bSi burial]/d[bSi burial coefficient]'
+        sname = 'd_bSi_bury_d_bury_coeff'
+        units = unit_system%conc_flux_units
+        vgrid = 'none'
+        truncate = .false.
+        call diags%add_diagnostic(lname, sname, units, vgrid, truncate,     &
+            ind%d_bSi_bury_d_bury_coeff, marbl_status_log)
+        if (marbl_status_log%labort_marbl) then
+          call marbl_logging_add_diagnostics_error(marbl_status_log, sname, subname)
+          return
+        end if
+
         ! Autotroph 2D diags
         if (.not.ind%lallocated()) then
           allocate(ind%N_lim_surf(autotroph_cnt))
@@ -3918,6 +3954,10 @@ contains
     diags(ind%popToSed)%field_2d(1)          = sum(POP%sed_loss)
     diags(ind%dustToSed)%field_2d(1)         = sum(dust%sed_loss)
     diags(ind%pfeToSed)%field_2d(1)          = sum(P_iron%sed_loss)
+
+    diags(ind%d_POC_bury_d_bury_coeff)%field_2d(1) = POC%d_bury_d_bury_coeff
+    diags(ind%d_POP_bury_d_bury_coeff)%field_2d(1) = POP%d_bury_d_bury_coeff
+    diags(ind%d_bSi_bury_d_bury_coeff)%field_2d(1) = P_SiO2%d_bury_d_bury_coeff
 
     end associate
 

--- a/src/marbl_interface_private_types.F90
+++ b/src/marbl_interface_private_types.F90
@@ -163,6 +163,7 @@ module marbl_interface_private_types
      real(r8) :: rho                        ! QA mass ratio of POC to this particle class
      real(r8) :: to_floor                   ! flux hitting sea floor (base units/L^2/sec)
      real(r8) :: flux_at_ref_depth          ! flux at particulate_flux_ref_depth (base units/L^2/sec)
+     real(r8) :: d_bury_d_bury_coeff        ! Derivative of burial with respect to bury coeff (base units/L^2/sec)
      real(r8), allocatable  :: sflux_in (:) ! incoming flux of soft subclass (base units/L^2/sec)
      real(r8), allocatable  :: hflux_in (:) ! incoming flux of hard subclass (base units/L^2/sec)
      real(r8), allocatable  :: prod     (:) ! production term (base units/L^3/sec)

--- a/src/marbl_interface_private_types.F90
+++ b/src/marbl_interface_private_types.F90
@@ -548,6 +548,9 @@ module marbl_interface_private_types
     integer(int_kind) :: bsiToSed
     integer(int_kind) :: dustToSed
     integer(int_kind) :: pfeToSed
+    integer(int_kind) :: d_POC_bury_d_bury_coeff
+    integer(int_kind) :: d_POP_bury_d_bury_coeff
+    integer(int_kind) :: d_bSi_bury_d_bury_coeff
 
     ! Autotroph 2D diags
     integer(int_kind), allocatable :: N_lim_surf(:)

--- a/src/marbl_interior_tendency_mod.F90
+++ b/src/marbl_interior_tendency_mod.F90
@@ -3179,6 +3179,16 @@ contains
 
            ! first compute burial efficiency, then compute loss to sediments
            bury_frac = 0.013_r8 + 0.53_r8 * flux_alt*flux_alt / (7.0_r8 + flux_alt)**2
+           if (POC_bury_coeff * bury_frac < POM_bury_frac_max) then
+              POC%d_bury_d_bury_coeff = POC%to_floor * bury_frac
+           else
+              POC%d_bury_d_bury_coeff = c0
+           end if
+           if (POP_bury_coeff * bury_frac < POM_bury_frac_max) then
+              POP%d_bury_d_bury_coeff = POP%to_floor * bury_frac
+           else
+              POP%d_bury_d_bury_coeff = c0
+           end if
            if (p_remin_scalef /= c1) bury_frac = c1 - p_remin_scalef * (c1 - bury_frac)
            POC%sed_loss(k) = POC%to_floor * min(POM_bury_frac_max, POC_bury_coeff * bury_frac)
 
@@ -3189,20 +3199,12 @@ contains
 
            if (ladjust_bury_coeff) then
               glo_avg_fields_interior_tendency(glo_avg_field_ind_interior_tendency_POC_bury) = POC%sed_loss(k)
-              if (POC_bury_coeff * bury_frac < POM_bury_frac_max) then
-                 glo_avg_fields_interior_tendency(glo_avg_field_ind_interior_tendency_d_POC_bury_d_bury_coeff) = &
-                      POC%to_floor * bury_frac
-              else
-                 glo_avg_fields_interior_tendency(glo_avg_field_ind_interior_tendency_d_POC_bury_d_bury_coeff) = c0
-              endif
+              glo_avg_fields_interior_tendency(glo_avg_field_ind_interior_tendency_d_POC_bury_d_bury_coeff) = &
+                   POC%d_bury_d_bury_coeff
 
               glo_avg_fields_interior_tendency(glo_avg_field_ind_interior_tendency_POP_bury) = POP%sed_loss(k)
-              if (POP_bury_coeff * bury_frac < POM_bury_frac_max) then
-                 glo_avg_fields_interior_tendency(glo_avg_field_ind_interior_tendency_d_POP_bury_d_bury_coeff) = &
-                      POP%to_floor * bury_frac
-              else
-                 glo_avg_fields_interior_tendency(glo_avg_field_ind_interior_tendency_d_POP_bury_d_bury_coeff) = c0
-              endif
+              glo_avg_fields_interior_tendency(glo_avg_field_ind_interior_tendency_d_POP_bury_d_bury_coeff) = &
+                   POP%d_bury_d_bury_coeff
            endif
 
            sed_denitrif(1:k) = bot_flux_to_tend(1:k) * parm_sed_denitrif_coeff * POC%to_floor &
@@ -3248,18 +3250,16 @@ contains
         if (p_remin_scalef /= c1) bury_frac = c1 - p_remin_scalef * (c1 - bury_frac)
         if (bSi_bury_coeff * bury_frac < bSi_bury_frac_max) then
            P_SiO2%sed_loss(k) = P_SiO2%to_floor * bSi_bury_coeff * bury_frac
+           P_SiO2%d_bury_d_bury_coeff = P_SiO2%to_floor * bury_frac
         else
            P_SiO2%sed_loss(k) = P_SiO2%to_floor * bSi_bury_frac_max
+           P_SiO2%d_bury_d_bury_coeff = c0
         endif
 
         if (ladjust_bury_coeff) then
            glo_avg_fields_interior_tendency(glo_avg_field_ind_interior_tendency_bSi_bury) = P_SiO2%sed_loss(k)
-           if (bSi_bury_coeff * bury_frac < bSi_bury_frac_max) then
-              glo_avg_fields_interior_tendency(glo_avg_field_ind_interior_tendency_d_bSi_bury_d_bury_coeff) = &
-                   P_SiO2%to_floor * bury_frac
-           else
-              glo_avg_fields_interior_tendency(glo_avg_field_ind_interior_tendency_d_bSi_bury_d_bury_coeff) = c0
-           endif
+           glo_avg_fields_interior_tendency(glo_avg_field_ind_interior_tendency_d_bSi_bury_d_bury_coeff) = &
+                P_SiO2%d_bury_d_bury_coeff
         endif
 
         P_CaCO3%to_floor         = P_CaCO3%sflux_out(k)         + P_CaCO3%hflux_out(k)


### PR DESCRIPTION
Three derivatives used to compute burial coefficients when `ladjust_bury_coeff = .true.` are now available as diagnostics regardless of the value of `ladjust_bury_coeff`. They are not included in the default diagnostic set but will be useful for computing the burial coefficients offline for GCMs that do not provide the global operators necessary to adjust the burial coefficients on the fly.