### PR TITLE
More CESM3 Updates

### DIFF
--- a/src/marbl_co2calc_mod.F90
+++ b/src/marbl_co2calc_mod.F90
@@ -45,7 +45,7 @@ module marbl_co2calc_mod
   !   10**-9 drops precision to 2 significant figures).
 
   real(kind=r8)          , parameter :: xacc = 1e-10_r8
-  integer(kind=int_kind) , parameter :: max_bracket_grow_it = 3
+  integer(kind=int_kind) , parameter :: max_bracket_grow_it = 5
   integer(kind=int_kind) , parameter :: maxit = 100
 
   real(kind=r8)          , parameter :: salt_min = 0.1_r8


### PR DESCRIPTION
A few small updates are expected as we turn MARBL on in the CESM3 fully-coupled development runs

1. Need to increase max number of times CO2 solver widens bracket looking for a root
2. Updated tuning
3. Limit denitrification in regions where nitrate is already very low (otherwise we get large magnitude negative nitrate concentrations)

I will likely add more items to the list above, but I'll take this out of draft once the list above is finalized and all the issues are addressed